### PR TITLE
fix token view on escrow dashboard

### DIFF
--- a/packages/apps/escrow-dashboard/src/components/Escrow/EscrowContainer.tsx
+++ b/packages/apps/escrow-dashboard/src/components/Escrow/EscrowContainer.tsx
@@ -31,6 +31,7 @@ import { setChainId as setEscrowChainId } from 'src/state/escrow/reducer';
 import { setChainId as setLeaderChainId } from 'src/state/leader/reducer';
 
 const NETWORK_ICONS: { [chainId in ChainId]?: ReactElement } = {
+  [ChainId.MAINNET]: <EthereumIcon />,
   [ChainId.RINKEBY]: <EthereumIcon />,
   [ChainId.GOERLI]: <EthereumIcon />,
   [ChainId.POLYGON]: <PolygonIcon />,

--- a/packages/apps/escrow-dashboard/src/state/token/hooks.ts
+++ b/packages/apps/escrow-dashboard/src/state/token/hooks.ts
@@ -5,7 +5,7 @@ import { AppState, useAppDispatch } from '..';
 import { useChainId } from '../escrow/hooks';
 import { fetchTokenStatsAsync } from './reducer';
 
-import { ChainId, SUPPORTED_CHAIN_IDS, TESTNET_CHAIN_IDS } from 'src/constants';
+import { ChainId, SUPPORTED_CHAIN_IDS } from 'src/constants';
 import { useSlowRefreshEffect } from 'src/hooks/useRefreshEffect';
 
 export const usePollTokenStats = () => {
@@ -21,10 +21,7 @@ export const useTokenStatsByChainId = () => {
   const token = useSelector((state: AppState) => state.token);
   const { stats } = token;
 
-  if (
-    currentChainId === ChainId.ALL ||
-    TESTNET_CHAIN_IDS.includes(currentChainId)
-  ) {
+  if (currentChainId === ChainId.ALL) {
     const tokenStats = {
       totalTransferEventCount: 0,
       holders: 0,
@@ -32,7 +29,7 @@ export const useTokenStatsByChainId = () => {
     };
 
     SUPPORTED_CHAIN_IDS.forEach((chainId) => {
-      if (stats[chainId] && !TESTNET_CHAIN_IDS.includes(chainId)) {
+      if (stats[chainId]) {
         tokenStats.totalTransferEventCount +=
           stats[chainId]?.totalTransferEventCount!;
         tokenStats.holders += stats[chainId]?.holders!;

--- a/packages/apps/escrow-dashboard/src/state/token/reducer.ts
+++ b/packages/apps/escrow-dashboard/src/state/token/reducer.ts
@@ -44,13 +44,14 @@ export const fetchTokenStatsAsync = createAsyncThunk<
   await Promise.all(
     SUPPORTED_CHAIN_IDS.map(async (chainId) => {
       if (chainId === ChainId.RINKEBY) {
-        return {
+        tokenStats[chainId] = {
           totalApprovalEventCount: 0,
           totalTransferEventCount: 0,
           totalValueTransfered: 0,
           holders: 0,
-          totalSupply: 0,
+          totalSupply: '0',
         };
+        return;
       }
       const stats = await gqlFetch(
         ESCROW_NETWORKS[chainId]?.subgraphUrl!,


### PR DESCRIPTION
## Description

Token view shows sum of mainnet chains when testnets are selected from tab control. So sometimes it doesn't make sense to users.

## Summary of changes

Show selected chain data on token metrics, and only show sum of all chain data if `All Network` tab is selected.
