### PR TITLE
fix mainnet token view

### DIFF
--- a/packages/apps/escrow-dashboard/src/components/Token/TokenView.tsx
+++ b/packages/apps/escrow-dashboard/src/components/Token/TokenView.tsx
@@ -1,10 +1,11 @@
 import { Grid } from '@mui/material';
 import * as React from 'react';
 import { CardTextBlock } from 'src/components/Cards';
-import { useTokenStats } from 'src/state/token/hooks';
+import { useTokenStatsByChainId } from 'src/state/token/hooks';
 
 export const TokenView: React.FC = (): React.ReactElement => {
-  const { totalTransferEventCount, holders, totalSupply } = useTokenStats();
+  const { totalTransferEventCount, holders, totalSupply } =
+    useTokenStatsByChainId();
 
   return (
     <Grid container spacing={{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }}>

--- a/packages/apps/escrow-dashboard/src/state/token/hooks.ts
+++ b/packages/apps/escrow-dashboard/src/state/token/hooks.ts
@@ -1,8 +1,9 @@
 import BigNumber from 'bignumber.js';
 import { useSelector } from 'react-redux';
-import { SUPPORTED_CHAIN_IDS, TESTNET_CHAIN_IDS } from 'src/constants';
+import { ChainId, SUPPORTED_CHAIN_IDS, TESTNET_CHAIN_IDS } from 'src/constants';
 import { useSlowRefreshEffect } from 'src/hooks/useRefreshEffect';
 import { AppState, useAppDispatch } from 'src/state';
+import { useChainId } from '../escrow/hooks';
 
 import { fetchTokenStatsAsync } from './reducer';
 
@@ -14,31 +15,39 @@ export const usePollTokenStats = () => {
   }, [dispatch]);
 };
 
-export const useTokenStats = () => {
+export const useTokenStatsByChainId = () => {
+  const currentChainId = useChainId();
   const token = useSelector((state: AppState) => state.token);
   const { stats } = token;
 
-  const tokenStats = {
-    totalTransferEventCount: 0,
-    holders: 0,
-    totalSupply: new BigNumber(0),
-  };
+  if (
+    currentChainId === ChainId.ALL ||
+    TESTNET_CHAIN_IDS.includes(currentChainId)
+  ) {
+    const tokenStats = {
+      totalTransferEventCount: 0,
+      holders: 0,
+      totalSupply: new BigNumber(0),
+    };
 
-  SUPPORTED_CHAIN_IDS.forEach((chainId) => {
-    if (stats[chainId] && !TESTNET_CHAIN_IDS.includes(chainId)) {
-      tokenStats.totalTransferEventCount +=
-        stats[chainId]?.totalTransferEventCount!;
-      tokenStats.holders += stats[chainId]?.holders!;
-      tokenStats.totalSupply = tokenStats.totalSupply.plus(
-        new BigNumber(token.stats[chainId]?.totalSupply ?? '0')
-      );
-    }
-  });
+    SUPPORTED_CHAIN_IDS.forEach((chainId) => {
+      if (stats[chainId] && !TESTNET_CHAIN_IDS.includes(chainId)) {
+        tokenStats.totalTransferEventCount +=
+          stats[chainId]?.totalTransferEventCount!;
+        tokenStats.holders += stats[chainId]?.holders!;
+        tokenStats.totalSupply = tokenStats.totalSupply.plus(
+          new BigNumber(token.stats[chainId]?.totalSupply ?? '0')
+        );
+      }
+    });
 
-  return {
-    ...tokenStats,
-    totalSupply: tokenStats.totalSupply.toJSON(),
-  };
+    return {
+      ...tokenStats,
+      totalSupply: tokenStats.totalSupply.toJSON(),
+    };
+  }
+
+  return stats[currentChainId]!;
 };
 
 export const useTokenStatsLoaded = () => {


### PR DESCRIPTION
Display specific token stats (transfer amounts, holders, total supply) when one of the mainnets is selected. If All networks or testnet is selected, token stats view will show aggregated data.