### PR TITLE
[Fortune] [Reputation Oracle] Add manifest endpoint

### DIFF
--- a/packages/apps/reputation-oracle/server/src/app.module.ts
+++ b/packages/apps/reputation-oracle/server/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller';
 import { DatabaseModule } from './database/database.module';
 import { HttpValidationPipe } from './common/pipes';
 import { HealthModule } from './modules/health/health.module';
+import { ManifestModule } from './modules/manifest/manifest.module';
 import { ReputationModule } from './modules/reputation/reputation.module';
 import { WebhookModule } from './modules/webhook/webhook.module';
 import { Web3Module } from './modules/web3/web3.module';
@@ -24,10 +25,11 @@ import { envValidator } from './common/config';
       envFilePath: process.env.NODE_ENV
         ? `.env.${process.env.NODE_ENV as string}`
         : '.env',
-        validationSchema: envValidator,
+      validationSchema: envValidator,
     }),
     DatabaseModule,
     HealthModule,
+    ManifestModule,
     ReputationModule,
     WebhookModule,
     Web3Module,

--- a/packages/apps/reputation-oracle/server/src/common/interfaces/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/common/interfaces/manifest.ts
@@ -1,0 +1,25 @@
+import { JobMode, JobRequestType } from '../enums';
+
+export interface IFortuneManifest {
+  submissionsRequired: number;
+  requesterTitle: string;
+  requesterDescription: string;
+  fee: string;
+  fundAmount: string;
+  requestType: JobRequestType;
+  mode: JobMode;
+}
+
+export interface ICvatManifest {
+  dataUrl: string;
+  labels: string[];
+  submissionsRequired: number;
+  requesterDescription: string;
+  requesterAccuracyTarget: number;
+  fee: string;
+  fundAmount: string;
+  requestType: JobRequestType;
+  mode: JobMode;
+}
+
+export type Manifest = IFortuneManifest | ICvatManifest;

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.controller.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test } from '@nestjs/testing';
+
+import { MOCK_ADDRESS, MOCK_MANIFEST } from '../../../test/constants';
+import { Web3Service } from '../web3/web3.service';
+import { ManifestController } from './manifest.controller';
+import { ManifestService } from './manifest.service';
+import { ChainId } from '@human-protocol/sdk';
+
+const OPERATOR_ADDRESS = 'TEST_OPERATOR_ADDRESS';
+
+const signerMock = {
+  address: OPERATOR_ADDRESS,
+  getAddress: jest.fn().mockResolvedValue(OPERATOR_ADDRESS),
+  getNetwork: jest.fn().mockResolvedValue({ chainId: 1 }),
+};
+
+describe('ManifestController', () => {
+  let manifestController: ManifestController;
+  let manifestService: ManifestService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ManifestService,
+        {
+          provide: Web3Service,
+          useValue: {
+            getSigner: jest.fn().mockReturnValue(signerMock),
+          },
+        },
+      ],
+    }).compile();
+
+    manifestService = moduleRef.get<ManifestService>(ManifestService);
+    manifestController = new ManifestController(manifestService);
+  });
+
+  describe('Get Manifest', () => {
+    it('should call service', async () => {
+      jest
+        .spyOn(manifestService, 'getManifest')
+        .mockResolvedValue(MOCK_MANIFEST);
+
+      expect(
+        await manifestController.getManifest({
+          chainId: ChainId.LOCALHOST,
+          escrowAddress: MOCK_ADDRESS,
+        }),
+      ).toBe(MOCK_MANIFEST);
+    });
+  });
+});

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Public } from '../../common/decorators';
+import { Manifest } from '../../common/interfaces/manifest';
+import { GetManifestQueryDto } from './manifest.dto';
+import { ManifestService } from './manifest.service';
+
+@Public()
+@ApiTags('Manifest')
+@Controller('manifest')
+export class ManifestController {
+  constructor(private readonly manifestService: ManifestService) {}
+
+  @Get()
+  public async getManifest(
+    @Query() query: GetManifestQueryDto,
+  ): Promise<Manifest> {
+    const { chainId, escrowAddress } = query;
+    return await this.manifestService.getManifest(chainId, escrowAddress);
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.dto.ts
@@ -1,0 +1,18 @@
+import { ChainId } from '@human-protocol/sdk';
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsEthereumAddress, IsString } from 'class-validator';
+
+export class GetManifestQueryDto {
+  @ApiProperty({
+    enum: ChainId,
+  })
+  @IsEnum(ChainId)
+  @Transform(({ value }) => Number(value))
+  public chainId: ChainId;
+
+  @ApiProperty()
+  @IsString()
+  @IsEthereumAddress()
+  public escrowAddress: string;
+}

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.module.ts
@@ -1,0 +1,13 @@
+import { Logger, Module } from '@nestjs/common';
+
+import { ManifestController } from './manifest.controller';
+import { ManifestService } from './manifest.service';
+import { Web3Module } from '../web3/web3.module';
+
+@Module({
+  imports: [Web3Module],
+  controllers: [ManifestController],
+  providers: [Logger, ManifestService],
+  exports: [ManifestService],
+})
+export class ManifestModule {}

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test } from '@nestjs/testing';
+import { ChainId, EscrowClient, StorageClient } from '@human-protocol/sdk';
+import { ethers } from 'ethers';
+import {
+  MOCK_ADDRESS,
+  MOCK_FILE_URL,
+  MOCK_MANIFEST,
+} from '../../../test/constants';
+import { Web3Service } from '../web3/web3.service';
+import { ManifestService } from './manifest.service';
+
+jest.mock('@human-protocol/sdk', () => ({
+  ...jest.requireActual('@human-protocol/sdk'),
+  EscrowClient: {
+    build: jest.fn(),
+  },
+  StorageClient: jest.fn().mockImplementation(() => ({
+    uploadFiles: jest
+      .fn()
+      .mockResolvedValue([{ url: 'UPLOADED_URL', hash: 'UPLOADED_HASH' }]),
+  })),
+}));
+
+describe('ManifestService', () => {
+  let manifestService: ManifestService, mockSigner: any;
+
+  const signerMock = {
+    address: MOCK_ADDRESS,
+    getNetwork: jest.fn().mockResolvedValue({ chainId: 1 }),
+  };
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ManifestService,
+        {
+          provide: Web3Service,
+          useValue: {
+            getSigner: jest.fn().mockReturnValue(signerMock),
+          },
+        },
+      ],
+    }).compile();
+
+    manifestService = moduleRef.get<ManifestService>(ManifestService);
+
+    const provider = new ethers.providers.JsonRpcProvider();
+    mockSigner = {
+      ...provider.getSigner(),
+      getAddress: jest.fn().mockReturnValue(ethers.constants.AddressZero),
+    };
+  });
+
+  describe('getManifest', () => {
+    it('should return manifest data', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (EscrowClient.build as any).mockImplementation(() => ({
+        getManifestUrl: jest.fn().mockResolvedValueOnce(MOCK_FILE_URL),
+      }));
+
+      StorageClient.downloadFileFromUrl = jest
+        .fn()
+        .mockResolvedValue(MOCK_MANIFEST);
+
+      const manifest = await manifestService.getManifest(
+        ChainId.LOCALHOST,
+        MOCK_ADDRESS,
+      );
+
+      expect(manifest).toEqual(MOCK_MANIFEST);
+    });
+  });
+});

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.spec.ts
@@ -29,7 +29,7 @@ describe('ManifestService', () => {
     getNetwork: jest.fn().mockResolvedValue({ chainId: 1 }),
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         ManifestService,
@@ -68,6 +68,32 @@ describe('ManifestService', () => {
       );
 
       expect(manifest).toEqual(MOCK_MANIFEST);
+    });
+
+    it('should throw error when manifest url is not found', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (EscrowClient.build as any).mockImplementation(() => ({
+        getManifestUrl: jest.fn().mockResolvedValueOnce(undefined),
+      }));
+
+      await expect(
+        manifestService.getManifest(ChainId.LOCALHOST, MOCK_ADDRESS),
+      ).rejects.toThrow('Manifest URL not found');
+    });
+
+    it('should throw error when manifest is not found', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (EscrowClient.build as any).mockImplementation(() => ({
+        getManifestUrl: jest.fn().mockResolvedValueOnce(MOCK_FILE_URL),
+      }));
+
+      StorageClient.downloadFileFromUrl = jest
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await expect(
+        manifestService.getManifest(ChainId.LOCALHOST, MOCK_ADDRESS),
+      ).rejects.toThrow('Manifest not found');
     });
   });
 });

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.ts
@@ -19,7 +19,15 @@ export class ManifestService {
 
     const manifestUrl = await escrowClient.getManifestUrl(escrowAddress);
 
+    if (!manifestUrl) {
+      throw new Error('Manifest URL not found');
+    }
+
     const manifest = await StorageClient.downloadFileFromUrl(manifestUrl);
+
+    if (!manifest) {
+      throw new Error('Manifest not found');
+    }
 
     return manifest;
   }

