### PR TITLE
fix: sdk storage module to return url after upload

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
@@ -198,8 +198,8 @@ class StorageClient:
                 raise e
 
             data = artifact.encode("utf-8")
-            hash = hashlib.sha1(data).hexdigest()
-            key = hash
+            data_sha = hashlib.sha1(data).hexdigest()
+            key = f"s3{data_sha}.json"
             url = (
                 f"{'https' if self.secure else 'http'}://{self.endpoint}/{bucket}/{key}"
             )
@@ -233,7 +233,7 @@ class StorageClient:
                 except Exception as e:
                     raise StorageClientError(str(e))
 
-            result_files.append({"key": key, "url": url, "hash": hash})
+            result_files.append({"key": key, "url": url, "hash": data_sha})
 
         return result_files
 

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
@@ -115,6 +115,8 @@ class StorageClient:
                     secure=secure,
                 )  # authenticated access
             )
+            self.endpoint = endpoint_url
+            self.secure = secure
         except Exception as e:
             LOG.error(f"Connection with S3 failed because of: {e}")
             raise e
@@ -196,8 +198,11 @@ class StorageClient:
                 raise e
 
             data = artifact.encode("utf-8")
-            data_sha = hashlib.sha1(data).hexdigest()
-            key = f"s3{data_sha}.json"
+            hash = hashlib.sha1(data).hexdigest()
+            key = hash
+            url = (
+                f"{'https' if self.secure else 'http'}://{self.endpoint}/{bucket}/{key}"
+            )
             file_exist = None
 
             try:
@@ -205,7 +210,6 @@ class StorageClient:
                 file_exist = self.client.stat_object(
                     bucket_name=bucket, object_name=key
                 )
-                result_files.append(key)
             except Exception as e:
                 if e.code == "NoSuchKey":
                     # file does not exist in bucket, so upload it
@@ -225,10 +229,11 @@ class StorageClient:
                         data=io.BytesIO(data),
                         length=len(data),
                     )
-                    result_files.append(key)
                     LOG.debug(f"Uploaded to S3, key: {key}")
                 except Exception as e:
                     raise StorageClientError(str(e))
+
+            result_files.append({"key": key, "url": url, "hash": hash})
 
         return result_files
 

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
@@ -198,8 +198,8 @@ class StorageClient:
                 raise e
 
             data = artifact.encode("utf-8")
-            data_sha = hashlib.sha1(data).hexdigest()
-            key = f"s3{data_sha}.json"
+            hash = hashlib.sha1(data).hexdigest()
+            key = f"s3{hash}.json"
             url = (
                 f"{'https' if self.secure else 'http'}://{self.endpoint}/{bucket}/{key}"
             )
@@ -233,7 +233,7 @@ class StorageClient:
                 except Exception as e:
                     raise StorageClientError(str(e))
 
-            result_files.append({"key": key, "url": url, "hash": data_sha})
+            result_files.append({"key": key, "url": url, "hash": hash})
 
         return result_files
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_storage.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_storage.py
@@ -155,8 +155,8 @@ class TestStorageClient(unittest.TestCase):
 
     def test_upload_files(self):
         file3 = "file3 content"
