### PR TITLE
Update web3 to support python 3.10 & 3.11

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/Pipfile
+++ b/packages/sdk/python/human-protocol-sdk/Pipfile
@@ -13,7 +13,8 @@ setuptools-pipfile = "*"
 cryptography = "*"
 minio = "*"
 validators = "*"
-web3 = "==5.24.0"
+web3 = "==6.8.*"
+aiohttp = "<4.0.0"  # broken freeze in one of dependencies
 pgpy = "*"
 
 [requires]

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -56,11 +56,11 @@ class EscrowConfig:
             manifest_url (str): Manifest file url
             hash (str): Manifest file hash
         """
-        if not Web3.isAddress(recording_oracle_address):
+        if not Web3.is_address(recording_oracle_address):
             raise EscrowClientError(
                 f"Invalid recording oracle address: {recording_oracle_address}"
             )
-        if not Web3.isAddress(reputation_oracle_address):
+        if not Web3.is_address(reputation_oracle_address):
             raise EscrowClientError(
                 f"Invalid reputation oracle address: {reputation_oracle_address}"
             )
@@ -116,7 +116,7 @@ class EscrowFilter:
             raise EscrowClientError(
                 "EscrowFilter class must have at least one parameter"
             )
-        if address and not Web3.isAddress(address):
+        if address and not Web3.is_address(address):
             raise EscrowClientError(f"Invalid address: {address}")
         if date_from and date_to and date_from > date_to:
             raise EscrowClientError(
@@ -175,11 +175,11 @@ class EscrowClient:
         Raises:
             EscrowClientError: If an error occurs while checking the parameters
         """
-        if not Web3.isAddress(token_address):
+        if not Web3.is_address(token_address):
             raise EscrowClientError(f"Invalid token address: {token_address}")
 
         for handler in trusted_handlers:
-            if not Web3.isAddress(handler):
+            if not Web3.is_address(handler):
                 raise EscrowClientError(f"Invalid handler address: {handler}")
 
         transaction_receipt = handle_transaction(
@@ -214,7 +214,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
@@ -272,7 +272,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if 0 >= amount:
             raise EscrowClientError("Amount must be positive")
@@ -304,7 +304,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if not hash:
             raise EscrowClientError("Invalid empty hash")
@@ -333,7 +333,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
@@ -369,10 +369,10 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         for recipient in recipients:
-            if not Web3.isAddress(recipient):
+            if not Web3.is_address(recipient):
                 raise EscrowClientError(f"Invalid recipient address: {recipient}")
         if len(recipients) == 0:
             raise EscrowClientError("Arrays must have any value")
@@ -415,7 +415,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
@@ -438,7 +438,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         handle_transaction(
@@ -461,10 +461,10 @@ class EscrowClient:
         Raises:
             EscrowClientError: If an error occurs while checking the parameters
         """
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         for handler in handlers:
-            if not Web3.isAddress(handler):
+            if not Web3.is_address(handler):
                 raise EscrowClientError(f"Invalid handler address: {handler}")
 
         handle_transaction(
@@ -489,7 +489,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.getBalance().call()
@@ -507,7 +507,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.manifestUrl().call()
@@ -525,7 +525,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
@@ -545,7 +545,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
@@ -567,7 +567,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.token().call()
@@ -585,7 +585,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return Status(
@@ -666,7 +666,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
@@ -686,7 +686,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (
@@ -708,7 +708,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return self._get_escrow_contract(escrow_address).functions.launcher().call()
@@ -726,7 +726,7 @@ class EscrowClient:
             EscrowClientError: If an error occurs while checking the parameters
         """
 
-        if not Web3.isAddress(escrow_address):
+        if not Web3.is_address(escrow_address):
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
 
         return (

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore.py
@@ -115,7 +115,7 @@ class KVStoreClient:
 
         if not key:
             raise KVStoreClientError("Key can not be empty")
-        if not Web3.isAddress(address):
+        if not Web3.is_address(address):
             raise KVStoreClientError(f"Invalid address: {address}")
         result = self.kvstore_contract.functions.get(address, key).call()
         return result

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
@@ -88,7 +88,7 @@ def parse_transfer_transaction(
     if not tx_receipt:
         return hmt_transferred, tx_balance
 
-    transfer_event = hmtoken_contract.events.Transfer().processReceipt(tx_receipt)
+    transfer_event = hmtoken_contract.events.Transfer().process_receipt(tx_receipt)
     logger.info(f"Transfer_event {transfer_event}.")
 
     hmt_transferred = bool(transfer_event)

--- a/packages/sdk/python/human-protocol-sdk/setup.py
+++ b/packages/sdk/python/human-protocol-sdk/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="human-protocol-sdk",
-    version="0.0.7",
+    version="0.0.8",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/human-protocol/packages/sdk/python/human-protocol-sdk",

--- a/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
@@ -42,9 +42,9 @@ class StakingTestCase(unittest.TestCase):
             [self.gas_payer.address],
         ).transact()
 
-        tx_receipt = self.staking_client.w3.eth.waitForTransactionReceipt(tx_hash)
+        tx_receipt = self.staking_client.w3.eth.wait_for_transaction_receipt(tx_hash)
 
-        events = self.staking_client.factory_contract.events.Launched().processReceipt(
+        events = self.staking_client.factory_contract.events.Launched().process_receipt(
             tx_receipt
         )
         self.escrow_address = events[0].get("args", {}).get("escrow", "")

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_kvstore.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_kvstore.py
@@ -145,7 +145,7 @@ class KVStoreTestCase(unittest.TestCase):
         mock_function = MagicMock()
         mock_function.return_value.call.return_value = "mock_value"
         self.kvstore.kvstore_contract.functions.get = mock_function
-        address = Web3.toChecksumAddress("0x1234567890123456789012345678901234567890")
+        address = Web3.to_checksum_address("0x1234567890123456789012345678901234567890")
         key = "key"
 
         result = self.kvstore.get(address, key)
@@ -155,7 +155,7 @@ class KVStoreTestCase(unittest.TestCase):
         self.assertEqual(result, "mock_value")
 
     def test_get_empty_key(self):
-        address = Web3.toChecksumAddress("0x1234567890123456789012345678901234567890")
+        address = Web3.to_checksum_address("0x1234567890123456789012345678901234567890")
         key = ""
         with self.assertRaises(KVStoreClientError) as cm:
             self.kvstore.get(address, key)
@@ -172,7 +172,7 @@ class KVStoreTestCase(unittest.TestCase):
         mock_function = MagicMock()
         mock_function.return_value.call.return_value = ""
         self.kvstore.kvstore_contract.functions.get = mock_function
-        address = Web3.toChecksumAddress("0x1234567890123456789012345678901234567890")
+        address = Web3.to_checksum_address("0x1234567890123456789012345678901234567890")
         key = "key"
 
         result = self.kvstore.get(address, key)
@@ -193,7 +193,7 @@ class KVStoreTestCase(unittest.TestCase):
         mock_function.return_value.call.return_value = "mock_value"
         kvstore.kvstore_contract.functions.get = mock_function
 
-        address = Web3.toChecksumAddress("0x1234567890123456789012345678901234567890")
+        address = Web3.to_checksum_address("0x1234567890123456789012345678901234567890")
         key = "key"
 
         result = kvstore.get(address, key)


### PR DESCRIPTION
## Description

Fully support python 3.10 & 3.11

## Summary of changes

Updated web3 package to the latest

## How test the changes
from web3 == 6.0.0 they started to use pythonic naming. so isAddress  is now is_address.

As far as I checked changelog there were no changes that affected SDK logic-wise

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
