### PR TITLE
Add ex oracle url to create job response

### DIFF
--- a/packages/examples/fortune/launcher/server/src/routes/escrow.ts
+++ b/packages/examples/fortune/launcher/server/src/routes/escrow.ts
@@ -28,7 +28,8 @@ export const createEscrow: FastifyPluginAsync = async (server) => {
         body: escrowSchema,
         response: {
           200: Type.Object({
-            response: Type.String(),
+            escrowAddress: Type.String(),
+            exchangeUrl: Type.String(),
           }),
         },
       },
@@ -79,7 +80,10 @@ export const createEscrow: FastifyPluginAsync = async (server) => {
           url,
           fortunesRequested
         );
-        return escrowAddress;
+        return {
+          escrowAddress,
+          exchangeUrl: `${data.exchangeOracleUrl}?address=${escrowAddress}`,
+        };
       }
 
       return reply

--- a/packages/examples/fortune/launcher/server/tests/routes/escrow.test.ts
+++ b/packages/examples/fortune/launcher/server/tests/routes/escrow.test.ts
@@ -99,6 +99,9 @@ describe('Escrow route tests', async () => {
     });
 
     expect(response.statusCode).eq(200);
-    expect(response.body).contains('0x');
+    const body = JSON.parse(response.body);
+    expect(body.escrowAddress).contains('0x');
+    expect(body.exchangeUrl).contains(body.escrowAddress);
+    expect(body.exchangeUrl).contains('http://localhost:3001/?address=');
   });
 });


### PR DESCRIPTION
## Description

Add ex oracle url to create job response

## Summary of changes
Add exchangeUrl to response, example:
{
  escrowAddress: '0xddEA3d67503164326F90F53CFD1705b90Ed1312D',
  exchangeUrl: 'http://localhost:3001/?address=0xddEA3d67503164326F90F53CFD1705b90Ed1312D'
 }

## How test the changes

`yarn fortune:test`

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