--- a/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/manifest/manifest.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ChainId, EscrowClient, StorageClient } from '@human-protocol/sdk';
+import { Manifest } from '../../common/interfaces/manifest';
+import { Web3Service } from '../web3/web3.service';
+
+@Injectable()
+export class ManifestService {
+  private readonly logger = new Logger(ManifestService.name);
+
+  constructor(private readonly web3Service: Web3Service) {}
+
+  public async getManifest(
+    chainId: ChainId,
+    escrowAddress: string,
+  ): Promise<Manifest> {
+    const signer = this.web3Service.getSigner(chainId);
+
+    const escrowClient = await EscrowClient.build(signer);
+
+    const manifestUrl = await escrowClient.getManifestUrl(escrowAddress);
+
+    const manifest = await StorageClient.downloadFileFromUrl(manifestUrl);
+
+    return manifest;
+  }
+}

--- a/packages/apps/reputation-oracle/server/test/constants.ts
+++ b/packages/apps/reputation-oracle/server/test/constants.ts
@@ -1,3 +1,6 @@
+import { JobMode, JobRequestType } from '../src/common/enums';
+import { IFortuneManifest } from '../src/common/interfaces/manifest';
+
 export const MOCK_REQUESTER_TITLE = 'Mock job title';
 export const MOCK_REQUESTER_DESCRIPTION = 'Mock job description';
 export const MOCK_ADDRESS = '0x1234567890abcdef';
