### PR TITLE
[Monorepo] Fix: Husky pre-commit to run black formatting when python file is changed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,12 @@
 
 npx lint-staged
 
-cd packages/sdk/python
-cd human-protocol-sdk && make format && git add . -u
-cd ../../../
-
+# Format python file changes
+cd packages/sdk/python/human-protocol-sdk
+diff=$(git diff --cached --name-only --diff-filter=ACM .)
+if [ -n "$diff" ]; then
+  echo "Running black on python files"
+  make format
+  git add . -u
+fi
+cd ../../../../


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Now, pre-commit runs black formatting of python files, even if they are not changed in the commit. This needs to be fixed, so that it should be called, only when python file is changed in the commit.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Fixed `pre-commit` bash script, to check if python file is changed before running black formatting.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
