### PR TITLE
[Escrow Dashboard] - Fix vercel config to prevent clickjacking

### DIFF
--- a/packages/apps/escrow-dashboard/vercel.json
+++ b/packages/apps/escrow-dashboard/vercel.json
@@ -1,3 +1,23 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'none'"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

Prevent clickjacking on escrow dashboard by adding some security options in the header.

## Summary of changes

Fix vercel.json to include X-Frame-Options and Content-Security-Policy in the header.

## Related issues
This will close #279 
