### PR TITLE
fix python basemodels dependency and sdk

### DIFF
--- a/packages/sdk/python/human-protocol-basemodels/Makefile
+++ b/packages/sdk/python/human-protocol-basemodels/Makefile
@@ -1,3 +1,6 @@
+setup:
+	pipenv install --dev
+
 clean-package:
 	rm -rf build dist *.egg-info
 

--- a/packages/sdk/python/human-protocol-basemodels/Pipfile
+++ b/packages/sdk/python/human-protocol-basemodels/Pipfile
@@ -4,13 +4,14 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+black = "*"
+pytest = "*"
+pylint = "*"
+setuptools-pipfile = "*"
 
 [packages]
 requests = "*"
 pydantic = "==1.10.4"
-pytest = "*"
-black = "*"
-pylint = "*"
 httpretty = "*"
 
 [requires]

--- a/packages/sdk/python/human-protocol-basemodels/setup.py
+++ b/packages/sdk/python/human-protocol-basemodels/setup.py
@@ -13,5 +13,6 @@ setuptools.setup(
         "Programming Language :: Python",
     ],
     packages=setuptools.find_packages(),
-    install_requires=["requests>=2", "typing-extensions", "pydantic>=1.6"],
+    setup_requires="setuptools-pipfile",
+    use_pipfile=True,
 )

--- a/packages/sdk/python/human-protocol-sdk/Makefile
+++ b/packages/sdk/python/human-protocol-sdk/Makefile
@@ -1,3 +1,6 @@
+setup:
+	pipenv install --dev
+
 clean-package:
 	rm -rf build artifacts dist *.egg-info .eggs
 

--- a/packages/sdk/python/human-protocol-sdk/Pipfile
+++ b/packages/sdk/python/human-protocol-sdk/Pipfile
@@ -11,7 +11,7 @@ setuptools-pipfile = "*"
 
 [packages]
 cryptography = "*"
-hmt-basemodels = "==0.1.18"
+human-protocol-basemodels = {editable = true, path = "./../human-protocol-basemodels"}
 minio = "*"
 validators = "*"
 web3 = "==5.24.0"

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/utils/manifest.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/utils/manifest.py
@@ -51,8 +51,8 @@ def test_manifest(
     if request_config:
         model.update({"request_config": request_config})
 
-    manifest = basemodels.Manifest(model)
-    manifest.validate()
+    manifest = basemodels.Manifest.construct(**model)
+    manifest.check()
 
     return manifest
 


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Python SDK fix

## Summary of changes
- Remove `hmt-basemodels` dependency, and use `human-protocol-basemodels`
- Fix dependency install of `human-protocol-basemodels` package.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #551 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
