### PR TITLE
[SDK] Fixed contract address in KVStoreClient

### DIFF
--- a/packages/sdk/typescript/human-protocol-sdk/src/kvstore.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/kvstore.ts
@@ -30,7 +30,7 @@ export class KVStoreClient {
    */
   constructor(signerOrProvider: Signer | Provider, network: NetworkData) {
     this.contract = KVStore__factory.connect(
-      network.factoryAddress,
+      network.kvstoreAddress,
       signerOrProvider
     );
     this.signerOrProvider = signerOrProvider;


### PR DESCRIPTION
## Description
In the constructor, the address of the EscrowFactory was specified, and not the address of the KVStore storage, for this reason, requests to the contract fell with an Ethereum error. 

## Summary of changes
Correct contract address in the constructor was set.

## How test the changes
`yarn test`

## Related issues
[[SDK] Fix contract address in KVStoreClient constructor#722](https://github.com/humanprotocol/human-protocol/issues/722)