### PR TITLE
[Fortune] [Recording Oracle] Change the way reading reputation oracle URL

### DIFF
--- a/packages/apps/fortune/recording-oracle/.env.sample
+++ b/packages/apps/fortune/recording-oracle/.env.sample
@@ -8,3 +8,6 @@ STORAGE_SECRET_KEY="devdevdev"
 STORAGE_ENDPOINT="localhost"
 STORAGE_PORT=9000
 STORAGE_BUCKET="solution"
+
+# TODO: Read reputation oracle URL from KVStore
+REPUTATION_ORACLE_URL="http://localhost:5002"

--- a/packages/apps/fortune/recording-oracle/src/common/config/server.config.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/config/server.config.ts
@@ -5,6 +5,7 @@ export const serverConfig = registerAs("server", () => ({
   port: +(process.env.PORT || "5001"),
   sessionSecret: process.env.SESSION_SECRET || "secret",
   feUrl: process.env.FE_URL || "http://localhost:3001",
+  reputationOracleURL: process.env.REPUTATION_ORACLE_URL || "http://localhost:5002",
 }));
 export const serverConfigKey = serverConfig.KEY;
 export type ServerConfigType = ConfigType<typeof serverConfig>;

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.controller.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.controller.spec.ts
@@ -34,6 +34,11 @@ describe("JobController", () => {
             bucket: "TEST_BUCKET",
           })),
         ),
+        ConfigModule.forFeature(
+          registerAs("server", () => ({
+            reputationOracleURL: "REPUTATION_ORACLE_URL",
+          })),
+        ),
       ],
       providers: [
         JobService,

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.module.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.module.ts
@@ -2,13 +2,13 @@ import { HttpModule } from "@nestjs/axios";
 import { Logger, Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 
-import { storageConfig } from "@/common/config";
+import { serverConfig, storageConfig } from "@/common/config";
 import { JobController } from "./job.controller";
 import { JobService } from "./job.service";
 import { Web3Module } from "../web3/web3.module";
 
 @Module({
-  imports: [ConfigModule.forFeature(storageConfig), HttpModule, Web3Module],
+  imports: [ConfigModule.forFeature(storageConfig), ConfigModule.forFeature(serverConfig), HttpModule, Web3Module],
   controllers: [JobController],
   providers: [Logger, JobService],
   exports: [JobService],

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.spec.ts
@@ -78,6 +78,11 @@ describe("JobController", () => {
             bucket: "TEST_BUCKET",
           })),
         ),
+        ConfigModule.forFeature(
+          registerAs("server", () => ({
+            reputationOracleURL: "REPUTATION_ORACLE_URL",
+          })),
+        ),
       ],
       providers: [
         JobService,
@@ -148,7 +153,7 @@ describe("JobController", () => {
 
       StorageClient.downloadFileFromUrl = jest.fn().mockImplementation(async url => {
         if (url === "MANIFEST_URL") {
-          return { fortunesRequired: 2, reputationOracleUrl: "REPUTATION_ORACLE_URL" };
+          return { fortunesRequired: 2 };
         }
 
         return [];
@@ -169,7 +174,7 @@ describe("JobController", () => {
 
       StorageClient.downloadFileFromUrl = jest.fn().mockImplementation(async url => {
         if (url === "MANIFEST_URL") {
-          return { fortunesRequired: 2, reputationOracleUrl: "REPUTATION_ORACLE_URL" };
+          return { fortunesRequired: 2 };
         }
 
         return [SOLUTION];
@@ -197,7 +202,7 @@ describe("JobController", () => {
 
       StorageClient.downloadFileFromUrl = jest.fn().mockImplementation(async url => {
         if (url === "MANIFEST_URL") {
-          return { fortunesRequired: 2, reputationOracleUrl: "REPUTATION_ORACLE_URL" };
+          return { fortunesRequired: 2 };
         }
 
         return [oldSolution];


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Ideally, reputation Oracle should be read from KVStore. But as of now, KVStore is not used yet. Therefore, as a workaround, we should read it from env variable. In the near future, we'll remove env variable, and read reputation oracle URL from KVStore.

## Summary of changes
- Read reputation oracle URL from env variable.
- Reading reputation oracle URL from KVStore is coded, but commented. Will uncomment in the future.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #629 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
