### PR TITLE
Adjust sdk syntax code for python less than 3.10

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/job.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/job.py
@@ -3,7 +3,15 @@ import logging
 import os
 from decimal import Decimal
 from enum import Enum
-from typing import Dict, List, Tuple, Optional, Any, TypedDict
+from typing import (
+    Dict,
+    List,
+    Tuple,
+    Optional,
+    Any,
+    TypedDict,
+    Union
+)
 
 from basemodels import Manifest
 from eth_keys import keys
@@ -1936,7 +1944,7 @@ class Job:
                     return True
         return False
 
-    def _find_operator(self, addr: Optional[str]) -> Tuple[str, str] | None:
+    def _find_operator(self, addr: Optional[str]) -> Union[Tuple[str, str], None]:
         """
         Find the operator to execute the transaction from trusted wallets.
 


### PR DESCRIPTION
## Description

Adjust sdk syntax code for python less than 3.10

## Summary of changes

Symbol `|` is supported starting from python 3.10, so `|` replaced with `Union[]`

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
