### PR TITLE
Remove contract deployment for staking contracts

### DIFF
--- a/packages/core/scripts/deploy.ts
+++ b/packages/core/scripts/deploy.ts
@@ -17,31 +17,6 @@ async function main() {
   );
   await escrowFactoryContract.deployed();
   console.log('Escrow Factory Address: ', escrowFactoryContract.address);
-
-  const Staking = await ethers.getContractFactory('Staking');
-  const stakingContract = await Staking.deploy(
-    HMTokenContract.address,
-    escrowFactoryContract.address,
-    1,
-    1
-  );
-  await stakingContract.deployed();
-  console.log('Staking Contract Address:', stakingContract.address);
-
-  const RewardPool = await ethers.getContractFactory('RewardPool');
-  const rewardPoolContract = await RewardPool.deploy(
-    HMTokenContract.address,
-    stakingContract.address,
-    1
-  );
-  await rewardPoolContract.deployed();
-  console.log('Reward Pool Contract Address:', rewardPoolContract.address);
-
-  // Configure Staking in EscrowFactory
-  await escrowFactoryContract.setStaking(stakingContract.address);
-
-  // Configure RewardPool in Staking
-  await stakingContract.setRewardPool(rewardPoolContract.address);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
After removing the contracts the deployment script fails because still references the contracts