@@ -8,3 +11,12 @@ export const MOCK_LABEL = 'contains burnt area';
 export const MOCK_JOB_LAUNCHER_FEE = 5;
 export const MOCK_RECORDING_ORACLE_FEE = 5;
 export const MOCK_REPUTATION_ORACLE_FEE = 5;
+export const MOCK_MANIFEST: IFortuneManifest = {
+  submissionsRequired: 2,
+  requesterTitle: 'Fortune',
+  requesterDescription: 'Some desc',
+  fee: '20',
+  fundAmount: '8',
+  requestType: JobRequestType.FORTUNE,
+  mode: JobMode.DESCRIPTIVE,
+};

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -146,8 +146,7 @@ class EscrowClient:
         # Initialize web3 instance
         self.w3 = web3
         if not self.w3.middleware_onion.get("geth_poa"):
-            self.w3.middleware_onion.inject(
-                geth_poa_middleware, "geth_poa", layer=0)
+            self.w3.middleware_onion.inject(geth_poa_middleware, "geth_poa", layer=0)
 
         # Load network configuration based on chainId
         try:
@@ -216,8 +215,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -275,16 +273,14 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if 0 >= amount:
             raise EscrowClientError("Amount must be positive")
 
         token_address = self.get_token_address(escrow_address)
 
         erc20_interface = get_erc20_interface()
-        token_contract = self.w3.eth.contract(
-            token_address, abi=erc20_interface["abi"])
+        token_contract = self.w3.eth.contract(token_address, abi=erc20_interface["abi"])
 
         handle_transaction(
             self.w3,
@@ -309,8 +305,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if not hash:
             raise EscrowClientError("Invalid empty hash")
         if not URL(url):
@@ -321,8 +316,7 @@ class EscrowClient:
         handle_transaction(
             self.w3,
             "Store Results",
-            self._get_escrow_contract(
-                escrow_address).functions.storeResults(url, hash),
+            self._get_escrow_contract(escrow_address).functions.storeResults(url, hash),
             EscrowClientError,
         )
 
@@ -340,8 +334,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -377,12 +370,10 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         for recipient in recipients:
             if not Web3.isAddress(recipient):
-                raise EscrowClientError(
-                    f"Invalid recipient address: {recipient}")
+                raise EscrowClientError(f"Invalid recipient address: {recipient}")
         if len(recipients) == 0:
             raise EscrowClientError("Arrays must have any value")
         if len(recipients) != len(amounts):
@@ -398,8 +389,7 @@ class EscrowClient:
                 f"Escrow does not have enough balance. Current balance: {balance}. Amounts: {total_amount}"
             )
         if not URL(final_results_url):
