### PR TITLE
Remove counter from Launched event

### DIFF
--- a/packages/core/contracts/EscrowFactory.sol
+++ b/packages/core/contracts/EscrowFactory.sol
@@ -15,7 +15,7 @@ contract EscrowFactory {
     address public lastEscrow;
     address public eip20;
     address public staking;
-    event Launched(address eip20, address escrow, uint256 counter);
+    event Launched(address eip20, address escrow);
 
     constructor(address _eip20, address _staking) {
         require(_eip20 != address(0), ERROR_ZERO_ADDRESS);
@@ -44,7 +44,7 @@ contract EscrowFactory {
         counter++;
         escrowCounters[address(escrow)] = counter;
         lastEscrow = address(escrow);
-        emit Launched(eip20, lastEscrow, counter);
+        emit Launched(eip20, lastEscrow);
         return lastEscrow;
     }
 

--- a/packages/core/test/EscrowFactory.ts
+++ b/packages/core/test/EscrowFactory.ts
@@ -87,7 +87,6 @@ describe('EscrowFactory', function () {
 
     expect(event?.eip20).to.equal(token.address, 'token address is correct');
     expect(event?.escrow).to.not.be.null;
-    expect(event?.counter.toString()).to.equal('1', 'counter is correct');
   });
 
   it('Should emit an event on launched', async function () {
@@ -95,7 +94,7 @@ describe('EscrowFactory', function () {
 
     await expect(escrowFactory.connect(operator).createEscrow(trustedHandlers))
       .to.emit(escrowFactory, 'Launched')
-      .withArgs(token.address, anyValue, 1);
+      .withArgs(token.address, anyValue);
   });
 
   it('Should find the newly created escrow from deployed escrow', async () => {
@@ -120,7 +119,6 @@ describe('EscrowFactory', function () {
 
     expect(event?.eip20).to.equal(token.address, 'token address is correct');
     expect(event?.escrow).to.not.be.null;
-    expect(event?.counter.toString()).to.equal('2', 'counter is correct');
   });
 
   it('Operator should not be able to create an escrow after allocating all of the stakes', async () => {
@@ -146,6 +144,5 @@ describe('EscrowFactory', function () {
 
     expect(event?.eip20).to.equal(token.address, 'token address is correct');
     expect(event?.escrow).to.not.be.null;
-    expect(event?.counter.toString()).to.equal('2', 'counter is correct');
   });
 });

--- a/packages/core/test/RewardPool.ts
+++ b/packages/core/test/RewardPool.ts
@@ -123,7 +123,6 @@ describe('RewardPool', function () {
 
       expect(event?.eip20).to.equal(token.address, 'token address is correct');
       expect(event?.escrow).to.not.be.null;
-      expect(event?.counter.toString()).to.equal('1', 'counter is correct');
 
       escrowAddress = event?.escrow;
 
@@ -210,7 +209,6 @@ describe('RewardPool', function () {
 
       expect(event?.eip20).to.equal(token.address, 'token address is correct');
       expect(event?.escrow).to.not.be.null;
-      expect(event?.counter.toString()).to.equal('1', 'counter is correct');
 
       escrowAddress = event?.escrow;
 

--- a/packages/core/test/Staking.ts
+++ b/packages/core/test/Staking.ts
@@ -227,7 +227,6 @@ describe('Staking', function () {
 
       expect(event?.eip20).to.equal(token.address, 'token address is correct');
       expect(event?.escrow).to.not.be.null;
-      expect(event?.counter.toString()).to.equal('1', 'counter is correct');
 
       escrowAddress = event?.escrow;
     });
@@ -324,7 +323,6 @@ describe('Staking', function () {
 
       expect(event?.eip20).to.equal(token.address, 'token address is correct');
       expect(event?.escrow).to.not.be.null;
-      expect(event?.counter.toString()).to.equal('1', 'counter is correct');
     });
 
     describe('Withdrawal without allocation', function () {
@@ -518,7 +516,6 @@ describe('Staking', function () {
           'token address is correct'
         );
         expect(event?.escrow).to.not.be.null;
-        expect(event?.counter.toString()).to.equal('1', 'counter is correct');
 
         escrowAddress = event?.escrow;
       });
@@ -583,7 +580,6 @@ describe('Staking', function () {
           'token address is correct'
         );
         expect(event?.escrow).to.not.be.null;
-        expect(event?.counter.toString()).to.equal('1', 'counter is correct');
 
         escrowAddress = event?.escrow;
 
@@ -638,7 +634,6 @@ describe('Staking', function () {
 
       expect(event?.eip20).to.equal(token.address, 'token address is correct');
       expect(event?.escrow).to.not.be.null;
-      expect(event?.counter.toString()).to.equal('1', 'counter is correct');
 
       escrowAddress = event?.escrow;
 


### PR DESCRIPTION
Changes to `Launched` event of EscrowFactory contract is unnecessary, which ends up with breaking subgraph.
So, reverting those changes to make original subgraph work.