### PR TITLE
Added get user balance with tests

### DIFF
--- a/packages/apps/job-launcher/server/src/common/interfaces/user.ts
+++ b/packages/apps/job-launcher/server/src/common/interfaces/user.ts
@@ -1,3 +1,4 @@
+import { Currency } from '../enums/payment';
 import { UserStatus, UserType } from '../enums/user';
 import { IBase } from './base';
 
@@ -6,4 +7,9 @@ export interface IUser extends IBase {
   email: string;
   status: UserStatus;
   type: UserType;
+}
+
+export interface IUserBalance {
+  amount: number;
+  currency: Currency;
 }

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.service.spec.ts
@@ -6,7 +6,7 @@ import { HttpService } from '@nestjs/axios';
 import { createMock } from '@golevelup/ts-jest';
 import { UserRepository } from '../user/user.repository';
 import { JwtService } from '@nestjs/jwt';
-import { Repository, UpdateResult } from 'typeorm';
+import { Repository } from 'typeorm';
 import { AuthEntity } from './auth.entity';
 import { UserService } from '../user/user.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -19,6 +19,7 @@ import { AuthStatus } from '../../common/enums/auth';
 import { IJwt } from '../../common/interfaces/auth';
 import { TokenType } from './token.entity';
 import { v4 } from 'uuid';
+import { PaymentService } from '../payment/payment.service';
 
 
 jest.mock('@human-protocol/sdk');
@@ -65,6 +66,7 @@ describe('AuthService', () => {
         { provide: UserRepository, useValue: createMock<UserRepository>() },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: HttpService, useValue: createMock<HttpService>() },
+        { provide: PaymentService, useValue: createMock<PaymentService>() },
       ],
     }).compile();
 

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
@@ -275,7 +275,7 @@ export class PaymentService {
         finalAmount = finalAmount.add(amount);
       }
     });
-    
+
     return finalAmount;
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/user/user.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/user/user.controller.ts
@@ -1,7 +1,24 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Query, Request, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { RolesGuard } from '../../common/guards';
+import { UserService } from './user.service';
+import { IUserBalance } from '../../common/interfaces';
 
 @ApiBearerAuth()
 @ApiTags('User')
 @Controller('/user')
-export class UserController {}
+export class UserController {
+    constructor(
+        private readonly userService: UserService,
+    ) {}
+
+    @UseGuards(RolesGuard)
+    @Get('/balance')
+    public async getBalance(@Request() req: any): Promise<IUserBalance> {
+        try {
+            return this.userService.getBalance(req.user?.id);
+        } catch (e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/packages/apps/job-launcher/server/src/modules/user/user.module.ts
+++ b/packages/apps/job-launcher/server/src/modules/user/user.module.ts
@@ -7,9 +7,10 @@ import { UserEntity } from './user.entity';
 import { UserController } from './user.controller';
 import { AuthEntity } from '../auth/auth.entity';
 import { UserRepository } from './user.repository';
+import { PaymentModule } from '../payment/payment.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity, AuthEntity]), ConfigModule],
+  imports: [TypeOrmModule.forFeature([UserEntity, AuthEntity]), ConfigModule, PaymentModule],
   controllers: [UserController],
   providers: [Logger, UserService, UserRepository],
   exports: [UserService],

--- a/packages/apps/job-launcher/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/user/user.service.spec.ts
@@ -10,6 +10,9 @@ import { UserService } from './user.service';
 import { UserCreateDto, UserUpdateDto } from './user.dto';
 import { UserEntity } from './user.entity';
 import { UserStatus, UserType } from '../../common/enums/user';
+import { ethers } from 'ethers';
+import { IUserBalance } from '../../common/interfaces';
+import { Currency } from '../../common/enums/payment';
 
 const PASSWORD_SECRET = '$2b$10$EICgM2wYixoJisgqckU9gu';
 
@@ -17,6 +20,7 @@ jest.mock('@human-protocol/sdk');
 
 describe('UserService', () => {
   let userService: UserService;
+  let paymentService: PaymentService;
   let userRepository: UserRepository;
   let configService: ConfigService;
   let httpService: HttpService;
@@ -45,6 +49,7 @@ describe('UserService', () => {
     userRepository = moduleRef.get(UserRepository);
     configService = moduleRef.get(ConfigService);
     httpService = moduleRef.get(HttpService);
+    paymentService = moduleRef.get(PaymentService);
   });
 
   describe('update', () => {
@@ -175,6 +180,23 @@ describe('UserService', () => {
         email,
         password: 'hashedPassword',
       });
+    });
+  });
+
+  describe('getBalance', () => {  
+    it('should return the correct balance with currency for a user', async () => {
+      const userId = 1;
+      const expectedBalance: IUserBalance = {
+        amount: 10, // ETH
+        currency: Currency.USD
+      }
+
+      jest.spyOn(paymentService, 'getUserBalance').mockResolvedValue(ethers.utils.parseUnits('10', 'ether'));
+  
+      const balance = await userService.getBalance(userId);
+  
+      expect(balance).toEqual(expectedBalance);
+      expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
     });
   });
 });

--- a/packages/apps/job-launcher/server/src/modules/user/user.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/user/user.service.ts
@@ -15,6 +15,10 @@ import { UserRepository } from './user.repository';
 import { ValidatePasswordDto } from '../auth/auth.dto';
 import { ErrorUser } from '../../common/constants/errors';
 import { ConfigNames } from '../../common/config';
+import { PaymentService } from '../payment/payment.service';
+import { ethers } from 'ethers';
+import { IUserBalance } from '../../common/interfaces';
+import { Currency } from '../../common/enums/payment';
 
 @Injectable()
 export class UserService {
@@ -23,6 +27,7 @@ export class UserService {
   constructor(
     private userRepository: UserRepository,
     private readonly configService: ConfigService,
+    private readonly paymentService: PaymentService,
   ) {}
 
   public async update(userId: number, dto: UserUpdateDto): Promise<UserEntity> {
@@ -92,6 +97,15 @@ export class UserService {
     if (userEntity) {
       this.logger.log(ErrorUser.AccountCannotBeRegistered, UserService.name);
       throw new ConflictException(ErrorUser.AccountCannotBeRegistered);
+    }
+  }
+
+  public async getBalance(userId: number): Promise<IUserBalance> {
+    const balance = await this.paymentService.getUserBalance(userId);
+
+    return {
+      amount: Number(ethers.utils.formatUnits(balance, 'ether')),
+      currency: Currency.USD
     }
   }
 }


### PR DESCRIPTION
## Description
Added the ability to get a custom balance by calling an `GET user/balance` endpoint.

## Summary of changes
- Added new `GET user/balance` endpoint
- Added get balance service method
- Added payment service unit tests
- Added user service unit tests
- Added request to update documentation

## How test the changes
`GET /user/balance`
`yarn test`

## Related issues
[[Job Launcher] Create GET /user/balance endpoint#719](https://github.com/humanprotocol/human-protocol/issues/719)