-            raise EscrowClientError(
-                f"Invalid final results URL: {final_results_url}")
+            raise EscrowClientError(f"Invalid final results URL: {final_results_url}")
         if not final_results_hash:
             raise EscrowClientError("Invalid empty final results hash")
 
@@ -426,8 +416,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -450,8 +439,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -474,8 +462,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         for handler in handlers:
             if not Web3.isAddress(handler):
                 raise EscrowClientError(f"Invalid handler address: {handler}")
@@ -503,8 +490,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.getBalance().call()
 
@@ -522,8 +508,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.manifestUrl().call()
 
@@ -541,12 +526,10 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
-            self._get_escrow_contract(
-                escrow_address).functions.finalResultsUrl().call()
+            self._get_escrow_contract(escrow_address).functions.finalResultsUrl().call()
         )
 
     def get_intermediate_results_url(self, escrow_address: str) -> str:
@@ -563,8 +546,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
             self._get_escrow_contract(escrow_address)
@@ -586,8 +568,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.token().call()
 
@@ -605,8 +586,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return Status(
             self._get_escrow_contract(escrow_address).functions.status().call()
@@ -659,16 +639,12 @@ class EscrowClient:
                 }}
             }}
             """.format(
-                """from:"{0}",""".format(
-                    filter.address) if filter.address else "",
-                """status:"{0}",""".format(
-                    filter.status.name) if filter.status else "",
-                """timestamp_gte:"{0}",""".format(
-                    int(filter.date_from.timestamp()))
+                """from:"{0}",""".format(filter.address) if filter.address else "",
+                """status:"{0}",""".format(filter.status.name) if filter.status else "",
+                """timestamp_gte:"{0}",""".format(int(filter.date_from.timestamp()))
                 if filter.date_from
                 else "",
-                """timestamp_lte:"{0}",""".format(
-                    int(filter.date_to.timestamp()))
+                """timestamp_lte:"{0}",""".format(int(filter.date_to.timestamp()))
                 if filter.date_to
                 else "",
             ),
@@ -691,12 +667,10 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
-            self._get_escrow_contract(
-                escrow_address).functions.recordingOracle().call()
+            self._get_escrow_contract(escrow_address).functions.recordingOracle().call()
         )
 
     def get_reputation_oracle_address(self, escrow_address: str) -> str:
@@ -713,8 +687,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
             self._get_escrow_contract(escrow_address)
@@ -736,14 +709,9 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
-        return (
-            self._get_escrow_contract(escrow_address)
-            .functions.canceler()
-            .call()
-        )
+        return self._get_escrow_contract(escrow_address).functions.canceler().call()
 
     def _get_escrow_contract(self, address: str) -> contract:
         """Returns the escrow contract instance.
