### PR TITLE
Added manifest validation, added additional dto classes, added unit tests

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -6,7 +6,6 @@ export enum ErrorJob {
   NotCreated = 'Job has not been created',
   NotEnoughFunds = 'Not enough funds',
   ManifestNotFound = 'Manifest not found',
-  ManifestDoesNotExist = 'Manifest does not exist',
   ManifestValidationFailed = 'Manifest validation failed',
   WebhookWasNotSent = 'Webhook was not sent',
 }

--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -6,6 +6,8 @@ export enum ErrorJob {
   NotCreated = 'Job has not been created',
   NotEnoughFunds = 'Not enough funds',
   ManifestNotFound = 'Manifest not found',
+  ManifestDoesNotExist = 'Manifest does not exist',
+  ManifestValidationFailed = 'Manifest validation failed',
   WebhookWasNotSent = 'Webhook was not sent',
 }
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -139,12 +139,84 @@ export class SendWebhookDto {
 export class ManifestDto {
   dataUrl?: string;
   labels?: string[];
+
+  @IsNumber()
+  @IsPositive()
   submissionsRequired: number;
+
   requesterTitle?: string;
+
+  @IsString()
   requesterDescription: string;
+
+  @IsNumber()
+  @IsPositive()
   requesterAccuracyTarget?: number;
+
+  @IsString()
   fee: string;
+
+  @IsString()
   fundAmount: string;
+
+  @IsEnum(JobRequestType)
   requestType: JobRequestType;
+
+  @IsEnum(JobMode)
+  mode: JobMode;
+}
+
+export class FortuneManifestDto {
+  @IsNumber()
+  @IsPositive()
+  submissionsRequired: number;
+  
+  @IsString()
+  requesterTitle: string;
+
+  @IsString()
+  requesterDescription: string;
+
+  @IsString()
+  fee: string;
+
+  @IsString()
+  fundAmount: string;
+
+  @IsEnum(JobRequestType)
+  requestType: JobRequestType;
+
+  @IsEnum(JobMode)
+  mode: JobMode;
+}
+
+export class ImageLabelBinaryManifestDto {
+  @IsString()
+  dataUrl: string;
+  
+  @IsArray()
+  labels: string[];
+
+  @IsNumber()
+  @IsPositive()
+  submissionsRequired: number;
+
+  @IsString()
+  requesterDescription: string;
+
+  @IsNumber()
+  @IsPositive()
+  requesterAccuracyTarget: number;
+
+  @IsString()
+  fee: string;
+
+  @IsString()
+  fundAmount: string;
+
+  @IsEnum(JobRequestType)
+  requestType: JobRequestType;
+
+  @IsEnum(JobMode)
   mode: JobMode;
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -136,36 +136,6 @@ export class SendWebhookDto {
   public chainId: number;
 }
 
-export class ManifestDto {
-  dataUrl?: string;
-  labels?: string[];
-
-  @IsNumber()
-  @IsPositive()
-  submissionsRequired: number;
-
-  requesterTitle?: string;
-
-  @IsString()
-  requesterDescription: string;
-
-  @IsNumber()
-  @IsPositive()
-  requesterAccuracyTarget?: number;
-
-  @IsString()
-  fee: string;
-
-  @IsString()
-  fundAmount: string;
-
-  @IsEnum(JobRequestType)
-  requestType: JobRequestType;
-
-  @IsEnum(JobMode)
-  mode: JobMode;
-}
-
 export class FortuneManifestDto {
   @IsNumber()
   @IsPositive()

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -33,7 +33,6 @@ import {
   ImageLabelBinaryManifestDto,
   JobCvatDto,
   JobFortuneDto,
-  ManifestDto,
   SaveManifestDto,
   SendWebhookDto,
 } from './job.dto';


### PR DESCRIPTION
## Description
Validate the manifest before launching the escrow.

## Summary of changes
- Added manifest validation
- Manifest DTO was divided for 2 types: FortuneManifestDto and ImageLabelBinaryManifestDto
- Added additional test cases
- Updated existing test cases

## How test the changes
`yarn test`

## Related issues
[Job Launcher - Validate manifest before creating escrow#600](https://github.com/humanprotocol/human-protocol/issues/600)
