### PR TITLE
[Job Launcher] Added fix for get rate route

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
@@ -62,7 +62,7 @@ export class PaymentController {
   @Get('/rates')
   public async getRate(@Query() data: GetRateDto): Promise<number> {
     try {
-      return this.currencyService.getRate(data.token, data.currency);
+      return this.currencyService.getRate(data.currency, data.token);
     } catch (e) {
       throw new Error(e);
     }

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
@@ -50,8 +50,10 @@ export class PaymentCreateDto {
 }
 
 export class GetRateDto {
-  @ApiProperty()
-  @IsString()
+  @ApiProperty({
+    enum: TokenId,
+  })
+  @IsEnum(TokenId)
   public token: TokenId;
 
   @ApiProperty({


### PR DESCRIPTION
## Description
**Describe the bug**
Fixed behaviour, when we send request to `/payment/rates` endpoint we receive a rate for a pair, we got a 404 response, now we receive correct rate value.

## How test the changes
`GET /payment/rates` - hmt:usd

## Related issues
[[Job Launcher] Fix 404 for /payment/rates endpoint#717](https://github.com/humanprotocol/human-protocol/issues/717)