@@ -757,8 +725,7 @@ class EscrowClient:
         """
 
         if not self.factory_contract.functions.hasEscrow(address):
-            raise EscrowClientError(
-                "Escrow address is not provided by the factory")
+            raise EscrowClientError("Escrow address is not provided by the factory")
         # Initialize contract instance
         escrow_interface = get_escrow_interface()
         return self.w3.eth.contract(address=address, abi=escrow_interface["abi"])

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/legacy_encryption.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/legacy_encryption.py
@@ -146,7 +146,7 @@ class Encryption:
             raise DecryptionError("wrong ecies header")
 
         #  1) generate shared-secret = kdf( ecdhAgree(myPrivKey, msg[1:65]) )
-        shared = data[1: 1 + self.PUBLIC_KEY_LEN]
+        shared = data[1 : 1 + self.PUBLIC_KEY_LEN]
 
         try:
             key_material = self._process_key_exchange(
@@ -163,12 +163,11 @@ class Encryption:
         key_enc, key_mac = key[:k_len], key[k_len:]
 
         key_mac = hashlib.sha256(key_mac).digest()
-        tag = data[-self.KEY_LEN:]
+        tag = data[-self.KEY_LEN :]
 
         # 2) Verify tag
         expected_tag = self._hmac_sha256(
-            key_mac, data[1 + self.PUBLIC_KEY_LEN: -
-                          self.KEY_LEN] + shared_mac_data
+            key_mac, data[1 + self.PUBLIC_KEY_LEN : -self.KEY_LEN] + shared_mac_data
         )
 
         # Whether same tag byte
@@ -180,10 +179,10 @@ class Encryption:
         block_size = algo.block_size // 8
 
         data_start = 1 + self.PUBLIC_KEY_LEN
-        data_slice = data[data_start: data_start + block_size]
+        data_slice = data[data_start : data_start + block_size]
 
         cipher_context = Cipher(algo, self.MODE(data_slice)).decryptor()
-        ciphertext = data[data_start + block_size: -self.KEY_LEN]
+        ciphertext = data[data_start + block_size : -self.KEY_LEN]
 
         return cipher_context.update(ciphertext) + cipher_context.finalize()
 
@@ -216,8 +215,7 @@ class Encryption:
                 that they derive the same key material
         """ ""
         private_key_int = int(t.cast(int, private_key))
-        ec_private_key = ec.derive_private_key(
-            private_key_int, self.ELLIPTIC_CURVE)
+        ec_private_key = ec.derive_private_key(private_key_int, self.ELLIPTIC_CURVE)
 
         public_key_bytes = b"\x04" + public_key.to_bytes()
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_encryption.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_encryption.py
@@ -10,7 +10,7 @@ from test.human_protocol_sdk.utils.encryption import (
     passphrase,
     signed_message,
     encrypted_unsigned_message,
-    message
+    message,
 )
 
 from human_protocol_sdk.encryption import Encryption, EncryptionUtils
@@ -28,8 +28,7 @@ class TestEncryption(unittest.TestCase):
     def test_locked_private_key(self):
         with self.assertRaises(ValueError) as cm:
             Encryption(private_key3)
-        self.assertEqual(
-            f"Private key locked. Passphrase needed", str(cm.exception))
+        self.assertEqual(f"Private key locked. Passphrase needed", str(cm.exception))
 
     def test_locked_private_key_with_wrong_passphrase(self):
         with self.assertRaises(PGPDecryptionError) as cm:
@@ -41,8 +40,7 @@ class TestEncryption(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             Encryption(invalid_private_key)
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))
 
     def test_encrypt(self):
         encryption = Encryption(private_key)
@@ -59,8 +57,7 @@ class TestEncryption(unittest.TestCase):
         self.assertIsInstance(encrypted_message, str)
 
     def test_encrypt_unsigned_message(self):
-        encrypted_message = EncryptionUtils.encrypt(
-            message, [public_key2, public_key3])
+        encrypted_message = EncryptionUtils.encrypt(message, [public_key2, public_key3])
         self.assertIsInstance(encrypted_message, str)
 
     def test_decrypt(self):
@@ -113,15 +110,13 @@ class TestEncryption(unittest.TestCase):
     def test_verify_invalid_signature(self):
         with self.assertRaises(ValueError) as cm:
             EncryptionUtils.verify(message, public_key)
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))
 
     def test_verify_invalid_public_key(self):
         invalid_public_key = """invalid_public_key"""
         with self.assertRaises(ValueError) as cm:
             EncryptionUtils.verify(signed_message, invalid_public_key)
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))
 
     def test_get_signed_data(self):
         result = EncryptionUtils.get_signed_data(signed_message)
@@ -130,5 +125,4 @@ class TestEncryption(unittest.TestCase):
     def test_get_signed_data_invalid_message(self):
         with self.assertRaises(ValueError) as cm:
             EncryptionUtils.get_signed_data("Invalid message")
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Exchange oracle needs to call reputation oracle manifest endpoint to get manifest data.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- New module `Manifest` is added to the reputation oracle.
- Relevant test cases are added.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #655 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
