### PR TITLE
remove sender in storeResults

### DIFF
--- a/packages/core/contracts/Escrow.sol
+++ b/packages/core/contracts/Escrow.sol
@@ -21,7 +21,7 @@ contract Escrow is IEscrow, ReentrancyGuard {
     uint32 private constant BULK_MAX_COUNT = 100;
 
     event TrustedHandlerAdded(address _handler);
-    event IntermediateStorage(address _sender, string _url, string _hash);
+    event IntermediateStorage(string _url, string _hash);
     event Pending(string manifest, string hash);
     event BulkTransfer(
         uint256 indexed _txId,
@@ -169,7 +169,6 @@ contract Escrow is IEscrow, ReentrancyGuard {
     }
 
     function storeResults(
-        address _sender,
         string memory _url,
         string memory _hash
     ) external override trusted notExpired {
@@ -179,7 +178,7 @@ contract Escrow is IEscrow, ReentrancyGuard {
             'Escrow not in Pending or Partial status state'
         );
         _storeResult(_url, _hash);
-        emit IntermediateStorage(_sender, _url, _hash);
+        emit IntermediateStorage(_url, _hash);
     }
 
     /**

--- a/packages/core/contracts/interfaces/IEscrow.sol
+++ b/packages/core/contracts/interfaces/IEscrow.sol
@@ -31,11 +31,7 @@ interface IEscrow {
 
     function complete() external;
 
-    function storeResults(
-        address _worker,
-        string memory _url,
-        string memory _hash
-    ) external;
+    function storeResults(string memory _url, string memory _hash) external;
 
     function bulkPayOut(
         address[] memory _recipients,

--- a/packages/core/test/Escrow.ts
+++ b/packages/core/test/Escrow.ts
@@ -174,11 +174,7 @@ describe('Escrow', function () {
         const result = await (
           await escrow
             .connect(reputationOracle)
-            .storeResults(
-              await externalAddress.getAddress(),
-              MOCK_URL,
-              MOCK_HASH
-            )
+            .storeResults(MOCK_URL, MOCK_HASH)
         ).wait();
 
         expect(result.events?.[0].event).to.equal(
@@ -198,13 +194,7 @@ describe('Escrow', function () {
       });
       it('Should revert with the right error if address calling not trusted', async function () {
         await expect(
-          escrow
-            .connect(externalAddress)
-            .storeResults(
-              await externalAddress.getAddress(),
-              MOCK_URL,
-              MOCK_HASH
-            )
+          escrow.connect(externalAddress).storeResults(MOCK_URL, MOCK_HASH)
         ).to.be.revertedWith('Address calling not trusted');
       });
 
@@ -213,13 +203,7 @@ describe('Escrow', function () {
           .connect(owner)
           .addTrustedHandlers([await reputationOracle.getAddress()]);
         await expect(
-          escrow
-            .connect(reputationOracle)
-            .storeResults(
-              await externalAddress.getAddress(),
-              MOCK_URL,
-              MOCK_HASH
-            )
+          escrow.connect(reputationOracle).storeResults(MOCK_URL, MOCK_HASH)
         ).to.be.revertedWith('Escrow not in Pending or Partial status state');
       });
     });
@@ -233,16 +217,10 @@ describe('Escrow', function () {
 
       it('Should emit an event on intermediate storage', async function () {
         await expect(
-          await escrow
-            .connect(owner)
-            .storeResults(
-              await externalAddress.getAddress(),
-              MOCK_URL,
-              MOCK_HASH
-            )
+          await escrow.connect(owner).storeResults(MOCK_URL, MOCK_HASH)
         )
           .to.emit(escrow, 'IntermediateStorage')
-          .withArgs(await externalAddress.getAddress(), MOCK_URL, MOCK_HASH);
+          .withArgs(MOCK_URL, MOCK_HASH);
       });
     });
 
@@ -257,11 +235,7 @@ describe('Escrow', function () {
         const result = await (
           await escrow
             .connect(reputationOracle)
-            .storeResults(
-              await externalAddress.getAddress(),
-              MOCK_URL,
-              MOCK_HASH
-            )
+            .storeResults(MOCK_URL, MOCK_HASH)
         ).wait();
 
         expect(result.events?.[0].event).to.equal(

--- a/packages/examples/fortune/recording-oracle/src/plugins/escrow.ts
+++ b/packages/examples/fortune/recording-oracle/src/plugins/escrow.ts
@@ -34,12 +34,12 @@ export class Escrow {
   ) {
     const Escrow = new web3.eth.Contract(EscrowAbi as [], escrowAddress);
     const gasNeeded = await Escrow.methods
-      .storeResults(workerAddress, resultsUrl, resultHash)
+      .storeResults(resultsUrl, resultHash)
       .estimateGas({ from: web3.eth.defaultAccount });
     const gasPrice = await web3.eth.getGasPrice();
 
     const result = await Escrow.methods
-      .storeResults(workerAddress, resultsUrl, resultHash)
+      .storeResults(resultsUrl, resultHash)
       .send({ from: web3.eth.defaultAccount, gas: gasNeeded, gasPrice });
 
     return result;

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/job.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/job.py
@@ -969,7 +969,7 @@ class Job:
         self.intermediate_manifest_hash = hash_
         self.intermediate_manifest_url = url
 
-        func_args = [sender, url, hash_]
+        func_args = [url, hash_]
 
         try:
             handle_transaction_with_retry(txn_func, self.retry, *func_args, **txn_info)

--- a/packages/sdk/typescript/human-protocol-sdk/src/job.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/job.ts
@@ -642,7 +642,6 @@ export class Job {
     const resultStored = await this._raffleExecute(
       this.contractData.escrow,
       'storeResults',
-      sender,
       key,
       hash
     );

--- a/packages/sdk/typescript/subgraph/src/mapping/Escrow.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/Escrow.ts
@@ -61,7 +61,7 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
 
   // Entity fields can be set based on event parameters
   entity.timestamp = event.block.timestamp;
-  entity.sender = event.params._sender;
+  entity.sender = event.transaction.from;
   entity._url = event.params._url;
   entity._hash = event.params._hash;
 
@@ -80,7 +80,7 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
   statsEntity.save();
   entity.save();
 
-  const worker = createOrLoadWorker(event.params._sender);
+  const worker = createOrLoadWorker(event.transaction.from);
   worker.amountJobsSolved = worker.amountJobsSolved.plus(BigInt.fromI32(1));
   worker.save();
 

--- a/packages/sdk/typescript/subgraph/template.yaml
+++ b/packages/sdk/typescript/subgraph/template.yaml
@@ -152,7 +152,7 @@ templates:
         - name: Escrow
           file: '{{{ Escrow.abi }}}'
       eventHandlers:
-        - event: IntermediateStorage(address,string,string)
+        - event: IntermediateStorage(string,string)
           handler: handleIntermediateStorage
         - event: Pending(string,string)
           handler: handlePending

--- a/packages/sdk/typescript/subgraph/tests/escrow/escrow.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/escrow/escrow.test.ts
@@ -65,7 +65,7 @@ describe('Escrow', () => {
       'timestamp',
       newIS.block.timestamp.toString()
     );
-    assert.fieldEquals('ISEvent', id, 'sender', newIS.params._sender.toHex());
+    assert.fieldEquals('ISEvent', id, 'sender', newIS.transaction.from.toHex());
     assert.fieldEquals('ISEvent', id, '_url', newIS.params._url.toString());
     assert.fieldEquals('ISEvent', id, '_hash', newIS.params._hash.toString());
   });

--- a/packages/sdk/typescript/subgraph/tests/escrow/fixtures.ts
+++ b/packages/sdk/typescript/subgraph/tests/escrow/fixtures.ts
@@ -16,10 +16,7 @@ export function createISEvent(
     newMockEvent()
   );
   newIntermediateStorageEvent.parameters = [];
-  const senderParam = new ethereum.EventParam(
-    '_sender',
-    ethereum.Value.fromAddress(sender)
-  );
+  newIntermediateStorageEvent.transaction.from = sender;
   const urlParam = new ethereum.EventParam(
     '_url',
     ethereum.Value.fromString(url)
@@ -29,7 +26,6 @@ export function createISEvent(
     ethereum.Value.fromString(hash)
   );
 
-  newIntermediateStorageEvent.parameters.push(senderParam);
   newIntermediateStorageEvent.parameters.push(urlParam);
   newIntermediateStorageEvent.parameters.push(hashParam);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Remove `sender` in `storeResults` function of `Escrow` contract, because it's unnecessary.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Removed `sender` param in `storeResults` function.
- Updated fortune, and SDKs accordingly for the function change.
- Updated subgraph to handle `IntermediateStorage` event properly.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #453 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
