### PR TITLE
Exchange Oracle webhooks signature verification

### DIFF
--- a/.github/workflows/ci-test-cvat.yaml
+++ b/.github/workflows/ci-test-cvat.yaml
@@ -1,0 +1,16 @@
+name: CVAT Exchange Oracle Tests
+
+on:
+  push:
+    paths:
+      - 'packages/examples/cvat/exchange_oracle/**'
+
+jobs:
+  cvat-exo-test:
+    name: CVAT Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: CVAT Exchange Oracle tests
+        working-directory: ./packages/examples/cvat/exchange-oracle
+        run: docker-compose -f docker-compose.test.yml up --attach test --exit-code-from test

--- a/.github/workflows/ci-test-cvat.yaml
+++ b/.github/workflows/ci-test-cvat.yaml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: CVAT Exchange Oracle tests
         working-directory: ./packages/examples/cvat/exchange-oracle
-        run: docker-compose -f docker-compose.test.yml up --attach test --exit-code-from test
+        run: docker compose -f docker-compose.test.yml up --attach test --exit-code-from test

--- a/packages/examples/cvat/exchange-oracle/poetry.lock
+++ b/packages/examples/cvat/exchange-oracle/poetry.lock
@@ -1262,13 +1262,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "human-protocol-sdk"
-version = "1.1.6"
+version = "1.1.7"
 description = "A python library to launch escrow contracts to the HUMAN network."
 optional = false
 python-versions = "*"
 files = [
-    {file = "human-protocol-sdk-1.1.6.tar.gz", hash = "sha256:b917a40a68ae856f0d1bc588e63342c102e004927da05abdc6b1a259dc68d0a0"},
-    {file = "human_protocol_sdk-1.1.6-py3-none-any.whl", hash = "sha256:f4e6c685c95992708c9c6a0037c4a1b24ee825d22a6dc1864159fccf12dd2472"},
+    {file = "human-protocol-sdk-1.1.7.tar.gz", hash = "sha256:ac4430f973c220ec535b6bd31eb09b7cd675adb53d5329c6c65af9b6ed0de091"},
+    {file = "human_protocol_sdk-1.1.7-py3-none-any.whl", hash = "sha256:cf526949a29b1b1c15c282e93a96d4ce1efc4827e483f1b280fec4f156d6e999"},
 ]
 
 [package.dependencies]
@@ -2760,4 +2760,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e6f8945e8e4fe9e331c39a9745a49ed0a78a4a1a7859acd539a963ec7e62ddc6"
+content-hash = "62a47e0b5556031a5a6abbf9fda9702602b0aba68111478c286e74504246f41a"

--- a/packages/examples/cvat/exchange-oracle/pyproject.toml
+++ b/packages/examples/cvat/exchange-oracle/pyproject.toml
@@ -19,7 +19,7 @@ pytest = "^7.2.2"
 cvat-sdk = "^2.4.4"
 sqlalchemy = "^2.0.16"
 apscheduler = "^3.10.1"
-human-protocol-sdk = "1.1.6"
+human-protocol-sdk = "^1.1.7"
 xmltodict = "^0.13.0"
 
 

--- a/packages/examples/cvat/exchange-oracle/src/modules/api.py
+++ b/packages/examples/cvat/exchange-oracle/src/modules/api.py
@@ -5,7 +5,7 @@ from src.modules.api_schema import OracleWebhook, OracleWebhookResponse, CvatWeb
 from src.db import SessionLocal
 
 from src.modules.chain.escrow import validate_escrow
-from src.validators.signature import validate_signature, validate_cvat_signature
+from src.validators.signature import validate_webhook_signature, validate_cvat_signature
 
 from src.modules.cvat.handlers.webhook import cvat_webhook_handler
 from src.modules.oracle_webhook.service import create_webhook
@@ -18,12 +18,13 @@ router = APIRouter()
     "/job-launcher",
     description="Consumes a webhook from a job launcher",
 )
