### PR TITLE
basemodels: manifest: include content preferences

### DIFF
--- a/packages/sdk/json-schema/manifest.json
+++ b/packages/sdk/json-schema/manifest.json
@@ -714,6 +714,13 @@
           "title": "Launch Group Id",
           "minimum": 0,
           "type": "integer"
+        },
+        "interests": {
+          "title": "Interests",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
         }
       }
     }

--- a/packages/sdk/python/human-protocol-basemodels/basemodels/manifest/restricted_audience.py
+++ b/packages/sdk/python/human-protocol-basemodels/basemodels/manifest/restricted_audience.py
@@ -45,6 +45,8 @@ class RestrictedAudience(BaseModel):
 
     launch_group_id: Optional[conint(ge=0, strict=True)]
 
+    interests: Optional[List[conint(strict=True)]]
+
     def dict(self, **kwargs):
         kwargs["exclude_unset"] = True
         return super().dict(**kwargs)

--- a/packages/sdk/python/human-protocol-basemodels/test/test_manifest.py
+++ b/packages/sdk/python/human-protocol-basemodels/test/test_manifest.py
@@ -395,6 +395,13 @@ class ManifestTest(unittest.TestCase):
         ]:
             assert_raises(data)
 
+        for data in [
+            {"interests": 1},
+            {"interests": {"mapped": 1}},
+            {"interests": ["as", "string"]},
+        ]:
+            assert_raises(data)
+
         data = {
             "lang": [
                 {"us": {"score": 0}},
@@ -427,6 +434,7 @@ class ManifestTest(unittest.TestCase):
             "min_user_score": 0,
             "max_user_score": 0.3,
             "launch_group_id": 101,
+            "interests": [1, 2, 3, 4],
         }
 
         RestrictedAudience(**data)

--- a/packages/sdk/typescript/human-protocol-sdk/src/types.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/types.ts
@@ -244,6 +244,11 @@ export type RestrictedAudience = {
    * Launch group ID
    */
   launch_group_id?: number;
+
+  /**
+   * Interests/Content preferences
+   */
+  interests?: number[];
 };
 
 /**


### PR DESCRIPTION
## Description

Introduce `interests` to manifest to allow launching jobs with specific interests as described in `Table of Interests` docs.

## Summary of changes

Modified manifests schemas to include `interests`

## How test the changes

Tests include both negative and positive cases for new functionality.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

NONE

<!-- Does this close any open issues? -->
NO

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
