### PR TITLE
fix: remove onlyStaker modifier and validation for allocation close

### DIFF
--- a/packages/core/test/Staking.ts
+++ b/packages/core/test/Staking.ts
@@ -895,6 +895,12 @@ describe('Staking', function () {
         ).to.be.revertedWith('Must be a valid address');
       });
 
+      it('Should revert with the right error if the caller is not the allocator', async function () {
+        await expect(
+          staking.connect(validator).closeAllocation(escrowAddress.toString())
+        ).to.be.revertedWith('Only the allocator can close the allocation');
+      });
+
       it('Should revert with the right error if escrow is not completed nor cancelled', async function () {
         await expect(
           staking.connect(operator).closeAllocation(escrowAddress.toString())


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Couple fixes in Staking contract.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Removed `onlyStaker` modifier, since it's unnecessary.
- Fixed validation of the `closeAllocation`, so that only the allocator can close the allocation.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #464 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
