### PR TITLE
Bug/create webhook 500

### DIFF
--- a/packages/examples/fortune-v2/reputation-oracle/server/src/database/typeorm/typeorm-logger.service.ts
+++ b/packages/examples/fortune-v2/reputation-oracle/server/src/database/typeorm/typeorm-logger.service.ts
@@ -1,4 +1,4 @@
-import util from 'util';
+import * as util from 'util';
 import {
   Logger as TypeOrmLogger,
   LoggerOptions as TypeOrmLoggerOptions,

--- a/packages/examples/fortune-v2/reputation-oracle/server/src/modules/webhook/webhook-incoming.entity.ts
+++ b/packages/examples/fortune-v2/reputation-oracle/server/src/modules/webhook/webhook-incoming.entity.ts
@@ -10,16 +10,16 @@ export class WebhookIncomingEntity extends BaseEntity {
   @Column({ type: 'int' })
   public chainId: ChainId;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: true })
   public oracleAddress: string;
 
   @Column({ type: 'varchar' })
   public escrowAddress: string;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: true })
   public resultsUrl: string;
 
-  @Column({ type: 'boolean' })
+  @Column({ type: 'boolean', nullable: true })
   public checkPassed: boolean;
 
   @Column({ type: 'int' })


### PR DESCRIPTION
## Description
Fixed 500 error code when sending a request to `POST /webhook`. In console: TypeError: Cannot read properties of undefined (reading ‘inspect’). Problem was with wrong import of `util` library in `typeorm-logger.service.ts`.

## Summary of changes
- Fixed import `util` library in `typeorm-logger.service.ts`
- Added nullable flag for some DB properties

## How test the changes
`POST /webhook`

## Related issues
[Reputation Oracle - Fixed status code 500 when creating a webhook#618](https://github.com/humanprotocol/human-protocol/issues/618)