### PR TITLE
[Subgraph] Amend LaunchedEscrow entity

### DIFF
--- a/packages/sdk/typescript/subgraph/schema.graphql
+++ b/packages/sdk/typescript/subgraph/schema.graphql
@@ -7,6 +7,7 @@ type LaunchedEscrow @entity {
   amountAllocated: BigInt
   amountPayout: BigInt
   status: String # string
+  manifestUrl: String # string
 }
 
 type ISEvent @entity {

--- a/packages/sdk/typescript/subgraph/src/mapping/Escrow.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/Escrow.ts
@@ -124,6 +124,7 @@ export function handlePending(event: Pending): void {
   // Update escrow entity
   const escrowEntity = LaunchedEscrow.load(dataSource.address().toHex());
   if (escrowEntity) {
+    escrowEntity.manifestUrl = event.params.manifest;
     escrowEntity.status = 'Pending';
     escrowEntity.save();
   }

--- a/packages/sdk/typescript/subgraph/tests/escrow/escrow.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/escrow/escrow.test.ts
@@ -105,6 +105,12 @@ describe('Escrow', () => {
       'status',
       'Pending'
     );
+    assert.fieldEquals(
+      'LaunchedEscrow',
+      escrowAddress.toHex(),
+      'manifestUrl',
+      newPending1.params.manifest.toString()
+    );
   });
 
   test('Should properly handle BulkTransfer events', () => {


### PR DESCRIPTION
## Description

At the moment, there's no way to get manifest urls from the LaunchedEscrow entites.

## Summary of changes

Added the manifestUrl property to LaunchedEscrow entity and set value in the PendingEvent handler.

## Related issues
This will close #525 