### PR TITLE
fix: [Core] update escrow function permissions

### DIFF
--- a/packages/core/contracts/Escrow.sol
+++ b/packages/core/contracts/Escrow.sol
@@ -47,6 +47,9 @@ contract Escrow is IEscrow, ReentrancyGuard {
     string public manifestUrl;
     string public manifestHash;
 
+    string public intermediateResultsUrl;
+    string public intermediateResultsHash;
+
     string public finalResultsUrl;
     string public finalResultsHash;
 
@@ -171,7 +174,12 @@ contract Escrow is IEscrow, ReentrancyGuard {
                 status == EscrowStatuses.Partial,
             'Escrow not in Pending or Partial status state'
         );
-        _storeResult(_url, _hash);
+        require(bytes(_url).length != 0, "URL can't be empty");
+        require(bytes(_hash).length != 0, "Hash can't be empty");
+
+        intermediateResultsUrl = _url;
+        intermediateResultsHash = _hash;
+
         emit IntermediateStorage(_url, _hash);
     }
 
@@ -229,7 +237,11 @@ contract Escrow is IEscrow, ReentrancyGuard {
         require(aggregatedBulkAmount < BULK_MAX_VALUE, 'Bulk value too high');
         require(aggregatedBulkAmount <= balance, 'Not enough balance');
 
-        _storeResult(_url, _hash);
+        require(bytes(_url).length != 0, "URL can't be empty");
+        require(bytes(_hash).length != 0, "Hash can't be empty");
+
+        finalResultsUrl = _url;
+        finalResultsHash = _hash;
 
         (
             uint256[] memory finalAmounts,
@@ -293,15 +305,6 @@ contract Escrow is IEscrow, ReentrancyGuard {
 
     function _safeTransfer(address to, uint256 value) internal {
         SafeERC20.safeTransfer(IERC20(token), to, value);
-    }
-
-    function _storeResult(string memory _url, string memory _hash) internal {
-        bool writeOnchain = bytes(_hash).length != 0 || bytes(_url).length != 0;
-        if (writeOnchain) {
-            // Be sure both of them are not zero
-            finalResultsUrl = _url;
-            finalResultsHash = _hash;
-        }
     }
 
     modifier trusted() {

--- a/packages/core/contracts/Escrow.sol
+++ b/packages/core/contracts/Escrow.sol
@@ -48,7 +48,6 @@ contract Escrow is IEscrow, ReentrancyGuard {
     string public manifestHash;
 
     string public intermediateResultsUrl;
-    string public intermediateResultsHash;
 
     string public finalResultsUrl;
     string public finalResultsHash;
@@ -178,7 +177,6 @@ contract Escrow is IEscrow, ReentrancyGuard {
         require(bytes(_hash).length != 0, "Hash can't be empty");
 
         intermediateResultsUrl = _url;
-        intermediateResultsHash = _hash;
 
         emit IntermediateStorage(_url, _hash);
     }

--- a/packages/examples/fortune/reputation-oracle/src/services/escrow.test.ts
+++ b/packages/examples/fortune/reputation-oracle/src/services/escrow.test.ts
@@ -25,10 +25,10 @@ const owner = web3.eth.accounts.privateKeyToAccount(
 const launcher = web3.eth.accounts.privateKeyToAccount(
   '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
 );
-const recordingAccount = web3.eth.accounts.privateKeyToAccount(
-  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+const reputationAccount = web3.eth.accounts.privateKeyToAccount(
+  '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
 );
-web3.eth.defaultAccount = recordingAccount.address;
+web3.eth.defaultAccount = reputationAccount.address;
 
 describe('Fortune', () => {
   beforeAll(async () => {

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -529,6 +529,28 @@ class EscrowClient:
             self._get_escrow_contract(escrow_address).functions.finalResultsUrl().call()
         )
 
+    def get_intermediate_results_url(self, escrow_address: str):
+        """Gets the intermediate results file URL.
+
+        Args:
+            escrow_address (str): Address of the escrow
+
+        Returns:
+            str: Intermediate results file url
+
+        Raises:
+            EscrowClientError: If an error occurs while checking the parameters
+        """
+
+        if not Web3.isAddress(escrow_address):
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
+
+        return (
+            self._get_escrow_contract(escrow_address)
+            .functions.intermediateResultsUrl()
+            .call()
+        )
+
     def get_token_address(self, escrow_address: str):
         """Gets the address of the token used to fund the escrow.
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -1521,6 +1521,57 @@ class EscrowTestCase(unittest.TestCase):
             "Escrow address is not provided by the factory", str(cm.exception)
         )
 
+    def test_get_intermediate_results_url(self):
+        mock_contract = MagicMock()
+        mock_contract.functions.intermediateResultsUrl = MagicMock()
+        mock_contract.functions.intermediateResultsUrl.return_value.call.return_value = (
+            "mock_value"
+        )
+        self.escrow._get_escrow_contract = MagicMock(return_value=mock_contract)
+        escrow_address = "0x1234567890123456789012345678901234567890"
+
+        result = self.escrow.get_intermediate_results_url(escrow_address)
+
+        self.escrow._get_escrow_contract.assert_called_once_with(escrow_address)
+        mock_contract.functions.intermediateResultsUrl.assert_called_once_with()
+        self.assertEqual(result, "mock_value")
+
+    def test_get_intermediate_results_url_invalid_address(self):
+        with self.assertRaises(EscrowClientError) as cm:
+            self.escrow.get_intermediate_results_url("invalid_address")
+        self.assertEqual(f"Invalid escrow address: invalid_address", str(cm.exception))
+
+    def test_get_intermediate_results_url_without_account(self):
+        mock_provider = MagicMock(spec=HTTPProvider)
+        w3 = Web3(mock_provider)
+        mock_chain_id = ChainId.LOCALHOST.value
+        type(w3.eth).chain_id = PropertyMock(return_value=mock_chain_id)
+
+        escrowClient = EscrowClient(w3)
+        mock_contract = MagicMock()
+        mock_contract.functions.intermediateResultsUrl = MagicMock()
+        mock_contract.functions.intermediateResultsUrl.return_value.call.return_value = (
+            "mock_value"
+        )
+        escrowClient._get_escrow_contract = MagicMock(return_value=mock_contract)
+        escrow_address = "0x1234567890123456789012345678901234567890"
+
+        result = escrowClient.get_intermediate_results_url(escrow_address)
+
+        escrowClient._get_escrow_contract.assert_called_once_with(escrow_address)
+        mock_contract.functions.intermediateResultsUrl.assert_called_once_with()
+        self.assertEqual(result, "mock_value")
+
+    def test_get_intermediate_results_url_invalid_escrow(self):
+        self.escrow.factory_contract.functions.hasEscrow = MagicMock(return_value=False)
+        with self.assertRaises(EscrowClientError) as cm:
+            self.escrow.get_intermediate_results_url(
+                "0x1234567890123456789012345678901234567890"
+            )
+        self.assertEqual(
+            "Escrow address is not provided by the factory", str(cm.exception)
+        )
+
     def test_get_token_address(self):
         mock_contract = MagicMock()
         mock_contract.functions.token = MagicMock()

--- a/packages/sdk/typescript/human-protocol-sdk/package.json
+++ b/packages/sdk/typescript/human-protocol-sdk/package.json
@@ -10,6 +10,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./dist",
+    "prebuild": "yarn workspace @human-protocol/core build",
     "build": "npm run clean && tsc",
     "prepublish": "npm run build",
     "test": "vitest -u",

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -609,6 +609,33 @@ export default class EscrowClient {
   }
 
   /**
+   * Returns the intermediate results file URL.
+   *
+   * @param {string} escrowAddress - Address of the escrow.
+   * @returns {Promise<void>}
+   * @throws {Error} - An error object if an error occurred.
+   */
+  async getIntermediateResultsUrl(escrowAddress: string): Promise<string> {
+    if (!ethers.utils.isAddress(escrowAddress)) {
+      throw ErrorInvalidEscrowAddressProvided;
+    }
+
+    if (!(await this.escrowFactoryContract.hasEscrow(escrowAddress))) {
+      throw ErrorEscrowAddressIsNotProvidedByFactory;
+    }
+
+    try {
+      this.escrowContract = Escrow__factory.connect(
+        escrowAddress,
+        this.signerOrProvider
+      );
+      return this.escrowContract.intermediateResultsUrl();
+    } catch (e: any) {
+      return throwError(e);
+    }
+  }
+
+  /**
    * Returns the value for a specified key and address
    *
    * @param {string} escrowAddress - Address of the escrow.


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Escrow functions `bulkPayout`, `storeResult`, and `complete` needs more restricted permission.
And reputation/recording oracle should not be considered super user, in general.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Added two more modifiers. `trustedOrReputationOracle`, `trustedOrRecordingOracle`.
- Changed modifier of three functions `bulkPayout`, `storeResult`, and `complete` of escrow contract.
- Removed `recordingOracle`, and `reputationOracle` from trusted handlers list.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #558 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
