### PR TITLE
`get_rewards_info` implementation using subgraph

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -157,7 +157,7 @@ NETWORKS = {
     ChainId.LOCALHOST: {
         "title": "Localhost",
         "scan_url": "",
-        "subgraph_url": "",
+        "subgraph_url": "subgraph_url",
         "hmt_address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
         "factory_address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
         "staking_address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
@@ -344,7 +344,7 @@ class StakingClient:
         reward_added_events_data = get_data_from_subgraph(
             self.network["subgraph_url"],
             """
-rewardAddedEvents(where:{{staker:"{0}"}}) {{
+rewardAddedEvents(where:{{slasher:"{0}"}}) {{
     escrow
     amount
 }}""".format(

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
@@ -16,6 +16,7 @@ from human_protocol_sdk.utils import (
     get_factory_interface,
     get_staking_interface,
     get_reward_pool_interface,
+    get_data_from_subgraph,
 )
 
 GAS_LIMIT = int(os.getenv("GAS_LIMIT", 4712388))
@@ -340,8 +341,25 @@ class StakingClient:
             List[dict]: List of rewards info
         """
 
-        # TODO:
-        pass
+        reward_added_events_data = get_data_from_subgraph(
+            self.network["subgraph_url"],
+            """
+rewardAddedEvents(where:{{staker:"{0}"}}) {{
+    escrow
+    amount
+}}""".format(
+                slasher
+            ),
+        )
+        reward_added_events = reward_added_events_data["data"]["rewardAddedEvents"]
+
+        return [
+            {
+                "escrow_address": reward_added_events[i]["escrow"],
+                "amount": reward_added_events[i]["amount"],
+            }
+            for i in range(len(reward_added_events))
+        ]
 
     def _is_valid_escrow(self, escrow_address: str) -> bool:
         """Checks if the escrow address is valid.

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
@@ -3,6 +3,7 @@ import logging
 import time
 from typing import Tuple, Optional
 
+import requests
 from web3.contract import Contract
 from web3.types import TxReceipt
 
@@ -110,8 +111,8 @@ def get_contract_interface(contract_entrypoint):
     with open(contract_entrypoint) as f:
         contract_interface = json.load(f)
     return contract_interface
-    
-        
+
+
 def get_hmtoken_interface():
     """Retrieve the HMToken interface.
 
@@ -190,3 +191,15 @@ def get_kvstore_interface():
     return get_contract_interface(
         "{}/contracts/KVStore.sol/KVStore.json".format(ARTIFACTS_FOLDER)
     )
+
+
+def get_data_from_subgraph(url: str, query: str):
+    request = requests.post(url, json={"query": query})
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise Exception(
+            "Subgraph query failed. return code is {}.      {}".format(
+                request.status_code, query
+            )
+        )

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_staking.py
@@ -373,7 +373,7 @@ class StakingTestCase(unittest.TestCase):
             mock_function.assert_called_once_with(
                 "subgraph_url",
                 """
-rewardAddedEvents(where:{staker:"slasher1"}) {
+rewardAddedEvents(where:{slasher:"slasher1"}) {
     escrow
     amount
 }""",


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Add subgraph calls to get rewards information for python staking module.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Added a new utility function `get_data_from_subgraph`.
- Implemented `get_rewards_info` function, to get `rewardAddedEvents` data from the subgraph.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #448

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
