### PR TITLE
update variable name and datatype in escrow contract

### DIFF
--- a/packages/core/contracts/Escrow.sol
+++ b/packages/core/contracts/Escrow.sol
@@ -17,6 +17,9 @@ contract Escrow is IEscrow, ReentrancyGuard {
 
     string constant ERROR_ZERO_ADDRESS = 'Escrow: zero address';
 
+    uint256 private constant BULK_MAX_VALUE = 1e9 * (10 ** 18);
+    uint32 private constant BULK_MAX_COUNT = 100;
+
     event TrustedHandlerAdded(address _handler);
     event IntermediateStorage(address _sender, string _url, string _hash);
     event Pending(string manifest, string hash);
@@ -38,8 +41,6 @@ contract Escrow is IEscrow, ReentrancyGuard {
 
     uint8 public reputationOracleFeePercentage;
     uint8 public recordingOracleFeePercentage;
-    uint256 private constant BULK_MAX_VALUE = 1e9 * (10 ** 18);
-    uint32 private constant BULK_MAX_COUNT = 100;
 
     address public token;
 
@@ -218,6 +219,7 @@ contract Escrow is IEscrow, ReentrancyGuard {
             _recipients.length == _amounts.length,
             "Amount of recipients and values don't match"
         );
+        require(_amounts.length > 0, 'Amounts should not be empty');
         require(_recipients.length < BULK_MAX_COUNT, 'Too many recipients');
         require(
             status != EscrowStatuses.Complete &&

--- a/packages/core/contracts/interfaces/IEscrow.sol
+++ b/packages/core/contracts/interfaces/IEscrow.sol
@@ -19,8 +19,8 @@ interface IEscrow {
     function setup(
         address _reputationOracle,
         address _recordingOracle,
-        uint256 _reputationOracleStake,
-        uint256 _recordingOracleStake,
+        uint8 _reputationOracleFeePercentage,
+        uint8 _recordingOracleFeePercentage,
         string memory _url,
         string memory _hash
     ) external;

--- a/packages/core/test/Escrow.ts
+++ b/packages/core/test/Escrow.ts
@@ -323,19 +323,19 @@ describe('Escrow', function () {
         ).to.be.revertedWith('Invalid or missing token spender');
       });
 
-      it('Should revert with the right error if stake out of bounds and too high', async function () {
+      it('Should revert with the right error if fee percentage out of bounds and too high', async function () {
         await expect(
           escrow
             .connect(owner)
             .setup(
               await reputationOracle.getAddress(),
               await recordingOracle.getAddress(),
-              500,
-              500,
+              80,
+              80,
               MOCK_URL,
               MOCK_HASH
             )
-        ).to.be.revertedWith('Stake out of bounds');
+        ).to.be.revertedWith('Percentage out of bounds');
       });
     });
 

--- a/packages/examples/fortune/tests/e2e-backend/contracts/InvalidEscrowAbi.json
+++ b/packages/examples/fortune/tests/e2e-backend/contracts/InvalidEscrowAbi.json
@@ -312,7 +312,7 @@
 	},
 	{
 		"inputs": [],
-		"name": "recordingOracleStake",
+		"name": "recordingOracleFeePercentage",
 		"outputs": [
 			{
 				"internalType": "uint256",
@@ -338,7 +338,7 @@
 	},
 	{
 		"inputs": [],
-		"name": "reputationOracleStake",
+		"name": "reputationOracleFeePercentage",
 		"outputs": [
 			{
 				"internalType": "uint256",
@@ -363,12 +363,12 @@
 			},
 			{
 				"internalType": "uint256",
-				"name": "_reputationOracleStake",
+				"name": "_reputationOracleFeePercentage",
 				"type": "uint256"
 			},
 			{
 				"internalType": "uint256",
-				"name": "_recordingOracleStake",
+				"name": "_recordingOracleFeePercentage",
 				"type": "uint256"
 			},
 			{

--- a/packages/sdk/typescript/human-protocol-sdk/src/job.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/job.ts
@@ -378,9 +378,9 @@ export class Job {
       return false;
     }
 
-    const reputationOracleStake =
+    const reputationOracleFeePercentage =
       (this.manifestData?.manifest?.oracle_stake || 0) * 100;
-    const recordingOracleStake =
+    const recordingOracleFeePercentage =
       (this.manifestData?.manifest?.oracle_stake || 0) * 100;
     const repuationOracleAddr =
       this.manifestData?.manifest?.reputation_oracle_addr || '';
@@ -436,8 +436,8 @@ export class Job {
       'setup',
       repuationOracleAddr,
       recordingOracleAddr,
-      reputationOracleStake,
-      recordingOracleStake,
+      reputationOracleFeePercentage,
+      recordingOracleFeePercentage,
       this.manifestData?.manifestlink?.url,
       this.manifestData?.manifestlink?.hash
     );

--- a/packages/tools/data-recovery-tool/src/abis/Escrow_rinkeby_0x925B24444511c86F4d4E63141D8Be0A025E2dca4.json
+++ b/packages/tools/data-recovery-tool/src/abis/Escrow_rinkeby_0x925B24444511c86F4d4E63141D8Be0A025E2dca4.json
@@ -344,7 +344,7 @@
   },
   {
     "inputs": [],
-    "name": "recordingOracleStake",
+    "name": "recordingOracleFeePercentage",
     "outputs": [
       {
         "internalType": "uint256",
@@ -370,7 +370,7 @@
   },
   {
     "inputs": [],
-    "name": "reputationOracleStake",
+    "name": "reputationOracleFeePercentage",
     "outputs": [
       {
         "internalType": "uint256",
@@ -395,12 +395,12 @@
       },
       {
         "internalType": "uint256",
-        "name": "_reputationOracleStake",
+        "name": "_reputationOracleFeePercentage",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "_recordingOracleStake",
+        "name": "_recordingOracleFeePercentage",
         "type": "uint256"
       },
       {


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Update escrow contract.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Change data type from `uint256` to `uint8` for fee percentage variables.
- Renamed `recordingOracleStake`, and `reputationOracleStake` to `recordingOracleFeePercentage`, and `reputationOracleFeePercentage`.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #447 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
