### PR TITLE
Fix get_pub_key_from_addr to get value of wallet_addr

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/eth_bridge.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/eth_bridge.py
@@ -383,7 +383,11 @@ def get_staking(staking_addr=HMTOKEN_ADDR, hmt_server_addr: str = None) -> Contr
     return contract
 
 
-def get_pub_key_from_addr(wallet_addr: str, hmt_server_addr: str = None) -> bytes:
+def get_pub_key_from_addr(
+    wallet_addr: str,
+    hmt_server_addr: str = None,
+    kvstore_contract: str = KVSTORE_CONTRACT,
+) -> bytes:
     """
     Given a wallet address, uses the kvstore to pull down the public key for a user
     in the hmt universe, defined by the kvstore key `hmt_pub_key`.  Works with the
@@ -431,8 +435,8 @@ def get_pub_key_from_addr(wallet_addr: str, hmt_server_addr: str = None) -> byte
         "{}/KVStore.sol/KVStore.json".format(ABIS_FOLDER)
     )
 
-    kvstore = w3.eth.contract(address=KVSTORE_CONTRACT, abi=contract_interface["abi"])
-    addr_pub_key = kvstore.functions.get(GAS_PAYER, "hmt_pub_key").call(
+    kvstore = w3.eth.contract(address=kvstore_contract, abi=contract_interface["abi"])
+    addr_pub_key = kvstore.functions.get(wallet_addr, "hmt_pub_key").call(
         {"from": GAS_PAYER}
     )
 

--- a/packages/sdk/typescript/human-protocol-sdk/src/job.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/job.ts
@@ -104,7 +104,7 @@ export class Job {
           alchemy: alchemyKey,
           infura: infuraKey,
         })
-      : new ethers.providers.JsonRpcProvider();
+      : new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545');
 
     this.providerData = {
       provider,


### PR DESCRIPTION
## Description

Fix `get_pub_key_from_addr` to get value of `wallet_addr`.

## Summary of changes

First parameter `wallet_addr` provided to function `get_pub_key_from_addr` was unused. `get_pub_key_from_addr` always returned `hmt_pub_key` of main `GAS_PAYER`. Now `get_pub_key_from_addr` retrieves `hmt_pub_key` for `wallet_addr` provided as first parameter.

## How test the changes

call set_pub_key_at_addr(pub_key, hmt_server_addr)
call get_pub_key_from_addr(wallet_addr)
value `pub_key` and value returned by `get_pub_key_from_addr` should be equal

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
