### PR TITLE
add bulk set function to kvstore and remove duplicate code from staking

### DIFF
--- a/packages/core/contracts/KVStore.sol
+++ b/packages/core/contracts/KVStore.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.6.0;
 
 contract KVStore {
     uint private constant MAX_STRING_LENGTH = 1000;
+    uint private constant BULK_MAX_COUNT = 20;
     mapping(address => mapping(string => string)) private store;
 
     event DataSaved(address indexed sender, string key, string value);
@@ -22,5 +23,17 @@ contract KVStore {
         );
         store[msg.sender][_key] = _value;
         emit DataSaved(msg.sender, _key, _value);
+    }
+
+    function setBulk(string[] memory _keys, string[] memory _values) public {
+        require(
+            _keys.length == _values.length,
+            'Keys and values must have the same length'
+        );
+        require(_keys.length < BULK_MAX_COUNT, 'Too many entries');
+
+        for (uint i = 0; i < _keys.length; i++) {
+            set(_keys[i], _values[i]);
+        }
     }
 }

--- a/packages/core/contracts/libs/Stakes.sol
+++ b/packages/core/contracts/libs/Stakes.sol
@@ -29,15 +29,6 @@ library Stakes {
     }
 
     /**
-     * @dev Withdraw tokens from the staker stake.
-     * @param stake Staker struct
-     * @param _tokens Amount of tokens to withdraw
-     */
-    function withdraw(Stakes.Staker storage stake, uint256 _tokens) internal {
-        stake.tokensStaked = stake.tokensStaked.sub(_tokens);
-    }
-
-    /**
      * @dev Release tokens from the staker stake.
      * @param stake Staker struct
      * @param _tokens Amount of tokens to release
@@ -117,7 +108,7 @@ library Stakes {
 
         if (tokensToWithdraw > 0) {
             stake.unlockTokens(tokensToWithdraw);
-            stake.withdraw(tokensToWithdraw);
+            stake.release(tokensToWithdraw);
         }
 
         return tokensToWithdraw;

--- a/packages/core/test/KVStore.ts
+++ b/packages/core/test/KVStore.ts
@@ -88,4 +88,55 @@ describe('KVStore', function () {
     });
     expect(decrypted).equal('H');
   });
+
+  it("doesn't allow storing invalid key-value pairs", async () => {
+    await expect(
+      kvStore.setBulk(['private_key1'], ['satoshi', 'satoshi'])
+    ).to.be.revertedWith('Keys and values must have the same length');
+  });
+
+  it("doesn't allow storing too many key-value pairs", async () => {
+    await expect(
+      kvStore.setBulk(Array(21).fill('private_key1'), Array(21).fill('satoshi'))
+    ).to.be.revertedWith('Too many entries');
+  });
+
+  it("doesn't allow storing too long key/value", async () => {
+    await expect(
+      kvStore.setBulk(
+        [
+          'satoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamoto',
+          'satoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamoto',
+        ],
+        ['satoshi', 'satoshi']
+      )
+    ).to.be.revertedWith('Maximum string length');
+
+    await expect(
+      kvStore.setBulk(
+        ['satoshi', 'satoshi'],
+        [
+          'satoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamoto',
+          'satoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamotosatoshinakamoto',
+        ]
+      )
+    ).to.be.revertedWith('Maximum string length');
+  });
+
+  it('store multiple values and its ipfs hash on smart contract', async () => {
+    await kvStore.setBulk(
+      ['public_key1', 'public_key2'],
+      [
+        'bafkreieadxyvobae4a2ww7tytw37dw2ihvvbujj5npjepurraavtaoczcq',
+        'bafkreieadxyvobae4a2ww7tytw37dw2ihvvbujj5npjepurraavtaoczcr',
+      ]
+    );
+
+    expect(await kvStore.get(accountOne.getAddress(), 'public_key1')).equal(
+      'bafkreieadxyvobae4a2ww7tytw37dw2ihvvbujj5npjepurraavtaoczcq'
+    );
+    expect(await kvStore.get(accountOne.getAddress(), 'public_key2')).equal(
+      'bafkreieadxyvobae4a2ww7tytw37dw2ihvvbujj5npjepurraavtaoczcr'
+    );
+  });
 });

--- a/packages/core/test/Staking.ts
+++ b/packages/core/test/Staking.ts
@@ -687,6 +687,27 @@ describe('Staking', function () {
         ).to.be.revertedWith('Must be a valid address');
       });
 
+      it('Should revert if slash amount exceeds allocation', async function () {
+        await staking
+          .connect(owner)
+          .slash(
+            await validator.getAddress(),
+            await operator.getAddress(),
+            escrowAddress,
+            slashedTokens
+          );
+
+        await expect(
+          staking
+            .connect(owner)
+            .slash(
+              await validator.getAddress(),
+              await operator.getAddress(),
+              escrowAddress,
+              allocatedTokens
+            )
+        ).to.be.revertedWith('Slash tokens exceed allocated ones');
+      });
       // TODO: Add additional tests
     });
 


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
- Added `setBulk` function to KVStore. Set 20 as maximum bulk count.
- Remove duplicated code from staking contract.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
