### PR TITLE
Escrow dashboard fix token view

### DIFF
--- a/packages/apps/escrow-dashboard/src/components/Token/TokenView.tsx
+++ b/packages/apps/escrow-dashboard/src/components/Token/TokenView.tsx
@@ -1,39 +1,39 @@
-import { Grid } from '@mui/material';
+import { Box, CircularProgress, Grid } from '@mui/material';
 import { FC } from 'react';
 
 import { CardTextBlock } from '../Cards';
 
-import { useTokenStatsByChainId } from 'src/state/token/hooks';
+import {
+  useTokenStatsByChainId,
+  useTokenStatsLoaded,
+} from 'src/state/token/hooks';
 
 export const TokenView: FC = () => {
   const { totalTransferEventCount, holders, totalSupply } =
     useTokenStatsByChainId();
+  const loaded = useTokenStatsLoaded();
 
   return (
-    <Grid container spacing={{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }}>
-      <Grid item xs={12} sm={6}>
-        <CardTextBlock
-          title="Amount of transfers"
-          value={totalTransferEventCount}
-        />
-      </Grid>
-      <Grid item xs={12} sm={6}>
-        <CardTextBlock title="Holders" value={holders} />
-      </Grid>
-      <Grid item xs={12}>
-        <CardTextBlock
-          title="Total Supply"
-          value={Number(totalSupply)}
-          format={
-            Number(totalSupply) >= Number('1e+18')
-              ? '0,0e+0'
-              : Number(totalSupply) >= Number('1e+9')
-              ? '0a'
-              : '0,0'
-          }
-        />
-      </Grid>
-      {/* <Grid item xs={12} sm={6}>
+    <Box>
+      {loaded ? (
+        <Grid container spacing={{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }}>
+          <Grid item xs={12} sm={6}>
+            <CardTextBlock
+              title="Amount of transfers"
+              value={totalTransferEventCount}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <CardTextBlock title="Holders" value={holders} />
+          </Grid>
+          <Grid item xs={12}>
+            <CardTextBlock
+              title="Total Supply"
+              value={Number(totalSupply)}
+              format={'0,0'}
+            />
+          </Grid>
+          {/* <Grid item xs={12} sm={6}>
         <CardTextBlock
           title={
             <Typography
@@ -50,6 +50,12 @@ export const TokenView: FC = () => {
           format={'$0,0.00'}
         />
       </Grid> */}
-    </Grid>
+        </Grid>
+      ) : (
+        <Box display="flex" justifyContent="center" py={10}>
+          <CircularProgress size={36} />
+        </Box>
+      )}
+    </Box>
   );
 };

--- a/packages/apps/escrow-dashboard/src/constants/index.ts
+++ b/packages/apps/escrow-dashboard/src/constants/index.ts
@@ -53,6 +53,14 @@ export const SUPPORTED_CHAIN_IDS = [
   ChainId.AVALANCHE,
 ];
 
+export const L1_L2_CHAIN_IDS = [
+  ChainId.BSC_MAINNET,
+  ChainId.POLYGON,
+  ChainId.SKALE,
+  ChainId.MOONBEAM,
+  ChainId.AVALANCHE,
+];
+
 export const TESTNET_CHAIN_IDS = [
   ChainId.RINKEBY,
   ChainId.GOERLI,

--- a/packages/apps/escrow-dashboard/src/state/token/hooks.ts
+++ b/packages/apps/escrow-dashboard/src/state/token/hooks.ts
@@ -5,7 +5,7 @@ import { AppState, useAppDispatch } from '..';
 import { useChainId } from '../escrow/hooks';
 import { fetchTokenStatsAsync } from './reducer';
 
-import { ChainId, SUPPORTED_CHAIN_IDS } from 'src/constants';
+import { ChainId, L1_L2_CHAIN_IDS, TESTNET_CHAIN_IDS } from 'src/constants';
 import { useSlowRefreshEffect } from 'src/hooks/useRefreshEffect';
 
 export const usePollTokenStats = () => {
@@ -21,27 +21,44 @@ export const useTokenStatsByChainId = () => {
   const token = useSelector((state: AppState) => state.token);
   const { stats } = token;
 
-  if (currentChainId === ChainId.ALL) {
+  let mainnetTotalSupply = new BigNumberJS(
+    token.stats[ChainId.MAINNET]?.totalSupply ?? '0'
+  );
+  let bridgedTotalSupply = new BigNumberJS(0);
+  L1_L2_CHAIN_IDS.forEach((chainId) => {
+    if (stats[chainId]) {
+      bridgedTotalSupply = bridgedTotalSupply.plus(
+        new BigNumberJS(token.stats[chainId]?.totalSupply ?? '0')
+      );
+    }
+  });
+
+  if (
+    currentChainId === ChainId.ALL ||
+    TESTNET_CHAIN_IDS.includes(currentChainId)
+  ) {
     const tokenStats = {
       totalTransferEventCount: 0,
       holders: 0,
-      totalSupply: new BigNumberJS(0),
     };
 
-    SUPPORTED_CHAIN_IDS.forEach((chainId) => {
+    L1_L2_CHAIN_IDS.forEach((chainId) => {
       if (stats[chainId]) {
         tokenStats.totalTransferEventCount +=
           stats[chainId]?.totalTransferEventCount!;
         tokenStats.holders += stats[chainId]?.holders!;
-        tokenStats.totalSupply = tokenStats.totalSupply.plus(
-          new BigNumberJS(token.stats[chainId]?.totalSupply ?? '0')
-        );
       }
     });
 
     return {
       ...tokenStats,
-      totalSupply: tokenStats.totalSupply.toJSON(),
+      totalSupply: mainnetTotalSupply.toJSON(),
+    };
+  }
+  if (currentChainId === ChainId.MAINNET) {
+    return {
+      ...stats[currentChainId],
+      totalSupply: mainnetTotalSupply.minus(bridgedTotalSupply).toJSON(),
     };
   }
 

--- a/packages/apps/escrow-dashboard/src/state/token/reducer.ts
+++ b/packages/apps/escrow-dashboard/src/state/token/reducer.ts
@@ -72,7 +72,14 @@ export const fetchTokenStatsAsync = createAsyncThunk<
             holders: Number(holders),
             totalSupply: '0',
           };
-        });
+        })
+        .catch((err) => ({
+          totalApprovalEventCount: 0,
+          totalTransferEventCount: 0,
+          totalValueTransfered: 0,
+          holders: 0,
+          totalSupply: '0',
+        }));
 
       const rpcUrl = ESCROW_NETWORKS[chainId]?.rpcUrl!;
       const hmtAddress = ESCROW_NETWORKS[chainId]?.hmtAddress!;


### PR DESCRIPTION
## Description

Update token section on the escrow-dashboard

## Summary of changes

-  Displayed aggregated data for mainnet chains when `All Networks` and testnet chains are selected.
-  Displayed `1B - Sum of other mainnets' total supply` for Total Supply when `Ethereum` is selected.