-        data_sha = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
-        key3 = f"s3{data_sha}.json"
+        hash = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
+        key3 = hash
 
         self.client.client.stat_object = MagicMock(
             side_effect=S3Error(
@@ -170,19 +170,27 @@ class TestStorageClient(unittest.TestCase):
         )
         self.client.client.put_object = MagicMock()
         result = self.client.upload_files(files=[file3], bucket=self.bucket)
-        self.assertEqual(result, [key3])
+        self.assertEqual(result[0]["key"], key3)
+        self.assertEqual(
+            result[0]["url"], f"https://s3.us-west-2.amazonaws.com/my-bucket/{key3}"
+        )
+        self.assertEqual(result[0]["hash"], hash)
 
     def test_upload_files_exist(self):
         file3 = "file3 content"
-        data_sha = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
-        key3 = f"s3{data_sha}.json"
+        hash = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
+        key3 = hash
 
         self.client.client.stat_object = MagicMock(
             side_effect=[{"_object_name": "1234567890"}]
         )
         self.client.client.put_object = MagicMock()
         result = self.client.upload_files(files=[file3], bucket=self.bucket)
-        self.assertEqual(result, [key3])
+        self.assertEqual(result[0]["key"], key3)
+        self.assertEqual(
+            result[0]["url"], f"https://s3.us-west-2.amazonaws.com/my-bucket/{key3}"
+        )
+        self.assertEqual(result[0]["hash"], hash)
 
     def test_upload_files_error(self):
         file3 = "file3 content"

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_storage.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_storage.py
@@ -155,8 +155,8 @@ class TestStorageClient(unittest.TestCase):
 
     def test_upload_files(self):
         file3 = "file3 content"
-        data_sha = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
-        key3 = f"s3{data_sha}.json"
+        hash = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
+        key3 = f"s3{hash}.json"
 
         self.client.client.stat_object = MagicMock(
             side_effect=S3Error(
@@ -174,12 +174,12 @@ class TestStorageClient(unittest.TestCase):
         self.assertEqual(
             result[0]["url"], f"https://s3.us-west-2.amazonaws.com/my-bucket/{key3}"
         )
-        self.assertEqual(result[0]["hash"], data_sha)
+        self.assertEqual(result[0]["hash"], hash)
 
     def test_upload_files_exist(self):
         file3 = "file3 content"
-        data_sha = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
-        key3 = f"s3{data_sha}.json"
+        hash = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
+        key3 = f"s3{hash}.json"
 
         self.client.client.stat_object = MagicMock(
             side_effect=[{"_object_name": "1234567890"}]
@@ -190,7 +190,7 @@ class TestStorageClient(unittest.TestCase):
         self.assertEqual(
             result[0]["url"], f"https://s3.us-west-2.amazonaws.com/my-bucket/{key3}"
         )
-        self.assertEqual(result[0]["hash"], data_sha)
+        self.assertEqual(result[0]["hash"], hash)
 
     def test_upload_files_error(self):
         file3 = "file3 content"

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_storage.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_storage.py
@@ -155,8 +155,8 @@ class TestStorageClient(unittest.TestCase):
 
     def test_upload_files(self):
         file3 = "file3 content"
-        hash = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
-        key3 = hash
+        data_sha = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
+        key3 = f"s3{data_sha}.json"
 
         self.client.client.stat_object = MagicMock(
             side_effect=S3Error(
@@ -174,12 +174,12 @@ class TestStorageClient(unittest.TestCase):
         self.assertEqual(
             result[0]["url"], f"https://s3.us-west-2.amazonaws.com/my-bucket/{key3}"
         )
-        self.assertEqual(result[0]["hash"], hash)
+        self.assertEqual(result[0]["hash"], data_sha)
 
     def test_upload_files_exist(self):
         file3 = "file3 content"
-        hash = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
-        key3 = hash
+        data_sha = hashlib.sha1(json.dumps("file3 content").encode("utf-8")).hexdigest()
+        key3 = f"s3{data_sha}.json"
 
         self.client.client.stat_object = MagicMock(
             side_effect=[{"_object_name": "1234567890"}]
@@ -190,7 +190,7 @@ class TestStorageClient(unittest.TestCase):
         self.assertEqual(
             result[0]["url"], f"https://s3.us-west-2.amazonaws.com/my-bucket/{key3}"
         )
-        self.assertEqual(result[0]["hash"], hash)
+        self.assertEqual(result[0]["hash"], data_sha)
 
     def test_upload_files_error(self):
         file3 = "file3 content"

--- a/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
@@ -15,6 +15,7 @@ import { HttpStatus } from './constants';
 
 export default class StorageClient {
   private client: Minio.Client;
+  private clientParams: StorageParams;
 
   /**
    * **Storage client constructor**
@@ -24,6 +25,8 @@ export default class StorageClient {
    */
   constructor(credentials: StorageCredentials, params: StorageParams) {
     try {
+      this.clientParams = params;
+
       this.client = new Minio.Client({
         ...params,
         accessKey: credentials.accessKey,
@@ -116,7 +119,15 @@ export default class StorageClient {
             'Content-Type': 'application/json',
           });
 
-          return { key, hash };
+          return {
+            key,
+            url: `${this.clientParams.useSSL ? 'https' : 'http'}://${
+              this.clientParams.endPoint
+            }${
+              this.clientParams.port ? `:${this.clientParams.port}` : ''
+            }/${bucket}/${key}`,
+            hash,
+          };
         } catch (e) {
           throw ErrorStorageFileNotUploaded;
         }

--- a/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
@@ -112,7 +112,7 @@ export default class StorageClient {
         const content = JSON.stringify(file);
 
         const hash = crypto.createHash('sha1').update(content).digest('hex');
-        const key = hash;
+        const key = `s3${hash}.json`;
 
         try {
           await this.client.putObject(bucket, key, content, {

--- a/packages/sdk/typescript/human-protocol-sdk/src/types.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/types.ts
@@ -74,6 +74,10 @@ export type UploadFile = {
    */
   key: string;
   /**
+   * Uploaded object URL
+   */
+  url: string;
+  /**
    * Hash of uploaded object key
    */
   hash: string;

--- a/packages/sdk/typescript/human-protocol-sdk/test/storage.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/storage.test.ts
@@ -105,7 +105,7 @@ describe('Storage tests', () => {
         const StorageClient = vi.fn().mockImplementation(() => {
           throw ErrorStorageClientNotInitialized;
         });
-      
+
         return {
           default: StorageClient
         }
@@ -165,6 +165,9 @@ describe('Storage tests', () => {
         }
       );
       expect(uploadedResults[0].key).toEqual(key);
+      expect(uploadedResults[0].url).toEqual(
+        `http://${DEFAULT_ENDPOINT}:${DEFAULT_PORT}/${DEFAULT_PUBLIC_BUCKET}/${key}`
+      );
       expect(uploadedResults[0].hash).toEqual(hash);
     });
 
@@ -338,6 +341,9 @@ describe('Storage tests', () => {
         }
       );
       expect(uploadedResults[0].key).toEqual(key);
+      expect(uploadedResults[0].url).toEqual(
+        `http://${DEFAULT_ENDPOINT}:${DEFAULT_PORT}/${DEFAULT_PUBLIC_BUCKET}/${key}`
+      );
       expect(uploadedResults[0].hash).toEqual(hash);
     });
 

--- a/packages/sdk/typescript/human-protocol-sdk/test/storage.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/storage.test.ts
@@ -154,7 +154,7 @@ describe('Storage tests', () => {
         .createHash('sha1')
         .update(JSON.stringify(file))
         .digest('hex');
-      const key = hash;
+      const key = `s3${hash}.json`;
 
       expect(storageClient['client'].putObject).toHaveBeenCalledWith(
         DEFAULT_PUBLIC_BUCKET,
@@ -188,7 +188,7 @@ describe('Storage tests', () => {
         .createHash('sha1')
         .update(JSON.stringify(file))
         .digest('hex');
-      const key = hash;
+      const key = `s3${hash}.json`;
 
       const downloadedResults = await storageClient.downloadFiles(
         [key],
@@ -261,14 +261,14 @@ describe('Storage tests', () => {
         .createHash('sha1')
         .update(JSON.stringify(file1))
         .digest('hex');
-      const key1 = hash1;
+      const key1 = `s3${hash1}.json`;
 
       const file2 = { key: STORAGE_TEST_FILE_VALUE_2 };
       const hash2 = crypto
         .createHash('sha1')
         .update(JSON.stringify(file2))
         .digest('hex');
-      const key2 = hash2;
+      const key2 = `s3${hash2}.json`;
 
       vi.spyOn(storageClient, 'listObjects').mockImplementation(() =>
         Promise.resolve([key1, key2])
@@ -330,7 +330,7 @@ describe('Storage tests', () => {
         .createHash('sha1')
         .update(JSON.stringify(file))
         .digest('hex');
-      const key = hash;
+      const key = `s3${hash}.json`;
 
       expect(storageClient['client'].putObject).toHaveBeenCalledWith(
         DEFAULT_PUBLIC_BUCKET,
@@ -364,7 +364,7 @@ describe('Storage tests', () => {
         .createHash('sha1')
         .update(JSON.stringify(file))
         .digest('hex');
-      const key = hash;
+      const key = `s3${hash}.json`;
 
       const downloadedResults = await storageClient.downloadFiles(
         [key],
@@ -397,14 +397,14 @@ describe('Storage tests', () => {
         .createHash('sha1')
         .update(JSON.stringify(file1))
         .digest('hex');
-      const key1 = hash1;
+      const key1 = `s3${hash1}.json`;
 
       const file2 = { key: STORAGE_TEST_FILE_VALUE_2 };
       const hash2 = crypto
         .createHash('sha1')
         .update(JSON.stringify(file2))
         .digest('hex');
-      const key2 = hash2;
+      const key2 = `s3${hash2}.json`;
 
       vi.spyOn(storageClient, 'listObjects').mockImplementation(() =>
         Promise.resolve([key1, key2])


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Fix SDK storage module

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Modified `upload_files` function to return `url` as part of upload result.
- Fixed file `key` on python sdk storage module to match ts sdk.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
closes #540  

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
