### PR TITLE
Add exception type annotations in fortune launcher

### DIFF
--- a/packages/examples/fortune/launcher/server/src/routes/payments.ts
+++ b/packages/examples/fortune/launcher/server/src/routes/payments.ts
@@ -41,7 +41,7 @@ export const createFiatPayment: FastifyPluginAsync = async (server) => {
       const { stripe } = server;
       try {
         return JSON.stringify({ publishableKey: stripe.publishableKey });
-      } catch (e) {
+      } catch (e: any) {
         return reply.status(400).send(e.message);
       }
     }
@@ -76,7 +76,7 @@ export const createFiatPayment: FastifyPluginAsync = async (server) => {
             fiatData?.paymentMethodOptions as Stripe.PaymentIntentCreateParams.PaymentMethodOptions
           )
         );
-      } catch (e) {
+      } catch (e: any) {
         return reply.status(400).send(e.message);
       }
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

While trying to run the local example I've faced several compilation problems in Launcher, preventing it's from starting.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

Added several type annotations for captured exceptions in the Launcher for the Fortune example.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

```bash
cd packages/examples/fortune
nvm use lts/hydrogen # > Now using node v18.16.1 (npm v9.5.1)
yarn
yarn start:local
```

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
