### PR TITLE
fix: sdk staking client to add staker address when getting staker info

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
@@ -306,7 +306,7 @@ class StakingClient:
 
         return [
             {
-                "staker": stakers[i],
+                "address": stakers[i],
                 "tokens_staked": staker_info[i][0],
                 "tokens_allocated": staker_info[i][1],
                 "tokens_locked": staker_info[i][2],
@@ -344,6 +344,7 @@ class StakingClient:
             return None
 
         return {
+            "address": staker_address,
             "tokens_staked": tokens_staked,
             "tokens_allocated": tokens_allocated,
             "tokens_locked": tokens_locked,

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
@@ -306,7 +306,7 @@ class StakingClient:
 
         return [
             {
-                "address": stakers[i],
+                "staker": stakers[i],
                 "tokens_staked": staker_info[i][0],
                 "tokens_allocated": staker_info[i][1],
                 "tokens_locked": staker_info[i][2],
@@ -344,7 +344,7 @@ class StakingClient:
             return None
 
         return {
-            "address": staker_address,
+            "staker": staker_address,
             "tokens_staked": tokens_staked,
             "tokens_allocated": tokens_allocated,
             "tokens_locked": tokens_locked,

--- a/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
@@ -502,28 +502,26 @@ class StakingTestCase(unittest.TestCase):
 
         self.assertEqual(len(all_stakers_info), 4)
         self.assertEqual(
-            all_stakers_info[0]["address"].lower(),
+            all_stakers_info[0]["staker"].lower(),
             "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266".lower(),
         )
         self.assertEqual(
-            all_stakers_info[1]["address"].lower(),
+            all_stakers_info[1]["staker"].lower(),
             "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".lower(),
         )
         self.assertEqual(
-            all_stakers_info[2]["address"].lower(),
+            all_stakers_info[2]["staker"].lower(),
             "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC".lower(),
         )
         self.assertEqual(
-            all_stakers_info[3]["address"].lower(),
+            all_stakers_info[3]["staker"].lower(),
             "0x90F79bf6EB2c4f870365E785982E1f101E93b906".lower(),
         )
 
     def test_get_staker_info(self):
         all_stakers_info = self.staking_client.get_all_stakers_info()
 
-        staker_info = self.staking_client.get_staker_info(
-            all_stakers_info[1]["address"]
-        )
+        staker_info = self.staking_client.get_staker_info(all_stakers_info[1]["staker"])
 
         self.assertEqual(
             all_stakers_info[1]["tokens_staked"], staker_info["tokens_staked"]

--- a/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
@@ -502,26 +502,28 @@ class StakingTestCase(unittest.TestCase):
 
         self.assertEqual(len(all_stakers_info), 4)
         self.assertEqual(
-            all_stakers_info[0]["staker"].lower(),
+            all_stakers_info[0]["address"].lower(),
             "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266".lower(),
         )
         self.assertEqual(
-            all_stakers_info[1]["staker"].lower(),
+            all_stakers_info[1]["address"].lower(),
             "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".lower(),
         )
         self.assertEqual(
-            all_stakers_info[2]["staker"].lower(),
+            all_stakers_info[2]["address"].lower(),
             "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC".lower(),
         )
         self.assertEqual(
-            all_stakers_info[3]["staker"].lower(),
+            all_stakers_info[3]["address"].lower(),
             "0x90F79bf6EB2c4f870365E785982E1f101E93b906".lower(),
         )
 
     def test_get_staker_info(self):
         all_stakers_info = self.staking_client.get_all_stakers_info()
 
-        staker_info = self.staking_client.get_staker_info(all_stakers_info[1]["staker"])
+        staker_info = self.staking_client.get_staker_info(
+            all_stakers_info[1]["address"]
+        )
 
         self.assertEqual(
             all_stakers_info[1]["tokens_staked"], staker_info["tokens_staked"]

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_staking.py
@@ -287,7 +287,7 @@ class StakingTestCase(unittest.TestCase):
         mock_function.assert_called_once()
 
         self.assertEqual(len(all_stakers_info), 2)
-        self.assertEqual(all_stakers_info[0]["address"].lower(), "staker1")
+        self.assertEqual(all_stakers_info[0]["staker"].lower(), "staker1")
         self.assertEqual(all_stakers_info[0]["tokens_staked"], 1)
         self.assertEqual(all_stakers_info[0]["tokens_allocated"], 2)
         self.assertEqual(all_stakers_info[0]["tokens_locked"], 3)
@@ -315,7 +315,7 @@ class StakingTestCase(unittest.TestCase):
 
         mock_function.assert_called_once_with(staker_address)
 
-        self.assertEqual(staker_info["address"], staker_address)
+        self.assertEqual(staker_info["staker"], staker_address)
         self.assertEqual(staker_info["tokens_staked"], 1)
         self.assertEqual(staker_info["tokens_allocated"], 2)
         self.assertEqual(staker_info["tokens_locked"], 3)
@@ -330,7 +330,7 @@ class StakingTestCase(unittest.TestCase):
 
         mock_function.assert_called_once_with(self.w3.eth.default_account)
 
-        self.assertEqual(staker_info["address"], self.w3.eth.default_account)
+        self.assertEqual(staker_info["staker"], self.w3.eth.default_account)
         self.assertEqual(staker_info["tokens_staked"], 1)
         self.assertEqual(staker_info["tokens_allocated"], 2)
         self.assertEqual(staker_info["tokens_locked"], 3)

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_staking.py
@@ -287,7 +287,7 @@ class StakingTestCase(unittest.TestCase):
         mock_function.assert_called_once()
 
         self.assertEqual(len(all_stakers_info), 2)
-        self.assertEqual(all_stakers_info[0]["staker"].lower(), "staker1")
+        self.assertEqual(all_stakers_info[0]["address"].lower(), "staker1")
         self.assertEqual(all_stakers_info[0]["tokens_staked"], 1)
         self.assertEqual(all_stakers_info[0]["tokens_allocated"], 2)
         self.assertEqual(all_stakers_info[0]["tokens_locked"], 3)
@@ -315,6 +315,7 @@ class StakingTestCase(unittest.TestCase):
 
         mock_function.assert_called_once_with(staker_address)
 
+        self.assertEqual(staker_info["address"], staker_address)
         self.assertEqual(staker_info["tokens_staked"], 1)
         self.assertEqual(staker_info["tokens_allocated"], 2)
         self.assertEqual(staker_info["tokens_locked"], 3)
@@ -329,6 +330,7 @@ class StakingTestCase(unittest.TestCase):
 
         mock_function.assert_called_once_with(self.w3.eth.default_account)
 
+        self.assertEqual(staker_info["address"], self.w3.eth.default_account)
         self.assertEqual(staker_info["tokens_staked"], 1)
         self.assertEqual(staker_info["tokens_allocated"], 2)
         self.assertEqual(staker_info["tokens_locked"], 3)

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -22,6 +22,10 @@ export interface IStaker {
   tokensAvailable: BigNumber;
 }
 
+export interface IStakerWithAddress extends IStaker {
+  address: string;
+}
+
 export interface IEscrowsFilter {
   address?: string;
   role?: number;

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -15,7 +15,7 @@ export interface IReward {
 }
 
 export interface IStaker {
-  address: string;
+  staker: string;
   tokensStaked: BigNumber;
   tokensAllocated: BigNumber;
   tokensLocked: BigNumber;

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -15,15 +15,12 @@ export interface IReward {
 }
 
 export interface IStaker {
+  address: string;
   tokensStaked: BigNumber;
   tokensAllocated: BigNumber;
   tokensLocked: BigNumber;
   tokensLockedUntil: BigNumber;
   tokensAvailable: BigNumber;
-}
-
-export interface IStakerWithAddress extends IStaker {
-  address: string;
 }
 
 export interface IEscrowsFilter {

--- a/packages/sdk/typescript/human-protocol-sdk/src/staking.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/staking.ts
@@ -26,7 +26,7 @@ import {
   ErrorStakingGetStakers,
   ErrorUnsupportedChainID,
 } from './error';
-import { IAllocation, IReward, IStakerWithAddress } from './interfaces';
+import { IAllocation, IReward, IStaker } from './interfaces';
 import { RAW_REWARDS_QUERY } from './queries';
 import { NetworkData } from './types';
 import { gqlFetch, throwError } from './utils';
@@ -337,7 +337,7 @@ export class StakingClient {
    * @returns {Promise<IStaker>} - Return staking information of the specified address
    * @throws {Error} - An error object if an error occurred, result otherwise
    */
-  public async getStaker(staker: string): Promise<IStakerWithAddress> {
+  public async getStaker(staker: string): Promise<IStaker> {
     if (!ethers.utils.isAddress(staker)) {
       throw ErrorInvalidStakerAddressProvided;
     }
@@ -370,10 +370,10 @@ export class StakingClient {
   /**
    * **Returns the staking information about all stakers of the protocol.*
    *
-   * @returns {Promise<IStakerInfo>} - Return an array with all stakers information
+   * @returns {Promise<IStaker[]>} - Return an array with all stakers information
    * @throws {Error} - An error object if an error occurred, results otherwise
    */
-  public async getAllStakers(): Promise<IStakerWithAddress[]> {
+  public async getAllStakers(): Promise<IStaker[]> {
     try {
       const result = await this.stakingContract.getListOfStakers();
 

--- a/packages/sdk/typescript/human-protocol-sdk/src/staking.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/staking.ts
@@ -26,7 +26,7 @@ import {
   ErrorStakingGetStakers,
   ErrorUnsupportedChainID,
 } from './error';
-import { IAllocation, IReward, IStaker } from './interfaces';
+import { IAllocation, IReward, IStakerWithAddress } from './interfaces';
 import { RAW_REWARDS_QUERY } from './queries';
 import { NetworkData } from './types';
 import { gqlFetch, throwError } from './utils';
@@ -337,7 +337,7 @@ export class StakingClient {
    * @returns {Promise<IStaker>} - Return staking information of the specified address
    * @throws {Error} - An error object if an error occurred, result otherwise
    */
-  public async getStaker(staker: string): Promise<IStaker> {
+  public async getStaker(staker: string): Promise<IStakerWithAddress> {
     if (!ethers.utils.isAddress(staker)) {
       throw ErrorInvalidStakerAddressProvided;
     }
@@ -355,6 +355,7 @@ export class StakingClient {
         .sub(tokensLocked);
 
       return {
+        address: staker,
         tokensStaked,
         tokensAllocated,
         tokensLocked,
@@ -372,7 +373,7 @@ export class StakingClient {
    * @returns {Promise<IStakerInfo>} - Return an array with all stakers information
    * @throws {Error} - An error object if an error occurred, results otherwise
    */
-  public async getAllStakers(): Promise<IStaker[]> {
+  public async getAllStakers(): Promise<IStakerWithAddress[]> {
     try {
       const result = await this.stakingContract.getListOfStakers();
 
@@ -380,7 +381,7 @@ export class StakingClient {
         throw ErrorStakingGetStakers;
       }
 
-      return result[1].map((staker: any) => {
+      return result[1].map((staker: any, index: number) => {
         const tokensStaked = BigNumber.from(staker.tokensStaked),
           tokensAllocated = BigNumber.from(staker.tokensAllocated),
           tokensLocked = BigNumber.from(staker.tokensLocked),
@@ -391,6 +392,7 @@ export class StakingClient {
           .sub(tokensLocked);
 
         return {
+          address: result[0][index],
           tokensStaked,
           tokensAllocated,
           tokensLocked,

--- a/packages/sdk/typescript/human-protocol-sdk/src/staking.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/staking.ts
@@ -355,7 +355,7 @@ export class StakingClient {
         .sub(tokensLocked);
 
       return {
-        address: staker,
+        staker,
         tokensStaked,
         tokensAllocated,
         tokensLocked,
@@ -392,7 +392,7 @@ export class StakingClient {
           .sub(tokensLocked);
 
         return {
-          address: result[0][index],
+          staker: result[0][index],
           tokensStaked,
           tokensAllocated,
           tokensLocked,

--- a/packages/sdk/typescript/human-protocol-sdk/test/staking.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/staking.test.ts
@@ -532,7 +532,7 @@ describe('StakingClient', () => {
       mockStakingContract.getStaker.mockResolvedValueOnce(mockStaker);
 
       const result = await stakingClient.getStaker(stakerAddress);
-      expect(result).toEqual(mockStaker);
+      expect(result).toEqual({ ...mockStaker, address: stakerAddress });
       expect(mockStakingContract.getStaker).toHaveBeenCalledWith(stakerAddress);
       expect(mockStakingContract.getStaker).toHaveBeenCalledTimes(1);
     });
@@ -571,7 +571,10 @@ describe('StakingClient', () => {
 
       const stakers = await stakingClient.getAllStakers();
 
-      expect(stakers).toEqual([mockStaker, mockStaker]);
+      expect(stakers).toEqual([
+        { ...mockStaker, address: stakerAddress },
+        { ...mockStaker, address: stakerAddress },
+      ]);
       expect(mockStakingContract.getListOfStakers).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/sdk/typescript/human-protocol-sdk/test/staking.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/staking.test.ts
@@ -522,7 +522,7 @@ describe('StakingClient', () => {
     const invalidAddress = 'InvalidAddress';
 
     test('should return staker information', async () => {
-      const mockStaker: IStaker = {
+      const mockStaker: Omit<IStaker, 'address'> = {
         tokensStaked: ethers.utils.parseEther('100'),
         tokensAllocated: ethers.utils.parseEther('50'),
         tokensLocked: ethers.utils.parseEther('25'),
@@ -554,7 +554,7 @@ describe('StakingClient', () => {
   });
 
   describe('getAllStakers()', () => {
-    const mockStaker: IStaker = {
+    const mockStaker: Omit<IStaker, 'address'> = {
       tokensStaked: ethers.utils.parseEther('100'),
       tokensAllocated: ethers.utils.parseEther('50'),
       tokensLocked: ethers.utils.parseEther('25'),

--- a/packages/sdk/typescript/human-protocol-sdk/test/staking.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/staking.test.ts
@@ -522,7 +522,7 @@ describe('StakingClient', () => {
     const invalidAddress = 'InvalidAddress';
 
     test('should return staker information', async () => {
-      const mockStaker: Omit<IStaker, 'address'> = {
+      const mockStaker: Omit<IStaker, 'staker'> = {
         tokensStaked: ethers.utils.parseEther('100'),
         tokensAllocated: ethers.utils.parseEther('50'),
         tokensLocked: ethers.utils.parseEther('25'),
@@ -532,7 +532,7 @@ describe('StakingClient', () => {
       mockStakingContract.getStaker.mockResolvedValueOnce(mockStaker);
 
       const result = await stakingClient.getStaker(stakerAddress);
-      expect(result).toEqual({ ...mockStaker, address: stakerAddress });
+      expect(result).toEqual({ ...mockStaker, staker: stakerAddress });
       expect(mockStakingContract.getStaker).toHaveBeenCalledWith(stakerAddress);
       expect(mockStakingContract.getStaker).toHaveBeenCalledTimes(1);
     });
@@ -554,7 +554,7 @@ describe('StakingClient', () => {
   });
 
   describe('getAllStakers()', () => {
-    const mockStaker: Omit<IStaker, 'address'> = {
+    const mockStaker: Omit<IStaker, 'staker'> = {
       tokensStaked: ethers.utils.parseEther('100'),
       tokensAllocated: ethers.utils.parseEther('50'),
       tokensLocked: ethers.utils.parseEther('25'),
@@ -572,8 +572,8 @@ describe('StakingClient', () => {
       const stakers = await stakingClient.getAllStakers();
 
       expect(stakers).toEqual([
-        { ...mockStaker, address: stakerAddress },
-        { ...mockStaker, address: stakerAddress },
+        { ...mockStaker, staker: stakerAddress },
+        { ...mockStaker, staker: stakerAddress },
       ]);
       expect(mockStakingContract.getListOfStakers).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Fix Node.js/Python SDK `StakingClient` module. It's missing address in the staker info, which is necessary.

## Summary of changes
- Updated return value schema of `getAllStakers`, and `getStaker` function of Node.js SDK, to include `address` of the staker.
- Updated `get_staker_info` function of Python SDK to include `address` of the staker.
- Renamed `staker` to `address` of the return value of `get_all_stakers_info` function, to unify the response schema with Node.js SDK.
- Updated relevant tests.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #648 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
