### PR TITLE
Init tests

### DIFF
--- a/packages/examples/cvat/recording-oracle/.gitignore
+++ b/packages/examples/cvat/recording-oracle/.gitignore
@@ -1,3 +1,8 @@
 /.venv
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.pytest_cache
+
+# Env file
+.env
+.python-version

--- a/packages/examples/cvat/recording-oracle/README.MD
+++ b/packages/examples/cvat/recording-oracle/README.MD
@@ -48,7 +48,15 @@ alembic downgrade -{number of migrations}
 ```
 
 
-
 ### Endpoints and API schema
 
 Available at `/docs` route
+
+
+### Tests
+
+To run tests
+```
+docker-compose -f docker-compose.test.yml up -d
+pytest
+```

--- a/packages/examples/cvat/recording-oracle/bin/start_test.sh
+++ b/packages/examples/cvat/recording-oracle/bin/start_test.sh
@@ -1,0 +1,10 @@
+export SQLALCHEMY_SILENCE_UBER_WARNING=1
+export ENVIRONMENT=test
+
+export PG_PORT=5434
+export PG_HOST=localhost
+export PG_USER=test
+export PG_PASSWORD=test
+export PG_DB=recording_oracle_test
+
+pytest

--- a/packages/examples/cvat/recording-oracle/docker-compose.test.yml
+++ b/packages/examples/cvat/recording-oracle/docker-compose.test.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:14.4
+    restart: on-failure
+    environment:
+      POSTGRES_PASSWORD: 'test'
+      POSTGRES_USER: 'test'
+      POSTGRES_DB: 'recording_oracle_test'
+      PGDATA: '/var/lib/postgresql/data/pgdata'
+    ports:
+      - 5434:5432
+    command: ["postgres", "-c", "log_statement=all"]

--- a/packages/examples/cvat/recording-oracle/src/db/__init__.py
+++ b/packages/examples/cvat/recording-oracle/src/db/__init__.py
@@ -1,0 +1,10 @@
+import sqlalchemy
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from src.config import Config
+
+DATABASE_URL = Config.postgres_config.connection_url()
+engine = sqlalchemy.create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, bind=engine)
+
+Base = declarative_base()

--- a/packages/examples/cvat/recording-oracle/tests/conftest.py
+++ b/packages/examples/cvat/recording-oracle/tests/conftest.py
@@ -1,0 +1,19 @@
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.db import Base, engine
+from src import app
+
+
+@pytest.fixture(autouse=True)
+def db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client() -> Generator:
+    with TestClient(app) as c:
+        yield c

--- a/packages/examples/cvat/recording-oracle/tests/integration/service/test_webhook_service.py
+++ b/packages/examples/cvat/recording-oracle/tests/integration/service/test_webhook_service.py
@@ -1,0 +1,252 @@
+import unittest
+import uuid
+
+from pydantic import ValidationError
+from src.db import SessionLocal
+from src.constants import Networks
+from src.modules.webhook.constants import (
+    OracleWebhookTypes,
+    OracleWebhookStatuses,
+)
+from src.modules.webhook.model import Webhook
+from sqlalchemy.exc import IntegrityError
+
+from src.modules.webhook.constants import (
+    OracleWebhookTypes,
+    OracleWebhookStatuses,
+)
+from src.modules.webhook import service as webhook_service
+
+
+class ServiceIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.session = SessionLocal()
+
+    def tearDown(self):
+        self.session.close()
+
+    def test_create_webhook(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        chain_id = Networks.polygon_mainnet.value
+        signature = "signature"
+
+        webhook_id = webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+
+        webhook = self.session.query(Webhook).filter_by(id=webhook_id).first()
+
+        self.assertEqual(webhook.escrow_address, escrow_address)
+        self.assertEqual(webhook.chain_id, chain_id)
+        self.assertEqual(webhook.attempts, 0)
+        self.assertEqual(webhook.signature, signature)
+        self.assertEqual(webhook.type, OracleWebhookTypes.exchange_oracle.value)
+        self.assertEqual(webhook.status, OracleWebhookStatuses.pending.value)
+
+    def test_create_webhook_none_escrow_address(self):
+        chain_id = Networks.polygon_mainnet.value
+        signature = "signature"
+        webhook_service.create_webhook(
+            self.session,
+            escrow_address=None,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+        with self.assertRaises(IntegrityError):
+            self.session.commit()
+
+    def test_create_webhook_none_chain_id(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        signature = "signature"
+        webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=None,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+        with self.assertRaises(IntegrityError):
+            self.session.commit()
+
+    def test_create_webhook_none_signature(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        chain_id = Networks.polygon_mainnet.value
+
+        webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=None,
+        )
+        with self.assertRaises(IntegrityError):
+            self.session.commit()
+
+    def test_get_pending_webhooks(self):
+        chain_id = Networks.polygon_mainnet.value
+
+        webhook1_id = str(uuid.uuid4())
+        webhook1 = Webhook(
+            id=webhook1_id,
+            signature="signature1",
+            escrow_address="0x1234567890123456789012345678901234567890",
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            status=OracleWebhookStatuses.pending.value,
+        )
+        webhook2_id = str(uuid.uuid4())
+        webhook2 = Webhook(
+            id=webhook2_id,
+            signature="signature2",
+            escrow_address="0x1234567890123456789012345678901234567891",
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            status=OracleWebhookStatuses.pending.value,
+        )
+        webhook3_id = str(uuid.uuid4())
+        webhook3 = Webhook(
+            id=webhook3_id,
+            signature="signature3",
+            escrow_address="0x1234567890123456789012345678901234567892",
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            status=OracleWebhookStatuses.completed.value,
+        )
+
+        webhook4_id = str(uuid.uuid4())
+        webhook4 = Webhook(
+            id=webhook4_id,
+            signature="signature4",
+            escrow_address="0x1234567890123456789012345678901234567892",
+            chain_id=chain_id,
+            type=OracleWebhookTypes.reputation_oracle.value,
+            status=OracleWebhookStatuses.pending.value,
+        )
+
+        self.session.add(webhook1)
+        self.session.add(webhook2)
+        self.session.add(webhook3)
+        self.session.add(webhook4)
+        self.session.commit()
+
+        pending_webhooks = webhook_service.get_pending_webhooks(
+            self.session, OracleWebhookTypes.exchange_oracle.value, 10
+        )
+        self.assertEqual(len(pending_webhooks), 2)
+        self.assertEqual(pending_webhooks[0].id, webhook1_id)
+        self.assertEqual(pending_webhooks[1].id, webhook2_id)
+
+        pending_webhooks = webhook_service.get_pending_webhooks(
+            self.session, OracleWebhookTypes.reputation_oracle.value, 10
+        )
+        self.assertEqual(len(pending_webhooks), 1)
+        self.assertEqual(pending_webhooks[0].id, webhook4_id)
+
+    def test_update_webhook_status(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        chain_id = Networks.polygon_mainnet.value
+        signature = "signature"
+
+        webhook_id = webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+
+        webhook_service.update_webhook_status(
+            self.session, webhook_id, OracleWebhookStatuses.completed.value
+        )
+
+        webhook = self.session.query(Webhook).filter_by(id=webhook_id).first()
+
+        self.assertEqual(webhook.escrow_address, escrow_address)
+        self.assertEqual(webhook.chain_id, chain_id)
+        self.assertEqual(webhook.attempts, 0)
+        self.assertEqual(webhook.signature, signature)
+        self.assertEqual(webhook.type, OracleWebhookTypes.exchange_oracle.value)
+        self.assertEqual(webhook.status, OracleWebhookStatuses.completed.value)
+
+    def test_update_webhook_invalid_status(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        chain_id = Networks.polygon_mainnet.value
+        signature = "signature"
+
+        webhook_id = webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+
+        with self.assertRaises(ValueError):
+            webhook_service.update_webhook_status(
+                self.session, webhook_id, "Invalid status"
+            )
+
+    def test_handle_webhook_success(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        chain_id = Networks.polygon_mainnet.value
+        signature = "signature"
+
+        webhook_id = webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+
+        webhook_service.handle_webhook_success(self.session, webhook_id)
+
+        webhook = self.session.query(Webhook).filter_by(id=webhook_id).first()
+
+        self.assertEqual(webhook.escrow_address, escrow_address)
+        self.assertEqual(webhook.chain_id, chain_id)
+        self.assertEqual(webhook.attempts, 1)
+        self.assertEqual(webhook.signature, signature)
+        self.assertEqual(webhook.type, OracleWebhookTypes.exchange_oracle.value)
+        self.assertEqual(webhook.status, OracleWebhookStatuses.completed.value)
+
+    def test_handle_webhook_fail(self):
+        escrow_address = "0x1234567890123456789012345678901234567890"
+        chain_id = Networks.polygon_mainnet.value
+        signature = "signature"
+
+        webhook_id = webhook_service.create_webhook(
+            self.session,
+            escrow_address=escrow_address,
+            chain_id=chain_id,
+            type=OracleWebhookTypes.exchange_oracle.value,
+            signature=signature,
+        )
+
+        webhook_service.handle_webhook_fail(self.session, webhook_id)
+
+        webhook = self.session.query(Webhook).filter_by(id=webhook_id).first()
+
+        self.assertEqual(webhook.escrow_address, escrow_address)
+        self.assertEqual(webhook.chain_id, chain_id)
+        self.assertEqual(webhook.attempts, 1)
+        self.assertEqual(webhook.signature, signature)
+        self.assertEqual(webhook.type, OracleWebhookTypes.exchange_oracle.value)
+        self.assertEqual(webhook.status, OracleWebhookStatuses.pending.value)
+
+        for i in range(4):
+            webhook_service.handle_webhook_fail(self.session, webhook_id)
+
+        webhook = self.session.query(Webhook).filter_by(id=webhook_id).first()
+
+        self.assertEqual(webhook.escrow_address, escrow_address)
+        self.assertEqual(webhook.chain_id, chain_id)
+        self.assertEqual(webhook.attempts, 5)
+        self.assertEqual(webhook.signature, signature)
+        self.assertEqual(webhook.type, OracleWebhookTypes.exchange_oracle.value)
+        self.assertEqual(webhook.status, OracleWebhookStatuses.failed.value)


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

Added setup for testing CVAT Recording Oracle

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

1. Added service tests for `webhook` module.
2. Added missing `db/` folder (wasn't here because of the `.gitignore` file in a root folder of `human-protocol` repo.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

```
poetry install
poetry shell
docker-compose -f docker-compose.test.yml up -d
./bin/start_test.sh
```

## Related issues

To close https://github.com/humanprotocol/human-protocol/issues/640

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
