### PR TITLE
[Fortune] [Exchange oracle] Get manifest data from reputation oracle

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/config/env.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/config/env.ts
@@ -4,6 +4,7 @@ export const ConfigNames = {
   HOST: 'HOST',
   PORT: 'PORT',
   WEB3_PRIVATE_KEY: 'WEB3_PRIVATE_KEY',
+  REPUTATION_ORACLE_URL: 'REPUTATION_ORACLE_URL',
 };
 
 export const envValidator = Joi.object({

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { JobController } from './job.controller';
 import { JobService } from './job.service';
@@ -14,11 +15,20 @@ describe('JobController', () => {
   const escrowAddress = '0x1234567890123456789012345678901234567890';
   const workerAddress = '0x1234567890123456789012345678901234567891';
 
+  const reputationOracleURL = 'https://example.com/reputationoracle';
+  const configServiceMock = {
+    get: jest.fn().mockReturnValue(reputationOracleURL),
+  };
+
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [JobController],
       providers: [
         JobService,
+        {
+          provide: ConfigService,
+          useValue: configServiceMock,
+        },
         {
           provide: Web3Service,
           useValue: {

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.module.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { JobController } from './job.controller';
 import { JobService } from './job.service';
 import { HttpModule } from '@nestjs/axios';
 import { Web3Module } from '../web3/web3.module';
 
 @Module({
-  imports: [HttpModule, Web3Module],
+  imports: [ConfigModule, HttpModule, Web3Module],
   controllers: [JobController],
   providers: [JobService],
 })

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -33,7 +33,7 @@ export class JobService {
     const kvstore = await KVStoreClient.build(signer);
     const reputationOracleURL = await kvstore.get(
       reputationOracleAddress,
-      KVStoreKeys.webhook_url,
+      KVStoreKeys.url,
     );
 
     if (!reputationOracleURL)

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -6,6 +6,8 @@ import {
 } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ConfigNames } from '../../common/config';
 import { Web3Service } from '../web3/web3.service';
 import { JobDetailsDto } from './job.dto';
 
@@ -17,6 +19,7 @@ export class JobService {
   } = {};
 
   constructor(
+    private readonly configService: ConfigService,
     @Inject(Web3Service)
     private readonly web3Service: Web3Service,
     private readonly httpService: HttpService,
@@ -26,14 +29,8 @@ export class JobService {
     chainId: number,
     escrowAddress: string,
   ): Promise<JobDetailsDto> {
-    const signer = this.web3Service.getSigner(chainId);
-    const escrowClient = await EscrowClient.build(signer);
-    const reputationOracleAddress =
-      await escrowClient.getReputationOracleAddress(escrowAddress);
-    const kvstore = await KVStoreClient.build(signer);
-    const reputationOracleURL = await kvstore.get(
-      reputationOracleAddress,
-      KVStoreKeys.url,
+    const reputationOracleURL = this.configService.get(
+      ConfigNames.REPUTATION_ORACLE_URL,
     );
 
     if (!reputationOracleURL)

--- a/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
@@ -242,4 +242,5 @@ export const KVStoreKeys = {
   webhook_url: 'webhook_url',
   fee: 'fee',
   public_key: 'public_key',
+  url: 'url',
 };

--- a/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
@@ -242,5 +242,4 @@ export const KVStoreKeys = {
   webhook_url: 'webhook_url',
   fee: 'fee',
   public_key: 'public_key',
-  url: 'url',
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Exchange Oracle should get the manifest from Reputation Oracle instead of pulling it from s3 bucket directly.

## Summary of changes
- Reputation Oracle URL is loaded from env variable.
- Added a http request to reputation endpoint to get manifest.
- Updated test cases.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #656 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