-def job_launcher_webhook(
+async def job_launcher_webhook(
     webhook: OracleWebhook,
+    request: Request,
     human_signature: Union[str, None] = Header(default=None),
 ):
     try:
-        validate_signature(human_signature)
+        await validate_webhook_signature(request, human_signature, webhook)
         validate_escrow(webhook.chain_id, webhook.escrow_address)
 
         with SessionLocal.begin() as session:

--- a/packages/examples/cvat/exchange-oracle/src/modules/chain/escrow.py
+++ b/packages/examples/cvat/exchange-oracle/src/modules/chain/escrow.py
@@ -39,3 +39,14 @@ def store_results(chain_id: int, escrow_address: str, url: str, hash: str) -> No
     escrow_client = EscrowClient(web3)
 
     escrow_client.store_results(escrow_address, url, hash)
+
+
+def get_job_launcher_address(chain_id: int, escrow_address: str) -> str:
+    web3 = get_web3(chain_id)
+    escrow_client = EscrowClient(web3)
+
+    # TODO: Replace it with escrow_client.get_job_launcher_address(escrow_address) when this will be released
+    contract = escrow_client._get_escrow_contract(escrow_address)
+    job_launcher_address = contract.functions.launcher().call()
+
+    return job_launcher_address

--- a/packages/examples/cvat/exchange-oracle/src/modules/chain/escrow.py
+++ b/packages/examples/cvat/exchange-oracle/src/modules/chain/escrow.py
@@ -45,8 +45,6 @@ def get_job_launcher_address(chain_id: int, escrow_address: str) -> str:
     web3 = get_web3(chain_id)
     escrow_client = EscrowClient(web3)
 
-    # TODO: Replace it with escrow_client.get_job_launcher_address(escrow_address) when this will be released
-    contract = escrow_client._get_escrow_contract(escrow_address)
-    job_launcher_address = contract.functions.launcher().call()
+    job_launcher_address = escrow_client.get_job_launcher_address(escrow_address)
 
     return job_launcher_address

--- a/packages/examples/cvat/exchange-oracle/src/modules/chain/web3.py
+++ b/packages/examples/cvat/exchange-oracle/src/modules/chain/web3.py
@@ -50,7 +50,7 @@ def sign_message(chain_id: Networks, message) -> str:
     return signed_message.signature.hex()
 
 
-def recover_signer(chain_id: Networks, message: str, signature: str) -> str:
+def recover_signer(chain_id: Networks, message, signature: str) -> str:
     w3 = get_web3(chain_id)
     message_hash = encode_defunct(text=str(message))
     signer = w3.eth.account.recover_message(message_hash, signature=signature)

--- a/packages/examples/cvat/exchange-oracle/src/validators/signature.py
+++ b/packages/examples/cvat/exchange-oracle/src/validators/signature.py
@@ -1,13 +1,27 @@
 import hmac
+from ast import literal_eval
 from hashlib import sha256
+
 from fastapi import HTTPException, Request
-
 from src.config import CvatConfig
+from src.modules.chain.escrow import get_job_launcher_address
+from src.modules.chain.web3 import recover_signer
 
 
-# TODO: Validate webhook signature
-def validate_signature(signature: str):
-    pass
+async def validate_webhook_signature(request: Request, signature: str, webhook: dict):
+    data: bytes = await request.body()
+    message: dict = literal_eval(data.decode("utf-8"))
+
+    signer = recover_signer(webhook.chain_id, message, signature)
+
+    job_launcher_address = get_job_launcher_address(
+        webhook.chain_id, webhook.escrow_address
+    )
+
+    if signer.lower() != job_launcher_address.lower():
+        raise ValueError(
+            f"Webhook sender address doesn't match. Excpected: {job_launcher_address}, received: {signer}."
+        )
 
 
 async def validate_cvat_signature(request: Request, x_signature_256: str):

--- a/packages/examples/cvat/exchange-oracle/tests/api/modules/oracle_webhook/test_jl_webhook.py
+++ b/packages/examples/cvat/exchange-oracle/tests/api/modules/oracle_webhook/test_jl_webhook.py
@@ -2,13 +2,15 @@ from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
 from human_protocol_sdk.constants import Status
 from src.modules.api_schema import OracleWebhook
+from tests.utils.constants import (
+    DEFAULT_GAS_PAYER as JOB_LAUNCHER,
+    WEBHOOK_MESSAGE,
+    WEBHOOK_MESSAGE_SIGNED,
+    SIGNATURE,
+)
 
 
 def test_incoming_webhook_200(client: TestClient) -> None:
-    data = {
-        "escrow_address": "0xFE776895f6b00AA53969b20119a4777Ed920676a",
-        "chain_id": 80001,
-    }
 
     with patch("src.modules.api.SessionLocal.begin") as mock_session_local, patch(
         "src.modules.api.create_webhook"
@@ -27,31 +29,35 @@ def test_incoming_webhook_200(client: TestClient) -> None:
         mock_escrow_instance = MagicMock()
         mock_escrow_instance.get_balance.return_value = 100
         mock_escrow_instance.get_status.return_value = Status.Pending
+        mock_escrow_instance.get_job_launcher_address.return_value = JOB_LAUNCHER
         mock_escrow_client.return_value = mock_escrow_instance
 
         response = client.post(
             "/webhook/job-launcher",
-            headers={"human-signature": "mocked signature"},
-            json=data,
+            headers={"human-signature": WEBHOOK_MESSAGE_SIGNED},
+            json=WEBHOOK_MESSAGE,
         )
 
         assert response.status_code == 200
         assert response.json() == {"id": "mocked_webhook_id"}
-        mock_get_web3.assert_called_once()
-        mock_escrow_client.assert_called_once_with(mock_web3_instance)
+        mock_get_web3.assert_called()
+        mock_escrow_client.assert_called_with(mock_web3_instance)
         mock_escrow_instance.get_balance.assert_called_once_with(
             "0xFE776895f6b00AA53969b20119a4777Ed920676a"
         )
         mock_escrow_instance.get_status.assert_called_once_with(
             "0xFE776895f6b00AA53969b20119a4777Ed920676a"
         )
+        mock_escrow_instance.get_job_launcher_address.assert_called_once_with(
+            "0xFE776895f6b00AA53969b20119a4777Ed920676a"
+        )
         mock_session_local.assert_called_once()
         mock_create_webhook.assert_called_once_with(
             mock_session,
-            data["escrow_address"],
-            data["chain_id"],
+            WEBHOOK_MESSAGE["escrow_address"],
+            WEBHOOK_MESSAGE["chain_id"],
             "job_launcher",
-            "mocked signature",
+            "0x653242fc57766948d0e84c8466b1d52ce701a20fc6b08b5c1bee361aa8c480a61470db594dccb5724345712a216c35aa14be7d435faaa596a7ffba7f476887bb1b",
         )
 
 
@@ -64,7 +70,7 @@ def test_incoming_webhook_400(client: TestClient) -> None:
 
     response = client.post(
         "/webhook/job-launcher",
-        headers={"human-signature": "mocked signature"},
+        headers={"human-signature": WEBHOOK_MESSAGE_SIGNED},
         json=data,
     )
 
@@ -86,7 +92,7 @@ def test_incoming_webhook_400(client: TestClient) -> None:
 
     response = client.post(
         "/webhook/job-launcher",
-        headers={"human-signature": "mocked signature"},
+        headers={"human-signature": WEBHOOK_MESSAGE_SIGNED},
         json=data,
     )
 
@@ -101,10 +107,6 @@ def test_incoming_webhook_400(client: TestClient) -> None:
     }
 
     # Invalid balance
-    data = {
-        "escrow_address": "0xFE776895f6b00AA53969b20119a4777Ed920676a",
-        "chain_id": 80001,
-    }
 
     with patch("src.modules.chain.escrow.get_web3") as mock_get_web3, patch(
         "src.modules.chain.escrow.EscrowClient"
@@ -115,21 +117,18 @@ def test_incoming_webhook_400(client: TestClient) -> None:
         mock_escrow_instance = MagicMock()
         mock_escrow_instance.get_balance.return_value = 0
         mock_escrow_instance.get_status.return_value = Status.Pending
+        mock_escrow_instance.get_job_launcher_address.return_value = JOB_LAUNCHER
         mock_escrow_client.return_value = mock_escrow_instance
 
         response = client.post(
             "/webhook/job-launcher",
-            headers={"human-signature": "mocked signature"},
-            json=data,
+            headers={"human-signature": WEBHOOK_MESSAGE_SIGNED},
+            json=WEBHOOK_MESSAGE,
         )
         assert response.status_code == 400
         assert response.json() == {"message": "Escrow doesn't have funds"}
 
     # Invalid status
-    data = {
-        "escrow_address": "0xFE776895f6b00AA53969b20119a4777Ed920676a",
-        "chain_id": 80001,
-    }
 
     with patch("src.modules.chain.escrow.get_web3") as mock_get_web3, patch(
         "src.modules.chain.escrow.EscrowClient"
@@ -140,14 +139,39 @@ def test_incoming_webhook_400(client: TestClient) -> None:
         mock_escrow_instance = MagicMock()
         mock_escrow_instance.get_balance.return_value = 100
         mock_escrow_instance.get_status.return_value = Status.Complete
+        mock_escrow_instance.get_job_launcher_address.return_value = JOB_LAUNCHER
         mock_escrow_client.return_value = mock_escrow_instance
 
         response = client.post(
             "/webhook/job-launcher",
-            headers={"human-signature": "mocked signature"},
-            json=data,
+            headers={"human-signature": WEBHOOK_MESSAGE_SIGNED},
+            json=WEBHOOK_MESSAGE,
         )
         assert response.status_code == 400
         assert response.json() == {
             "message": "Escrow is not in a Pending state. Current state: Complete"
+        }
+
+    # Invalid signature
+
+    with patch("src.modules.chain.escrow.get_web3") as mock_get_web3, patch(
+        "src.modules.chain.escrow.EscrowClient"
+    ) as mock_escrow_client:
+        mock_web3_instance = MagicMock()
+        mock_get_web3.return_value = mock_web3_instance
+
+        mock_escrow_instance = MagicMock()
+        mock_escrow_instance.get_balance.return_value = 100
+        mock_escrow_instance.get_status.return_value = Status.Complete
+        mock_escrow_instance.get_job_launcher_address.return_value = JOB_LAUNCHER
+        mock_escrow_client.return_value = mock_escrow_instance
+
+        response = client.post(
+            "/webhook/job-launcher",
+            headers={"human-signature": SIGNATURE},
+            json=WEBHOOK_MESSAGE,
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            "message": "Webhook sender address doesn't match. Excpected: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, received: 0xaF32359A1Ac2f8E2203fc37C0ce8ca04cc4459e1."
         }

--- a/packages/examples/cvat/exchange-oracle/tests/utils/constants.py
+++ b/packages/examples/cvat/exchange-oracle/tests/utils/constants.py
@@ -16,3 +16,10 @@ DEFAULT_URL = "https://storage.googleapis.com/fortune-manifests/manifest.json"
 DEFAULT_HASH = "test"
 
 SIGNATURE = "0x63fde9fec5d1924c8837bae8f19c632291725fb94bb03fb3e8d89bf6de17f52014e402e5769d27989a73e889c9aa35c7ace790d2b239d8e1d9d07046ae2d44f51c"
+
+WEBHOOK_MESSAGE = {
+    "escrow_address": "0xFE776895f6b00AA53969b20119a4777Ed920676a",
+    "chain_id": 80001,
+}
+
+WEBHOOK_MESSAGE_SIGNED = "0x653242fc57766948d0e84c8466b1d52ce701a20fc6b08b5c1bee361aa8c480a61470db594dccb5724345712a216c35aa14be7d435faaa596a7ffba7f476887bb1b"


### PR DESCRIPTION
## Description

Signature verification for incoming webhooks in Exchange Oracle

## Summary of changes

Add new method to retrieve the Job Launcher address from the escrow and verify if it is the signer of the incoming webhook

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
#646 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
