### PR TITLE
[Fortune] [Job Launcher] download result endpoint

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -8,6 +8,7 @@ export enum ErrorJob {
   ManifestNotFound = 'Manifest not found',
   ManifestValidationFailed = 'Manifest validation failed',
   WebhookWasNotSent = 'Webhook was not sent',
+  ResultNotFound = 'Result not found',
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -9,6 +9,7 @@ export enum ErrorJob {
   ManifestValidationFailed = 'Manifest validation failed',
   WebhookWasNotSent = 'Webhook was not sent',
   ResultNotFound = 'Result not found',
+  ResultValidationFailed = 'Result validation failed',
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { RolesGuard } from '../../common/guards';
 import { JobCvatDto, JobFortuneDto } from './job.dto';
@@ -26,5 +33,11 @@ export class JobController {
     @Body() data: JobCvatDto,
   ): Promise<number> {
     return this.jobService.createCvatJob(req.user?.id, data);
+  }
+
+  @UseGuards(RolesGuard)
+  @Get('/result')
+  public async getResult(@Request() req: any): Promise<any> {
+    return this.jobService.getResult(req.user?.id);
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -177,3 +177,28 @@ export class ImageLabelBinaryManifestDto {
   @IsEnum(JobRequestType)
   requestType: JobRequestType;
 }
+
+export class FortuneFinalResultDto {
+  @IsString()
+  exchangeAddress: string;
+
+  @IsString()
+  workerAddress: string;
+
+  @IsString()
+  solution: string;
+}
+
+export class ImageLabelBinaryFinalResultDto {
+  @IsString()
+  url: string;
+
+  @IsString()
+  final_answer: string;
+
+  @IsArray()
+  correct: string[];
+
+  @IsArray()
+  wrong: string[];
+}

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -5,7 +5,7 @@ import {
   StorageClient,
 } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
-import { BadGatewayException, NotFoundException } from '@nestjs/common';
+import { BadGatewayException, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { BigNumber, FixedNumber, ethers } from 'ethers';
@@ -36,7 +36,9 @@ import {
 import { PaymentService } from '../payment/payment.service';
 import { Web3Service } from '../web3/web3.service';
 import {
+  FortuneFinalResultDto,
   FortuneManifestDto,
+  ImageLabelBinaryFinalResultDto,
   ImageLabelBinaryManifestDto,
   JobFortuneDto,
 } from './job.dto';
@@ -138,18 +140,18 @@ describe('JobService', () => {
     };
 
     let getUserBalanceMock: any;
-  
+
     beforeEach(() => {
       getUserBalanceMock = jest.spyOn(paymentService, 'getUserBalance');
-      
+
       jest.spyOn(currencyService, 'getRate').mockResolvedValue(rate);
       jest.spyOn(paymentService, 'savePayment').mockResolvedValue(true);
     });
-  
+
     afterEach(() => {
       jest.restoreAllMocks();
     });
-  
+
     it('should create a fortune job successfully', async () => {
       const userBalance = ethers.utils.parseUnits('15', 'ether')
       getUserBalanceMock.mockResolvedValue(userBalance);
@@ -167,9 +169,9 @@ describe('JobService', () => {
           ethers.utils.formatUnits(fundAmountInWei.add(jobLauncherFee), 'ether'),
         ).mulUnsafe(FixedNumber.from(rate.toString())),
       );
-  
+
       await jobService.createFortuneJob(userId, dto);
-  
+
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
       expect(paymentService.savePayment).toHaveBeenCalledWith(
         userId,
@@ -190,16 +192,16 @@ describe('JobService', () => {
         waitUntil: expect.any(Date),
       });
     });
-  
+
     it('should throw an exception for insufficient user balance', async () => {
       const fundAmount = 10; // ETH
       const userBalance = ethers.utils.parseUnits('1', 'ether'); // 1 ETH
-  
+
       jest.spyOn(paymentService, 'getUserBalance').mockResolvedValue(userBalance);
-  
-  
+
+
       getUserBalanceMock.mockResolvedValue(userBalance);
-  
+
       const dto: JobFortuneDto = {
         chainId: MOCK_CHAIN_ID,
         fortunesRequired: MOCK_FORTUNES_REQUIRED,
@@ -207,21 +209,21 @@ describe('JobService', () => {
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         fundAmount,
       };
-  
+
       await expect(
         jobService.createFortuneJob(userId, dto),
       ).rejects.toThrowError(ErrorJob.NotEnoughFunds);
     });
-  
+
     it('should throw an exception if job entity creation fails', async () => {
       const fundAmount = 1; // ETH
-  
+
       const userBalance = ethers.utils.parseUnits('10', 'ether')
 
       getUserBalanceMock.mockResolvedValue(userBalance);
-  
+
       jest.spyOn(jobRepository, 'create').mockResolvedValue(undefined!);
-  
+
       const dto: JobFortuneDto = {
         chainId: MOCK_CHAIN_ID,
         fortunesRequired: MOCK_FORTUNES_REQUIRED,
@@ -229,13 +231,13 @@ describe('JobService', () => {
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         fundAmount,
       };
-  
+
       await expect(
         jobService.createFortuneJob(userId, dto),
       ).rejects.toThrowError(ErrorJob.NotCreated);
     });
   });
-  
+
   describe('launchJob with Fortune type', () => {
     let getManifestMock: any;
     const chainId = ChainId.LOCALHOST;
@@ -243,16 +245,16 @@ describe('JobService', () => {
     const mockTokenContract: any = {
       transfer: jest.fn(),
     };
-  
+
     beforeEach(() => {
       jest.spyOn(HMToken__factory, 'connect').mockReturnValue(mockTokenContract);
       getManifestMock = jest.spyOn(jobService, 'getManifest');
     });
-  
+
     afterEach(() => {
       jest.restoreAllMocks();
     });
-  
+
     it('should launch a job successfully', async () => {
       const fundAmountInWei = ethers.utils.parseUnits('10', 'ether');
       const totalFeePercentage = BigNumber.from(MOCK_JOB_LAUNCHER_FEE)
@@ -269,9 +271,9 @@ describe('JobService', () => {
         fundAmount: fundAmountInWei.toString(),
         requestType: JobRequestType.FORTUNE,
       };
-  
+
       getManifestMock.mockResolvedValue(manifest);
-  
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId,
         manifestUrl: MOCK_FILE_URL,
@@ -282,16 +284,16 @@ describe('JobService', () => {
         status: JobStatus.PENDING,
         save: jest.fn().mockResolvedValue(true),
       };
-  
+
       await jobService.launchJob(mockJobEntity as JobEntity);
-  
+
       expect(mockTokenContract.transfer).toHaveBeenCalledWith(MOCK_ADDRESS, mockJobEntity.fundAmount);
       expect(mockJobEntity.escrowAddress).toBe(MOCK_ADDRESS);
       expect(mockJobEntity.status).toBe(JobStatus.LAUNCHED);
       expect(mockJobEntity.save).toHaveBeenCalled();
       expect(jobService.getManifest).toHaveBeenCalledWith(mockJobEntity.manifestUrl);
     });
-  
+
     it('should throw an unpredictable gas limit error if transfer failed', async () => {
       const fundAmountInWei = ethers.utils.parseUnits('10', 'ether');
 
@@ -302,10 +304,10 @@ describe('JobService', () => {
         fundAmount: fundAmountInWei.toString(),
         requestType: JobRequestType.FORTUNE,
       };
-  
+
       getManifestMock.mockResolvedValue(manifest);
       mockTokenContract.transfer.mockRejectedValue(Object.assign(new Error(ethers.utils.Logger.errors.UNPREDICTABLE_GAS_LIMIT), { code: ethers.utils.Logger.errors.UNPREDICTABLE_GAS_LIMIT }));
-  
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId,
         manifestUrl: MOCK_FILE_URL,
@@ -314,15 +316,15 @@ describe('JobService', () => {
         status: JobStatus.PENDING,
         save: jest.fn().mockResolvedValue(true),
       };
-  
+
       await expect(
         jobService.launchJob(mockJobEntity as JobEntity),
       ).rejects.toThrow(new Error(ethers.utils.Logger.errors.UNPREDICTABLE_GAS_LIMIT));
     });
-  
+
     it('should throw an error if the manifest does not exist', async () => {
       getManifestMock.mockResolvedValue(null!);
-  
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId,
         manifestUrl: MOCK_FILE_URL,
@@ -331,12 +333,12 @@ describe('JobService', () => {
         status: JobStatus.PENDING,
         save: jest.fn().mockResolvedValue(true),
       };
-  
+
       await expect(
         jobService.launchJob(mockJobEntity as JobEntity),
       ).rejects.toThrow();
     });
-  
+
     it('should throw an error if the manifest validation failed', async () => {
       const invalidManifest: Partial<FortuneManifestDto> = {
         submissionsRequired: 10,
@@ -344,9 +346,9 @@ describe('JobService', () => {
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         requestType: JobRequestType.FORTUNE,
       };
-  
+
       getManifestMock.mockResolvedValue(invalidManifest as FortuneManifestDto);
-  
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId,
         manifestUrl: MOCK_FILE_URL,
@@ -355,7 +357,7 @@ describe('JobService', () => {
         status: JobStatus.PENDING,
         save: jest.fn().mockResolvedValue(true),
       };
-  
+
       await expect(
         jobService.launchJob(mockJobEntity as JobEntity),
       ).rejects.toThrow();
@@ -367,7 +369,7 @@ describe('JobService', () => {
           .fn()
           .mockRejectedValue(new Error()),
       }));
-  
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId: 1,
         manifestUrl: MOCK_FILE_URL,
@@ -376,7 +378,7 @@ describe('JobService', () => {
         status: JobStatus.PENDING,
         save: jest.fn().mockResolvedValue(true),
       };
-  
+
       await expect(
         jobService.launchJob(mockJobEntity as JobEntity),
       ).rejects.toThrow();
@@ -394,11 +396,11 @@ describe('JobService', () => {
       jest.spyOn(HMToken__factory, 'connect').mockReturnValue(mockTokenContract);
       getManifestMock = jest.spyOn(jobService, 'getManifest');
     });
-  
+
     afterEach(() => {
       jest.restoreAllMocks();
     });
-  
+
     it('should launch a job successfully', async () => {
       const fundAmountInWei = ethers.utils.parseUnits('10', 'ether');
       const totalFeePercentage = BigNumber.from(MOCK_JOB_LAUNCHER_FEE)
@@ -420,7 +422,7 @@ describe('JobService', () => {
 
       jest.spyOn(jobService, 'getManifest').mockResolvedValue(manifest);
     });
-  
+
     it('should throw an error if the manifest validation failed', async () => {
       const invalidManifest: Partial<ImageLabelBinaryManifestDto> = {
         dataUrl: MOCK_FILE_URL,
@@ -430,9 +432,9 @@ describe('JobService', () => {
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         requestType: JobRequestType.IMAGE_LABEL_BINARY,
       };
-  
+
       getManifestMock.mockResolvedValue(invalidManifest as ImageLabelBinaryManifestDto);
-  
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId: 1,
         manifestUrl: MOCK_FILE_URL,
@@ -441,7 +443,7 @@ describe('JobService', () => {
         status: JobStatus.PENDING,
         save: jest.fn().mockResolvedValue(true),
       };
-  
+
       await expect(
         jobService.launchJob(mockJobEntity as JobEntity),
       ).rejects.toThrow();
@@ -454,26 +456,26 @@ describe('JobService', () => {
     beforeEach(() => {
       uploadFilesMock = jest.spyOn(jobService.storageClient, 'uploadFiles');
     });
-  
+
     afterEach(() => {
       jest.restoreAllMocks();
     });
-  
+
     it('should save the manifest and return the manifest URL and hash', async () => {
       const encryptedManifest = { data: 'encrypted data' };
-  
+
       uploadFilesMock.mockResolvedValue([
         {
           url: MOCK_FILE_URL,
           hash: MOCK_FILE_HASH,
         },
       ]);
-  
+
       const result = await jobService.saveManifest(
         encryptedManifest,
         MOCK_BUCKET_NAME,
       );
-  
+
       expect(result).toEqual({
         manifestUrl: MOCK_FILE_URL,
         manifestHash: MOCK_FILE_HASH,
@@ -483,13 +485,13 @@ describe('JobService', () => {
         MOCK_BUCKET_NAME,
       );
     });
-  
+
     it('should throw an error if the manifest file fails to upload', async () => {
       const encryptedManifest = { data: 'encrypted data' };
       const uploadError = new Error(ErrorBucket.UnableSaveFile);
-  
+
       uploadFilesMock.mockRejectedValue(uploadError);
-  
+
       await expect(
         jobService.saveManifest(encryptedManifest, MOCK_BUCKET_NAME),
       ).rejects.toThrowError(new BadGatewayException(ErrorBucket.UnableSaveFile));
@@ -498,14 +500,14 @@ describe('JobService', () => {
         MOCK_BUCKET_NAME,
       );
     });
-  
+
     it('should rethrow any other errors encountered', async () => {
       const encryptedManifest = { data: 'encrypted data' };
       const errorMessage = 'Something went wrong';
       const uploadError = new Error(errorMessage);
-  
+
       uploadFilesMock.mockRejectedValue(uploadError);
-  
+
       await expect(
         jobService.saveManifest(encryptedManifest, MOCK_BUCKET_NAME),
       ).rejects.toThrowError(new Error(errorMessage));
@@ -553,11 +555,11 @@ describe('JobService', () => {
     beforeEach(() => {
       downloadFileFromUrlMock = jest.spyOn(StorageClient, 'downloadFileFromUrl');
     });
-  
+
     afterEach(() => {
       jest.restoreAllMocks();
     });
-  
+
     it('should download and return the manifest', async () => {
       const fundAmountInWei = ethers.utils.parseUnits(
         '10',
@@ -572,7 +574,7 @@ describe('JobService', () => {
           ethers.utils.formatUnits(fundAmountInWei.add(jobLauncherFee), 'ether'),
         ).mulUnsafe(FixedNumber.from('10'.toString())),
       );
-  
+
       const manifest: FortuneManifestDto = {
         submissionsRequired: 10,
         requesterTitle: MOCK_REQUESTER_TITLE,
@@ -580,20 +582,20 @@ describe('JobService', () => {
         fundAmount: usdTotalAmount.toString(),
         requestType: JobRequestType.FORTUNE,
       };
-  
+
       downloadFileFromUrlMock.mockReturnValue(manifest);
-  
+
       const result = await jobService.getManifest(MOCK_FILE_URL);
-  
+
       expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
         MOCK_FILE_URL,
       );
       expect(result).toEqual(manifest);
     });
-  
+
     it('should throw a NotFoundException if the manifest is not found', async () => {
       downloadFileFromUrlMock.mockResolvedValue(null);
-  
+
       await expect(jobService.getManifest(MOCK_FILE_URL)).rejects.toThrowError(
         new NotFoundException(ErrorJob.ManifestNotFound),
       );
@@ -602,5 +604,65 @@ describe('JobService', () => {
       );
     });
   });
-  
+
+  describe('getResult', () => {
+    let downloadFileFromUrlMock: any;
+
+    beforeEach(() => {
+      downloadFileFromUrlMock = jest.spyOn(
+        StorageClient,
+        'downloadFileFromUrl',
+      );
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should download and return the fortune result', async () => {
+      const fortuneResult: FortuneFinalResultDto = {
+        exchangeAddress: MOCK_ADDRESS,
+        workerAddress: MOCK_ADDRESS,
+        solution: 'good',
+      };
+
+      downloadFileFromUrlMock.mockResolvedValue(fortuneResult);
+
+      const result = await jobService.getResult(MOCK_FILE_URL);
+
+      expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
+        MOCK_FILE_URL,
+      );
+      expect(result).toEqual(fortuneResult);
+    });
+
+    it('should download and return the image binary result', async () => {
+      const imageBinaryResult: ImageLabelBinaryFinalResultDto = {
+        url: 'https://example.com',
+        final_answer: 'good',
+        correct: ['good', 'good', 'good'],
+        wrong: [''],
+      };
+
+      downloadFileFromUrlMock.mockResolvedValue(imageBinaryResult);
+
+      const result = await jobService.getResult(MOCK_FILE_URL);
+
+      expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
+        MOCK_FILE_URL,
+      );
+      expect(result).toEqual(imageBinaryResult);
+    });
+
+    it('should throw a NotFoundException if the result is not found', async () => {
+      downloadFileFromUrlMock.mockResolvedValue(null);
+
+      await expect(jobService.getResult(MOCK_FILE_URL)).rejects.toThrowError(
+        new NotFoundException(ErrorJob.ResultNotFound),
+      );
+      expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
+        MOCK_FILE_URL,
+      );
+    });
+  });
 });

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -664,5 +664,20 @@ describe('JobService', () => {
         MOCK_FILE_URL,
       );
     });
+
+    it('should throw a NotFoundException if the result is not valid', async () => {
+      downloadFileFromUrlMock.mockResolvedValue({
+        exchangeAddress: MOCK_ADDRESS,
+        workerAddress: MOCK_ADDRESS,
+        solutionNotFortune: 'good',
+      });
+
+      await expect(jobService.getResult(MOCK_FILE_URL)).rejects.toThrowError(
+        new NotFoundException(ErrorJob.ResultValidationFailed),
+      );
+      expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
+        MOCK_FILE_URL,
+      );
+    });
   });
 });

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -25,7 +25,6 @@ import {
   ChainId,
   EscrowClient,
   NETWORKS,
-  StakingClient,
   StorageClient,
   StorageCredentials,
   StorageParams,
@@ -399,6 +398,31 @@ export class JobService {
 
     if (!result) {
       throw new NotFoundException(ErrorJob.ResultNotFound);
+    }
+
+    const fortuneDtoCheck = new FortuneFinalResultDto();
+    const imageLabelBinaryDtoCheck = new ImageLabelBinaryFinalResultDto();
+
+    Object.assign(fortuneDtoCheck, result);
+    Object.assign(imageLabelBinaryDtoCheck, result);
+
+    const fortuneValidationErrors: ValidationError[] = await validate(
+      fortuneDtoCheck,
+    );
+    const imageLabelBinaryValidationErrors: ValidationError[] = await validate(
+      imageLabelBinaryDtoCheck,
+    );
+    if (
+      fortuneValidationErrors.length > 0 &&
+      imageLabelBinaryValidationErrors.length > 0
+    ) {
+      this.logger.log(
+        ErrorJob.ResultValidationFailed,
+        JobService.name,
+        fortuneValidationErrors,
+        imageLabelBinaryValidationErrors,
+      );
+      throw new NotFoundException(ErrorJob.ResultValidationFailed);
     }
 
     return result;

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -111,14 +111,13 @@ export class JobService {
       'ether',
     );
 
-    const rate = await this.currencyService.getRate(
-      Currency.USD,
-      TokenId.HMT
-    );
+    const rate = await this.currencyService.getRate(Currency.USD, TokenId.HMT);
 
     const jobLauncherFee = BigNumber.from(
       this.configService.get<number>(ConfigNames.JOB_LAUNCHER_FEE)!,
-    ).div(100).mul(fundAmountInWei);
+    )
+      .div(100)
+      .mul(fundAmountInWei);
 
     const usdTotalAmount = BigNumber.from(
       FixedNumber.from(
@@ -193,14 +192,13 @@ export class JobService {
       'ether',
     );
 
-    const rate = await this.currencyService.getRate(
-      Currency.USD,
-      TokenId.HMT
-    );
+    const rate = await this.currencyService.getRate(Currency.USD, TokenId.HMT);
 
     const jobLauncherFee = BigNumber.from(
       this.configService.get<number>(ConfigNames.JOB_LAUNCHER_FEE)!,
-    ).div(100).mul(fundAmountInWei);
+    )
+      .div(100)
+      .mul(fundAmountInWei);
 
     const usdTotalAmount = BigNumber.from(
       FixedNumber.from(
@@ -252,7 +250,7 @@ export class JobService {
       PaymentType.WITHDRAWAL,
       usdTotalAmount,
     );
-    
+
     jobEntity.status = JobStatus.PAID;
     await jobEntity.save();
 
@@ -344,15 +342,20 @@ export class JobService {
   private async validateManifest(
     manifest: FortuneManifestDto | ImageLabelBinaryManifestDto,
   ): Promise<boolean> {
-    const dtoCheck = manifest.requestType === JobRequestType.FORTUNE
-      ? new FortuneManifestDto()
-      : new ImageLabelBinaryManifestDto();
+    const dtoCheck =
+      manifest.requestType === JobRequestType.FORTUNE
+        ? new FortuneManifestDto()
+        : new ImageLabelBinaryManifestDto();
 
     Object.assign(dtoCheck, manifest);
 
     const validationErrors: ValidationError[] = await validate(dtoCheck);
     if (validationErrors.length > 0) {
-      this.logger.log(ErrorJob.ManifestValidationFailed, JobService.name, validationErrors);
+      this.logger.log(
+        ErrorJob.ManifestValidationFailed,
+        JobService.name,
+        validationErrors,
+      );
       throw new NotFoundException(ErrorJob.ManifestValidationFailed);
     }
 
@@ -385,5 +388,15 @@ export class JobService {
     }
 
     return true;
+  }
+
+  public async getResult(finalResultUrl: string): Promise<any> {
+    const result = await StorageClient.downloadFileFromUrl(finalResultUrl);
+
+    if (!result) {
+      throw new NotFoundException(ErrorJob.ResultNotFound);
+    }
+
+    return result;
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -32,7 +32,9 @@ import {
   UploadFile,
 } from '@human-protocol/sdk';
 import {
+  FortuneFinalResultDto,
   FortuneManifestDto,
+  ImageLabelBinaryFinalResultDto,
   ImageLabelBinaryManifestDto,
   JobCvatDto,
   JobFortuneDto,
@@ -390,7 +392,9 @@ export class JobService {
     return true;
   }
 
-  public async getResult(finalResultUrl: string): Promise<any> {
+  public async getResult(
+    finalResultUrl: string,
+  ): Promise<FortuneFinalResultDto | ImageLabelBinaryFinalResultDto> {
     const result = await StorageClient.downloadFileFromUrl(finalResultUrl);
 
     if (!result) {


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
We need `/result` endpoint in job launcher to download result details.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Added an endpoint to job controller.
- Added a new service function that uses StorageClient to download result.
- Added unit tests for service function.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #106 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
