### PR TITLE
fix reward pool event and subgraph

### DIFF
--- a/packages/core/contracts/RewardPool.sol
+++ b/packages/core/contracts/RewardPool.sol
@@ -36,6 +36,7 @@ contract RewardPool is IRewardPool, OwnableUpgradeable, UUPSUpgradeable {
      */
     event RewardAdded(
         address indexed escrowAddress,
+        address indexed staker,
         address indexed slasher,
         uint256 tokens
     );
@@ -71,6 +72,7 @@ contract RewardPool is IRewardPool, OwnableUpgradeable, UUPSUpgradeable {
      */
     function addReward(
         address _escrowAddress,
+        address _staker,
         address _slasher,
         uint256 _tokens
     ) external override onlyStaking {
@@ -85,10 +87,15 @@ contract RewardPool is IRewardPool, OwnableUpgradeable, UUPSUpgradeable {
         totalFee = totalFee + fees;
 
         // Add reward record
-        Reward memory reward = Reward(_escrowAddress, _slasher, rewardAfterFee);
+        Reward memory reward = Reward(
+            _escrowAddress,
+            _staker,
+            _slasher,
+            rewardAfterFee
+        );
         rewards[_escrowAddress].push(reward);
 
-        emit RewardAdded(_escrowAddress, _slasher, rewardAfterFee);
+        emit RewardAdded(_escrowAddress, _staker, _slasher, rewardAfterFee);
     }
 
     /**

--- a/packages/core/contracts/Staking.sol
+++ b/packages/core/contracts/Staking.sol
@@ -454,7 +454,12 @@ contract Staking is IStaking, OwnableUpgradeable, UUPSUpgradeable {
         _safeTransfer(rewardPool, _tokens);
 
         // Keep record on Reward Pool
-        IRewardPool(rewardPool).addReward(_escrowAddress, _slasher, _tokens);
+        IRewardPool(rewardPool).addReward(
+            _escrowAddress,
+            _staker,
+            _slasher,
+            _tokens
+        );
 
         emit StakeSlashed(_staker, _tokens, _escrowAddress, _slasher);
     }

--- a/packages/core/contracts/interfaces/IRewardPool.sol
+++ b/packages/core/contracts/interfaces/IRewardPool.sol
@@ -8,14 +8,16 @@ interface IRewardPool {
      */
     struct Reward {
         address escrowAddress;
+        address staker;
         address slasher;
         uint256 tokens; // Tokens allocated to a escrowAddress
     }
 
     function addReward(
         address _escrowAddress,
-        address slasher,
-        uint256 tokens
+        address _staker,
+        address _slasher,
+        uint256 _tokens
     ) external;
 
     function getRewards(

--- a/packages/core/test/RewardPool.ts
+++ b/packages/core/test/RewardPool.ts
@@ -148,6 +148,7 @@ describe('RewardPool', function () {
           .addReward(
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
             1
           )
       ).to.be.revertedWith('Caller is not staking contract');
@@ -186,6 +187,7 @@ describe('RewardPool', function () {
         .to.emit(rewardPool, 'RewardAdded')
         .withArgs(
           escrowAddress,
+          await operator.getAddress(),
           await validator.getAddress(),
           slashedTokens - rewardFee
         );

--- a/packages/sdk/typescript/subgraph/schema.graphql
+++ b/packages/sdk/typescript/subgraph/schema.graphql
@@ -210,6 +210,7 @@ type RewardAddedEvent @entity {
   id: ID!
   escrow: Bytes! # address
   staker: Bytes! # address
+  slasher: Bytes! # address
   amount: BigInt!
   block: BigInt!
   timestamp: BigInt!

--- a/packages/sdk/typescript/subgraph/src/mapping/RewardPool.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/RewardPool.ts
@@ -14,7 +14,8 @@ export function handleRewardAdded(event: RewardAdded): void {
 
   // Entity fields can be set based on event parameters
   entity.escrow = event.params.escrowAddress;
-  entity.staker = event.params.slasher;
+  entity.staker = event.params.staker;
+  entity.slasher = event.params.slasher;
   entity.amount = event.params.tokens;
 
   entity.block = event.block.number;

--- a/packages/sdk/typescript/subgraph/template.yaml
+++ b/packages/sdk/typescript/subgraph/template.yaml
@@ -131,7 +131,7 @@ dataSources:
         - name: RewardPool
           file: '{{{ RewardPool.abi }}}'
       eventHandlers:
-        - event: RewardAdded(indexed address,indexed address,uint256)
+        - event: RewardAdded(indexed address,indexed address,indexed address,uint256)
           handler: handleRewardAdded
       file: ./src/mapping/RewardPool.ts
 templates:

--- a/packages/sdk/typescript/subgraph/tests/reward-pool/fixtures.ts
+++ b/packages/sdk/typescript/subgraph/tests/reward-pool/fixtures.ts
@@ -4,6 +4,7 @@ import { ethereum, Address, BigInt } from '@graphprotocol/graph-ts';
 
 export function createRewardAddedEvent(
   escrowAddress: string,
+  staker: string,
   slasher: string,
   tokens: i32,
   timestamp: BigInt
@@ -17,6 +18,12 @@ export function createRewardAddedEvent(
     new ethereum.EventParam(
       'escrowAddress',
       ethereum.Value.fromAddress(Address.fromString(escrowAddress))
+    )
+  );
+  newRewardAddedEvent.parameters.push(
+    new ethereum.EventParam(
+      'staker',
+      ethereum.Value.fromAddress(Address.fromString(staker))
     )
   );
   newRewardAddedEvent.parameters.push(

--- a/packages/sdk/typescript/subgraph/tests/reward-pool/reward-pool.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/reward-pool/reward-pool.test.ts
@@ -8,12 +8,14 @@ describe('RewardPool', () => {
   test('Should properly index StakeAllocated events', () => {
     const data1 = createRewardAddedEvent(
       '0xD979105297fB0eee83F7433fC09279cb5B94fFC7',
+      '0xD979105297fB0eee83F7433fC09279cb5B94fFC5',
       '0xD979105297fB0eee83F7433fC09279cb5B94fFC6',
       30,
       BigInt.fromI32(50)
     );
     const data2 = createRewardAddedEvent(
       '0x92a2eEF7Ff696BCef98957a0189872680600a95A',
+      '0x92a2eEF7Ff696BCef98957a0189872680600a958',
       '0x92a2eEF7Ff696BCef98957a0189872680600a959',
       50,
       BigInt.fromI32(51)
@@ -52,6 +54,12 @@ describe('RewardPool', () => {
       'RewardAddedEvent',
       id1,
       'staker',
+      data1.params.staker.toHexString()
+    );
+    assert.fieldEquals(
+      'RewardAddedEvent',
+      id1,
+      'slasher',
       data1.params.slasher.toHexString()
     );
     assert.fieldEquals('RewardAddedEvent', id1, 'amount', '30');
@@ -85,6 +93,12 @@ describe('RewardPool', () => {
       'RewardAddedEvent',
       id2,
       'staker',
+      data2.params.staker.toHexString()
+    );
+    assert.fieldEquals(
+      'RewardAddedEvent',
+      id2,
+      'slasher',
       data2.params.slasher.toHexString()
     );
     assert.fieldEquals('RewardAddedEvent', id2, 'amount', '50');


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Fix RewardPool contract to have staker information, and subgraph to properly index it.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Fixed `RewardPool` contract.
  - Add `_staker` to `addReward` function.
  - Updated `RewardAdded` event to emit `staker` info as well.
- Fixed `Staking` contract, for `addReward` function change.
- Fixed subgraph to properly index `RewardAdded` event.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
Closes #450 .

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
