### PR TITLE
[Reputation Oracle] Removed job mode type

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/enums/job.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/job.ts
@@ -1,8 +1,3 @@
-export enum JobMode {
-  BATCH = 'BATCH',
-  DESCRIPTIVE = 'DESCRIPTIVE',
-}
-
 export enum JobRequestType {
   IMAGE_LABEL_BINARY = 'IMAGE_LABEL_BINARY',
   FORTUNE = 'FORTUNE',

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.dto.ts
@@ -9,7 +9,7 @@ import {
 } from 'class-validator';
 import { WebhookStatus } from '../../common/enums';
 import { ChainId } from '@human-protocol/sdk';
-import { JobMode, JobRequestType } from '../../common/enums';
+import { JobRequestType } from '../../common/enums';
 
 export class WebhookIncomingDto {
   @ApiProperty()
@@ -71,7 +71,6 @@ export class ManifestDto {
   fee: string;
   fundAmount: string;
   requestType: JobRequestType;
-  mode: JobMode;
 }
 
 export class FortuneFinalResult {

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -25,7 +25,7 @@ import {
   ErrorResults,
   ErrorWebhook,
 } from '../../common/constants/errors';
-import { JobMode, JobRequestType } from '../../common/enums';
+import { JobRequestType } from '../../common/enums';
 import {
   MOCK_ADDRESS,
   MOCK_FILE_HASH,
@@ -181,7 +181,6 @@ describe('WebhookService', () => {
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
       fee: totalFee.toString(),
       fundAmount: totalAmount.toString(),
-      mode: JobMode.DESCRIPTIVE,
     };
 
     const webhookEntity: Partial<WebhookIncomingEntity> = {
@@ -343,7 +342,6 @@ describe('WebhookService', () => {
       requesterAccuracyTarget: 10,
       fee: totalFee.toString(),
       fundAmount: totalAmount.toString(),
-      mode: JobMode.BATCH,
     };
 
     const webhookEntity: Partial<WebhookIncomingEntity> = {
@@ -498,7 +496,6 @@ describe('WebhookService', () => {
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
       fee: totalFee.toString(),
       fundAmount: totalAmount.toString(),
-      mode: JobMode.DESCRIPTIVE,
     };
 
     const webhookEntity: Partial<WebhookIncomingEntity> = {

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -146,8 +146,7 @@ class EscrowClient:
         # Initialize web3 instance
         self.w3 = web3
         if not self.w3.middleware_onion.get("geth_poa"):
-            self.w3.middleware_onion.inject(
-                geth_poa_middleware, "geth_poa", layer=0)
+            self.w3.middleware_onion.inject(geth_poa_middleware, "geth_poa", layer=0)
 
         # Load network configuration based on chainId
         try:
@@ -216,8 +215,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -275,16 +273,14 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if 0 >= amount:
             raise EscrowClientError("Amount must be positive")
 
         token_address = self.get_token_address(escrow_address)
 
         erc20_interface = get_erc20_interface()
-        token_contract = self.w3.eth.contract(
-            token_address, abi=erc20_interface["abi"])
+        token_contract = self.w3.eth.contract(token_address, abi=erc20_interface["abi"])
 
         handle_transaction(
             self.w3,
@@ -309,8 +305,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if not hash:
             raise EscrowClientError("Invalid empty hash")
         if not URL(url):
@@ -321,8 +316,7 @@ class EscrowClient:
         handle_transaction(
             self.w3,
             "Store Results",
-            self._get_escrow_contract(
-                escrow_address).functions.storeResults(url, hash),
+            self._get_escrow_contract(escrow_address).functions.storeResults(url, hash),
             EscrowClientError,
         )
 
@@ -340,8 +334,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -377,12 +370,10 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         for recipient in recipients:
             if not Web3.isAddress(recipient):
-                raise EscrowClientError(
-                    f"Invalid recipient address: {recipient}")
+                raise EscrowClientError(f"Invalid recipient address: {recipient}")
         if len(recipients) == 0:
             raise EscrowClientError("Arrays must have any value")
         if len(recipients) != len(amounts):
@@ -398,8 +389,7 @@ class EscrowClient:
                 f"Escrow does not have enough balance. Current balance: {balance}. Amounts: {total_amount}"
             )
         if not URL(final_results_url):
-            raise EscrowClientError(
-                f"Invalid final results URL: {final_results_url}")
+            raise EscrowClientError(f"Invalid final results URL: {final_results_url}")
         if not final_results_hash:
             raise EscrowClientError("Invalid empty final results hash")
 
@@ -426,8 +416,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -450,8 +439,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
             self.w3,
@@ -474,8 +462,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         for handler in handlers:
             if not Web3.isAddress(handler):
                 raise EscrowClientError(f"Invalid handler address: {handler}")
@@ -503,8 +490,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.getBalance().call()
 
@@ -522,8 +508,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.manifestUrl().call()
 
@@ -541,12 +526,10 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
-            self._get_escrow_contract(
-                escrow_address).functions.finalResultsUrl().call()
+            self._get_escrow_contract(escrow_address).functions.finalResultsUrl().call()
         )
 
     def get_intermediate_results_url(self, escrow_address: str) -> str:
@@ -563,8 +546,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
             self._get_escrow_contract(escrow_address)
@@ -586,8 +568,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.token().call()
 
@@ -605,8 +586,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return Status(
             self._get_escrow_contract(escrow_address).functions.status().call()
@@ -659,16 +639,12 @@ class EscrowClient:
                 }}
             }}
             """.format(
-                """from:"{0}",""".format(
-                    filter.address) if filter.address else "",
-                """status:"{0}",""".format(
-                    filter.status.name) if filter.status else "",
-                """timestamp_gte:"{0}",""".format(
-                    int(filter.date_from.timestamp()))
+                """from:"{0}",""".format(filter.address) if filter.address else "",
+                """status:"{0}",""".format(filter.status.name) if filter.status else "",
+                """timestamp_gte:"{0}",""".format(int(filter.date_from.timestamp()))
                 if filter.date_from
                 else "",
-                """timestamp_lte:"{0}",""".format(
-                    int(filter.date_to.timestamp()))
+                """timestamp_lte:"{0}",""".format(int(filter.date_to.timestamp()))
                 if filter.date_to
                 else "",
             ),
@@ -691,12 +667,10 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
-            self._get_escrow_contract(
-                escrow_address).functions.recordingOracle().call()
+            self._get_escrow_contract(escrow_address).functions.recordingOracle().call()
         )
 
     def get_reputation_oracle_address(self, escrow_address: str) -> str:
@@ -713,8 +687,7 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
             self._get_escrow_contract(escrow_address)
@@ -736,14 +709,9 @@ class EscrowClient:
         """
 
         if not Web3.isAddress(escrow_address):
-            raise EscrowClientError(
-                f"Invalid escrow address: {escrow_address}")
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
-        return (
-            self._get_escrow_contract(escrow_address)
-            .functions.canceler()
-            .call()
-        )
+        return self._get_escrow_contract(escrow_address).functions.canceler().call()
 
     def _get_escrow_contract(self, address: str) -> contract:
         """Returns the escrow contract instance.
@@ -757,8 +725,7 @@ class EscrowClient:
         """
 
         if not self.factory_contract.functions.hasEscrow(address):
-            raise EscrowClientError(
-                "Escrow address is not provided by the factory")
+            raise EscrowClientError("Escrow address is not provided by the factory")
         # Initialize contract instance
         escrow_interface = get_escrow_interface()
         return self.w3.eth.contract(address=address, abi=escrow_interface["abi"])

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/legacy_encryption.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/legacy_encryption.py
@@ -146,7 +146,7 @@ class Encryption:
             raise DecryptionError("wrong ecies header")
 
         #  1) generate shared-secret = kdf( ecdhAgree(myPrivKey, msg[1:65]) )
-        shared = data[1: 1 + self.PUBLIC_KEY_LEN]
+        shared = data[1 : 1 + self.PUBLIC_KEY_LEN]
 
         try:
             key_material = self._process_key_exchange(
@@ -163,12 +163,11 @@ class Encryption:
         key_enc, key_mac = key[:k_len], key[k_len:]
 
         key_mac = hashlib.sha256(key_mac).digest()
-        tag = data[-self.KEY_LEN:]
+        tag = data[-self.KEY_LEN :]
 
         # 2) Verify tag
         expected_tag = self._hmac_sha256(
-            key_mac, data[1 + self.PUBLIC_KEY_LEN: -
-                          self.KEY_LEN] + shared_mac_data
+            key_mac, data[1 + self.PUBLIC_KEY_LEN : -self.KEY_LEN] + shared_mac_data
         )
 
         # Whether same tag byte
@@ -180,10 +179,10 @@ class Encryption:
         block_size = algo.block_size // 8
 
         data_start = 1 + self.PUBLIC_KEY_LEN
-        data_slice = data[data_start: data_start + block_size]
+        data_slice = data[data_start : data_start + block_size]
 
         cipher_context = Cipher(algo, self.MODE(data_slice)).decryptor()
-        ciphertext = data[data_start + block_size: -self.KEY_LEN]
+        ciphertext = data[data_start + block_size : -self.KEY_LEN]
 
         return cipher_context.update(ciphertext) + cipher_context.finalize()
 
@@ -216,8 +215,7 @@ class Encryption:
                 that they derive the same key material
         """ ""
         private_key_int = int(t.cast(int, private_key))
-        ec_private_key = ec.derive_private_key(
-            private_key_int, self.ELLIPTIC_CURVE)
+        ec_private_key = ec.derive_private_key(private_key_int, self.ELLIPTIC_CURVE)
 
         public_key_bytes = b"\x04" + public_key.to_bytes()
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_encryption.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_encryption.py
@@ -10,7 +10,7 @@ from test.human_protocol_sdk.utils.encryption import (
     passphrase,
     signed_message,
     encrypted_unsigned_message,
-    message
+    message,
 )
 
 from human_protocol_sdk.encryption import Encryption, EncryptionUtils
@@ -28,8 +28,7 @@ class TestEncryption(unittest.TestCase):
     def test_locked_private_key(self):
         with self.assertRaises(ValueError) as cm:
             Encryption(private_key3)
-        self.assertEqual(
-            f"Private key locked. Passphrase needed", str(cm.exception))
+        self.assertEqual(f"Private key locked. Passphrase needed", str(cm.exception))
 
     def test_locked_private_key_with_wrong_passphrase(self):
         with self.assertRaises(PGPDecryptionError) as cm:
@@ -41,8 +40,7 @@ class TestEncryption(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             Encryption(invalid_private_key)
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))
 
     def test_encrypt(self):
         encryption = Encryption(private_key)
@@ -59,8 +57,7 @@ class TestEncryption(unittest.TestCase):
         self.assertIsInstance(encrypted_message, str)
 
     def test_encrypt_unsigned_message(self):
-        encrypted_message = EncryptionUtils.encrypt(
-            message, [public_key2, public_key3])
+        encrypted_message = EncryptionUtils.encrypt(message, [public_key2, public_key3])
         self.assertIsInstance(encrypted_message, str)
 
     def test_decrypt(self):
@@ -113,15 +110,13 @@ class TestEncryption(unittest.TestCase):
     def test_verify_invalid_signature(self):
         with self.assertRaises(ValueError) as cm:
             EncryptionUtils.verify(message, public_key)
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))
 
     def test_verify_invalid_public_key(self):
         invalid_public_key = """invalid_public_key"""
         with self.assertRaises(ValueError) as cm:
             EncryptionUtils.verify(signed_message, invalid_public_key)
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))
 
     def test_get_signed_data(self):
         result = EncryptionUtils.get_signed_data(signed_message)
@@ -130,5 +125,4 @@ class TestEncryption(unittest.TestCase):
     def test_get_signed_data_invalid_message(self):
         with self.assertRaises(ValueError) as cm:
             EncryptionUtils.get_signed_data("Invalid message")
-        self.assertEqual(f"Expected: ASCII-armored PGP data",
-                         str(cm.exception))
+        self.assertEqual(f"Expected: ASCII-armored PGP data", str(cm.exception))


### PR DESCRIPTION
## Description
Deprecated [JobMode enum type](https://github.com/humanprotocol/human-protocol/blob/0dc320f95b5d96227e198c9fe3e620a3c548c9d2/packages/apps/reputation-oracle/server/src/common/enums/job.ts#L1) and related data because It is no longer up to date and used.

## Summary of changes
- Removed JobMode enum type
- Updated manifest 
- Updated tests

## How test the changes
`yarn test`

## Related issues
[[Reputation Oracle] - Deprecate JobMode enum type and related data#685](https://github.com/humanprotocol/human-protocol/issues/685)