### PR TITLE
Recording oracle/webhook

### DIFF
--- a/packages/examples/fortune-v2/exchange-oracle/server/src/app.module.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/app.module.ts
@@ -6,7 +6,6 @@ import { EthersModule } from "nestjs-ethers";
 
 import { AppController } from "./app.controller";
 import { DatabaseModule } from "./database/database.module";
-import { RolesGuard } from "./common/guards";
 import { HttpValidationPipe } from "./common/pipes";
 import { HealthModule } from "./health/health.module";
 import { networkMap, networks } from "./common/interfaces/networks";
@@ -23,10 +22,6 @@ const ethersModules = networks.map(network => {
 
 @Module({
   providers: [
-    {
-      provide: APP_GUARD,
-      useClass: RolesGuard,
-    },
     {
       provide: APP_PIPE,
       useClass: HttpValidationPipe,

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/common/decorators/webhook.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/common/decorators/webhook.ts
@@ -5,10 +5,9 @@ export interface IWebhook extends IBase {
   signature: string;
   chainId: number;
   escrowAddress: string;
-  s3Url: string;
   retriesCount?: number;
   status?: WebhookStatus;
-  waitUntil: Date;
+  waitUntil?: Date;
 }
 
 export enum ChainId {

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/common/helpers/encryption.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/common/helpers/encryption.ts
@@ -1,0 +1,118 @@
+import * as openpgp from 'openpgp';
+import * as bip39 from "bip39"
+import { IDecryptMessage, IEncryptMessage, IKeyPair, ISignMessage, IVerifyMessage } from '../interfaces/encryption';
+
+
+export async function encrypt(data: IEncryptMessage): Promise<string> {
+  const publicKeysArmored = data.publicKeys;
+  const privateKeyArmored = data.privateKey;
+  const passphrase = data.mnemonic;
+  const plaintext = data.message;
+  
+  const publicKeys = await Promise.all(publicKeysArmored.map(armoredKey => openpgp.readKey({ armoredKey })));
+  
+  const privateKey = await openpgp.decryptKey({
+    privateKey: await openpgp.readPrivateKey({ armoredKey: privateKeyArmored }),
+    passphrase
+  });
+  
+  const message = await openpgp.createMessage({ text: plaintext });
+  const encrypted = await openpgp.encrypt({
+    message,
+    encryptionKeys: publicKeys,
+    signingKeys: privateKey
+  });
+
+  return encrypted as string;
+}
+
+export async function decrypt(data: IDecryptMessage): Promise<string> {
+  const publicKey = await openpgp.readKey({ armoredKey: data.publicKey });
+
+  const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readPrivateKey({ armoredKey: data.privateKey }),
+      passphrase: data.mnemonic
+  });
+
+  const message = await openpgp.readMessage({
+      armoredMessage: data.message
+  });
+
+  const { data: decrypted, signatures } = await openpgp.decrypt({
+      message,
+      decryptionKeys: privateKey,
+      expectSigned: true,
+      verificationKeys: publicKey, // mandatory with expectSigned=true
+  });
+  console.log(decrypted, signatures);
+  return decrypted as string;
+}
+
+export async function sign(data: ISignMessage): Promise<string> { 
+  const privateKey = await openpgp.decryptKey({
+      privateKey: await openpgp.readPrivateKey({ armoredKey: data.privateKey }),
+      passphrase: data.mnemonic
+  });
+
+  const unsignedMessage = await openpgp.createCleartextMessage({ text: data.message });
+  
+  const cleartextMessage = await openpgp.sign({
+      message: unsignedMessage,
+      signingKeys: privateKey,
+      format: 'armored' 
+  });
+
+  console.log(unsignedMessage)
+  
+  return cleartextMessage;
+}
+
+export async function verify(data: IVerifyMessage): Promise<boolean> { 
+  const publicKey = await openpgp.readKey({ armoredKey: data.publicKey });
+
+  const signedMessage = await openpgp.readCleartextMessage({
+      cleartextMessage: data.message
+  });
+
+  const verificationResult = await signedMessage.verify([publicKey])
+  
+  const { verified, keyID } = verificationResult[0];
+
+  try {
+      console.log('Signed by key id ' + keyID.toHex());
+      return await verified;
+  } catch (e) {
+      throw new Error('Signature could not be verified: ' + e.message);
+  }
+}
+
+export async function getSignedData(message: string): Promise<any> { 
+  const signedMessage = await openpgp.readCleartextMessage({
+      cleartextMessage: message
+  });
+
+  try {
+      return JSON.parse(signedMessage.getText());
+  } catch (e) {
+      throw new Error('Signature could not be verified: ' + e.message);
+  }
+}
+
+export async function generateKeyPair(): Promise<IKeyPair> {
+  const mnemonic = bip39.generateMnemonic()
+
+  const { privateKey, publicKey, revocationCertificate } = await openpgp.generateKey({
+    type: 'ecc',
+    curve: 'ed25519',
+    userIDs: [{ name: 'Human Protocol', email: 'human@hmt.ai' }],
+    passphrase: mnemonic,
+    format: 'armored'
+  });
+
+  return {
+    mnemonic,
+    privateKey,
+    publicKey,
+    revocationCertificate
+  };
+}

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/common/helpers/index.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/common/helpers/index.ts
@@ -1,2 +1,2 @@
 export * from "./array";
-export * from "./json";
+export * from "./encryption";

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/common/helpers/json.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/common/helpers/json.ts
@@ -1,8 +1,0 @@
-export function isJson(str: string) {
-  try {
-    JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-  return true;
-}

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/common/interfaces/encryption.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/common/interfaces/encryption.ts
@@ -1,0 +1,32 @@
+export interface IKeyPair {
+  privateKey: string;
+  publicKey: string;
+  mnemonic: string;
+  revocationCertificate?: string;
+}
+
+export interface IEncryptMessage {
+  privateKey: string;
+  publicKeys: string[];
+  mnemonic: string;
+  message: string;
+}
+
+export interface IDecryptMessage {
+  privateKey: string;
+  publicKey: string;
+  mnemonic: string;
+  message: string;
+}
+
+
+export interface ISignMessage {
+  privateKey: string;
+  mnemonic: string;
+  message: string;
+}
+
+export interface IVerifyMessage {
+  publicKey: string;
+  message: string;
+}

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/common/interfaces/signature.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/common/interfaces/signature.ts
@@ -1,0 +1,4 @@
+export interface ISignature {
+  chainId: number;
+  escrowAddress: string;
+}

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/dto/create.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/dto/create.ts
@@ -1,36 +1,9 @@
-import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsEnum, IsNumber, IsString } from "class-validator";
-import { WebhookStatus } from "../../common/decorators";
-import { IWebhookCreateDto } from "../interfaces";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString } from "class-validator";
+import { IWebhookIncomingCreateDto } from "../interfaces";
 
-export class JobCreateDto implements IWebhookCreateDto {
+export class WebhookIncomingCreateDto implements IWebhookIncomingCreateDto {
   @ApiProperty()
   @IsString()
   public signature: string;
-
-  @ApiPropertyOptional()
-  @IsNumber()
-  public chainId: number;
-
-  @ApiProperty()
-  @IsString()
-  public escrowAddress: string;
-
-  @ApiProperty()
-  @IsString()
-  public s3Url: string;
-
-  @ApiProperty()
-  @IsNumber()
-  public retriesCount: number;
-
-  @ApiPropertyOptional({
-    enum: WebhookStatus,
-  })
-  @IsEnum(WebhookStatus)
-  public status: WebhookStatus;
-
-  @ApiProperty()
-  @IsString()
-  public waitUntil: Date;
 }

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/dto/update.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/dto/update.ts
@@ -3,9 +3,9 @@ import { IsDate, IsEnum, IsString } from "class-validator";
 import { WebhookStatus } from "../../common/decorators";
 
 import { WebhookCommonDto } from "../../common/dto/webhook-common";
-import { IWebhookUpdateDto } from "../interfaces";
+import { IWebhookIncomingUpdateDto } from "../interfaces";
 
-export class UpdateWebhookDto extends WebhookCommonDto implements IWebhookUpdateDto {
+export class UpdateIncomingWebhookDto extends WebhookCommonDto implements IWebhookIncomingUpdateDto {
   @ApiPropertyOptional({
     enum: WebhookStatus,
   })

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/interfaces/create.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/interfaces/create.ts
@@ -1,11 +1,11 @@
-import { WebhookStatus } from "../../common/decorators";
+import { ISignature } from "../../common/interfaces/signature";
 
-export interface IWebhookCreateDto {
+export interface IWebhookIncomingCreateDto {
   signature: string;
-  chainId: number;
-  escrowAddress: string;
-  s3Url: string;
-  retriesCount: number;
-  status: WebhookStatus;
-  waitUntil: Date;
 }
+
+export interface IWebhookOutgoingCreateDto {
+  signature: string;
+  payload: ISignature;
+}
+

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/interfaces/update.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/interfaces/update.ts
@@ -1,7 +1,7 @@
 import { WebhookStatus } from "../../common/decorators";
 import { IWebhookCommonDto } from "../../common/dto/webhook-common";
 
-export interface IWebhookUpdateDto extends IWebhookCommonDto {
+export interface IWebhookIncomingUpdateDto extends IWebhookCommonDto {
   status?: WebhookStatus;
   waitUntil?: Date;
 }

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/webhook-outgoing.entity.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/webhook-outgoing.entity.ts
@@ -14,10 +14,4 @@ export class WebhookOutgoingEntity extends BaseEntity implements IWebhook {
 
   @Column({ type: "varchar" })
   public escrowAddress: string;
-
-  @Column({ type: "varchar" })
-  public s3Url: string;
-
-  @Column({ type: "timestamptz" })
-  public waitUntil: Date;
 }

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/webhook.module.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/webhook.module.ts
@@ -3,7 +3,6 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { ConfigModule } from "@nestjs/config";
 
 import { WebhookService } from "./webhook.service";
-import { WebhookIncomingEntity } from "./webhook-incoming.entity";
 import { WebhookController } from "./webhook.controller";
 import { WebhookCron } from "./webhook.cron";
 import { StorageModule } from "../storage/storage.module";
@@ -12,7 +11,7 @@ import { WebhookOutgoingEntity } from "./webhook-outgoing.entity";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([WebhookIncomingEntity, WebhookOutgoingEntity]),
+    TypeOrmModule.forFeature([WebhookOutgoingEntity]),
     ConfigModule,
     StorageModule,
     HttpModule,

--- a/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/webhook.service.ts
+++ b/packages/examples/fortune-v2/exchange-oracle/server/src/webhook/webhook.service.ts
@@ -1,17 +1,16 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ConfigService } from "@nestjs/config";
-
-import { WebhookIncomingEntity } from "./webhook-incoming.entity";
 import { Repository } from "typeorm";
+import { WebhookOutgoingEntity } from "./webhook-outgoing.entity";
 
 @Injectable()
 export class WebhookService {
   private readonly logger = new Logger(WebhookService.name);
 
   constructor(
-    @InjectRepository(WebhookIncomingEntity)
-    private readonly webhookIncomingEntityRepository: Repository<WebhookIncomingEntity>,
+    @InjectRepository(WebhookOutgoingEntity)
+    private readonly webhookOutgoingEntityRepository: Repository<WebhookOutgoingEntity>,
     private readonly configService: ConfigService,
   ) {}
 }

--- a/packages/examples/fortune-v2/job-launcher/server/src/currency/currency.service.ts
+++ b/packages/examples/fortune-v2/job-launcher/server/src/currency/currency.service.ts
@@ -13,11 +13,4 @@ export class CurrencyService {
     );
     return data[token_name][currency];
   }
-
-  public async getPair(token_name: string, currency: string) {
-    const { data } = await firstValueFrom(
-      await this.httpService.get(`${COINGECKO_API_URL}?ids=${token_name}&vs_currencies=${currency}`),
-    );
-    return data[token_name][currency];
-  }
 }

--- a/packages/examples/fortune-v2/job-launcher/server/src/payment/dto/confirm.ts
+++ b/packages/examples/fortune-v2/job-launcher/server/src/payment/dto/confirm.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString } from "class-validator";
+import { IPaymentConfirmDto } from "../interfaces";
+
+export class PaymentConfirmDto implements IPaymentConfirmDto {
+  @ApiProperty()
+  @IsString()
+  public paymentId: string;
+}

--- a/packages/examples/fortune-v2/recording-oracle/server/src/common/decorators/webhook.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/common/decorators/webhook.ts
@@ -7,7 +7,7 @@ export interface IWebhook extends IBase {
   escrowAddress: string;
   retriesCount?: number;
   status?: WebhookStatus;
-  waitUntil: Date;
+  waitUntil?: Date;
 }
 
 export enum ChainId {

--- a/packages/examples/fortune-v2/recording-oracle/server/src/common/enums/errors.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/common/enums/errors.ts
@@ -31,5 +31,6 @@ export enum Bucket {
 export enum Webhook {
   NotFound = "Webhook not found",
   NotCreated = "Webhook has not been created",
+  NotSent = "Webhook has not been sent",
   BadParams = "Bad params"
 }

--- a/packages/examples/fortune-v2/recording-oracle/server/src/common/interfaces/signature.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/common/interfaces/signature.ts
@@ -1,0 +1,4 @@
+export interface ISignature {
+  chainId: number;
+  escrowAddress: string;
+}

--- a/packages/examples/fortune-v2/recording-oracle/server/src/migrations/1677750428969-addWebhookOutgoingTable.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/migrations/1677750428969-addWebhookOutgoingTable.ts
@@ -37,10 +37,6 @@ export class addWebhookOutgoingTable1677750428969 implements MigrationInterface 
           name: "updated_at",
           type: "timestamptz",
         },
-        {
-          name: "wait_until",
-          type: "timestamptz",
-        },
       ],
     });
 

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/dto/create.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/dto/create.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { IsNumber, IsString } from "class-validator";
-import { IWebhookCreateDto } from "../interfaces";
+import { IWebhookIncomingCreateDto } from "../interfaces";
 
-export class WebhookCreateDto implements IWebhookCreateDto {
+export class WebhookIncomingCreateDto implements IWebhookIncomingCreateDto {
   @ApiProperty()
   @IsString()
   public signature: string;

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/dto/update.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/dto/update.ts
@@ -3,9 +3,9 @@ import { IsDate, IsEnum, IsString } from "class-validator";
 import { WebhookStatus } from "../../common/decorators";
 
 import { WebhookCommonDto } from "../../common/dto/webhook-common";
-import { IWebhookUpdateDto } from "../interfaces";
+import { IWebhookIncomingUpdateDto } from "../interfaces";
 
-export class UpdateWebhookDto extends WebhookCommonDto implements IWebhookUpdateDto {
+export class UpdateIncomingWebhookDto extends WebhookCommonDto implements IWebhookIncomingUpdateDto {
   @ApiPropertyOptional({
     enum: WebhookStatus,
   })

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/interfaces/create.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/interfaces/create.ts
@@ -1,3 +1,11 @@
-export interface IWebhookCreateDto {
+import { ISignature } from "../../common/interfaces/signature";
+
+export interface IWebhookIncomingCreateDto {
   signature: string;
 }
+
+export interface IWebhookOutgoingCreateDto {
+  signature: string;
+  payload: ISignature;
+}
+

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/interfaces/update.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/interfaces/update.ts
@@ -1,7 +1,7 @@
 import { WebhookStatus } from "../../common/decorators";
 import { IWebhookCommonDto } from "../../common/dto/webhook-common";
 
-export interface IWebhookUpdateDto extends IWebhookCommonDto {
+export interface IWebhookIncomingUpdateDto extends IWebhookCommonDto {
   status?: WebhookStatus;
   waitUntil?: Date;
 }

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/webhook-outgoing.entity.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/webhook-outgoing.entity.ts
@@ -14,7 +14,4 @@ export class WebhookOutgoingEntity extends BaseEntity implements IWebhook {
 
   @Column({ type: "varchar" })
   public escrowAddress: string;
-  
-  @Column({ type: "timestamptz" })
-  public waitUntil: Date;
 }

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/webhook.controller.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/webhook.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Header, Post, Request, UseGuards } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { Public } from "../common/decorators";
-import { WebhookCreateDto } from "./dto";
+import { WebhookIncomingCreateDto } from "./dto";
 import { WebhookService } from "./webhook.service";
 
 @Public()
@@ -11,7 +11,7 @@ export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
   @Post("/")
-  public async createIncomingWebhook(@Request() req: any, @Body() data: WebhookCreateDto): Promise<boolean> {
+  public async createIncomingWebhook(@Request() req: any, @Body() data: WebhookIncomingCreateDto): Promise<boolean> {
     return this.webhookService.createIncomingWebhook(data);
   }
 }

--- a/packages/examples/fortune-v2/recording-oracle/server/src/webhook/webhook.service.ts
+++ b/packages/examples/fortune-v2/recording-oracle/server/src/webhook/webhook.service.ts
@@ -6,12 +6,13 @@ import { ConfigService } from "@nestjs/config";
 
 import { WebhookIncomingEntity } from "./webhook-incoming.entity";
 import { Repository } from "typeorm";
-import { IWebhookCreateDto } from "./interfaces";
+import { IWebhookIncomingCreateDto, IWebhookOutgoingCreateDto } from "./interfaces";
 import { WebhookStatus } from "../common/decorators";
 import * as errors from "../common/enums/errors";
-import { getSignedData, verify } from "../common/helpers";
+import { getSignedData, sign, verify } from "../common/helpers";
 import { IVerifyMessage } from "../common/interfaces/encryption";
 import { ISignature } from "../common/interfaces/signature";
+import { WebhookOutgoingEntity } from "./webhook-outgoing.entity";
 
 @Injectable()
 export class WebhookService {
@@ -20,11 +21,14 @@ export class WebhookService {
   constructor(
     @InjectRepository(WebhookIncomingEntity)
     private readonly webhookIncomingEntityRepository: Repository<WebhookIncomingEntity>,
+    @InjectRepository(WebhookOutgoingEntity)
+    private readonly webhookOutgoingEntityRepository: Repository<WebhookOutgoingEntity>,
     private readonly configService: ConfigService,
     private readonly httpService: HttpService
   ) {}
 
-  public async createIncomingWebhook(dto: IWebhookCreateDto): Promise<boolean> {
+  public async createIncomingWebhook(dto: IWebhookIncomingCreateDto): Promise<boolean> {
+    // TODO: Get signature from headers
     const { signature } = dto;
 
     const verifyData: IVerifyMessage = {
@@ -73,5 +77,50 @@ export class WebhookService {
   public async processIncommingWebhook(webhookIncomingEntity: WebhookIncomingEntity): Promise<boolean> {
     // TODO: https://github.com/humanprotocol/human-protocol/issues/300
     return true;
+  }
+
+  /*
+    const signedData = {
+      mnemonic: this.configService.get<string>("MNEMONIC", "MNEMONIC"),
+      privateKey: this.configService.get<string>("PGP_PRIVATE_KEY", "PGP_PRIVATE_KEY"),
+      publicKey: this.configService.get<string>("PGP_PUBLIC_KEY", "PGP_PUBLIC_KEY"),
+      message: JSON.stringify(signatureData)
+    }
+
+    const signature = await sign(signedData)
+  */
+  public async notifyOracle(oracleUrl: string, dto: IWebhookOutgoingCreateDto): Promise<boolean> {
+    const { signature, payload } = dto;
+
+    try {
+      // TODO: Send signature in headers
+      const { data } = await firstValueFrom(
+        this.httpService.post(oracleUrl, { 
+          signature
+        }),
+      );
+
+      if (!data) {
+        this.logger.log(errors.Webhook.NotSent, WebhookService.name);
+        throw new NotFoundException(errors.Webhook.NotSent);
+      }
+
+      return true;
+    } catch (e) {
+      const webhookEntity = await this.webhookOutgoingEntityRepository
+        .create({
+          chainId: payload.chainId,
+          escrowAddress: payload.escrowAddress,
+          signature,
+        })
+        .save();
+
+      if (!webhookEntity) {
+        this.logger.log(errors.Webhook.NotCreated, WebhookService.name);
+        throw new NotFoundException(errors.Webhook.NotCreated);
+      }
+
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## Description
Client for communication with Reputation Oracle.
 
The Recording Oracle should be able to send a webhook to Reputation Oracle, in case of an error, write the result to a table `webhooks_outgoing_table` with the `FAILED` status.

[Detailed spec in notion](https://www.notion.so/human-protocol/Recording-Oracle-84ebf2e52e5a4c1087cea216f2bafa04?pvs=4#5b9ae1b7f30b42c78c925b1c9c0db1de)

## Related issues
[Fortune | Recording Oracle - Develop Reputation Oracle client#307](https://github.com/humanprotocol/human-protocol/issues/307)
[Fortune | Recording Oracle - Implement common Webhook module with processing details#300](https://github.com/humanprotocol/human-protocol/issues/300)