### PR TITLE
[Job Launcher] Added payment link logic

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -59,7 +59,7 @@ export enum ErrorPayment {
   CustomerNotFound = 'Customer not found',
   CustomerNotCreated = 'Customer not created',
   IncorrectAmount = 'Incorrect amount',
-  TransactionHashAlreadyExists = 'Transaction hash already exists',
+  TransactionAlreadyExists = 'Transaction already exists',
   TransactionNotFoundByHash = 'Transaction not found by hash',
   InvalidTransactionData = 'Invalid transaction data',
   TransactionHasNotEnoughAmountOfConfirmations = 'Transaction has not enough amount of confirmations',

--- a/packages/apps/job-launcher/server/src/common/enums/payment.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/payment.ts
@@ -64,6 +64,7 @@ export enum PaymentType {
 }
 
 export enum PaymentStatus {
+  PENDING = 'PENDING',
   FAILED = 'FAILED',
   SUCCEEDED = 'SUCCEEDED',
 }

--- a/packages/apps/job-launcher/server/src/common/enums/payment.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/payment.ts
@@ -68,3 +68,11 @@ export enum PaymentStatus {
   FAILED = 'FAILED',
   SUCCEEDED = 'SUCCEEDED',
 }
+
+export enum StripePaymentStatus {
+  CANCELED = 'canceled',
+  REQUIRES_PAYMENT_METHOD = 'requires_payment_method',
+  SUCCEEDED = 'succeeded',
+}
+
+

--- a/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
@@ -13,6 +13,9 @@ export class InitialMigration1691485394906 implements MigrationInterface {
             CREATE TYPE "hmt"."payments_source_enum" AS ENUM('FIAT', 'CRYPTO', 'BALANCE')
         `);
     await queryRunner.query(`
+            CREATE TYPE "hmt"."payments_status_enum" AS ENUM('PENDING', 'FAILED', 'SUCCEEDED')
+        `);
+    await queryRunner.query(`
             CREATE TABLE "hmt"."payments" (
                 "id" SERIAL NOT NULL,
                 "created_at" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -24,6 +27,7 @@ export class InitialMigration1691485394906 implements MigrationInterface {
                 "currency" character varying NOT NULL,
                 "type" "hmt"."payments_type_enum" NOT NULL,
                 "source" "hmt"."payments_source_enum" NOT NULL,
+                "status" "hmt"."payments_status_enum" NOT NULL,
                 "user_id" integer NOT NULL,
                 CONSTRAINT "PK_197ab7af18c93fbb0c9b28b4a59" PRIMARY KEY ("id")
             )
@@ -191,6 +195,9 @@ export class InitialMigration1691485394906 implements MigrationInterface {
         `);
     await queryRunner.query(`
             DROP TYPE "hmt"."payments_type_enum"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."payments_status_enum"
         `);
     await queryRunner.dropSchema(NS);
   }

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
@@ -34,7 +34,7 @@ export class PaymentController {
     @Request() req: RequestWithUser,
     @Body() data: PaymentFiatCreateDto,
   ): Promise<string> {
-    return this.paymentService.createFiatPayment(req.user, data);
+    return this.paymentService.createFiatPayment(req.user.id, data);
   }
 
   @Post('/fiat/confirm-payment')
@@ -50,7 +50,7 @@ export class PaymentController {
     @Request() req: any,
     @Body() data: PaymentCryptoCreateDto,
   ): Promise<boolean> {
-    return this.paymentService.createCryptoPayment(req.user?.id, data);
+    return this.paymentService.createCryptoPayment(req.user.id, data);
   }
 
   @Get('/rates')

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
@@ -3,6 +3,7 @@ import { IsEnum, IsNumber, IsString, Min } from 'class-validator';
 import {
   Currency,
   PaymentSource,
+  PaymentStatus,
   PaymentType,
   TokenId,
 } from '../../common/enums/payment';
@@ -48,6 +49,7 @@ export class PaymentCreateDto {
   public rate?: number;
   public type?: PaymentType;
   public chainId?: number;
+  public status?: PaymentStatus;
 }
 
 export class GetRateDto {

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { NS } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
-import { PaymentSource, PaymentType } from '../../common/enums/payment';
+import { PaymentSource, PaymentStatus, PaymentType } from '../../common/enums/payment';
 import { UserEntity } from '../user/user.entity';
 
 @Entity({ schema: NS, name: 'payments' })
@@ -40,6 +40,12 @@ export class PaymentEntity extends BaseEntity {
     enum: PaymentSource,
   })
   public source: PaymentSource;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentStatus,
+  })
+  public status: PaymentStatus;
 
   @JoinColumn()
   @ManyToOne(() => UserEntity, (user) => user.payments)


### PR DESCRIPTION
## Description
Save payment when calling createFiatPayment and link it to user, otherwise if someone has a paymentId from another user that was not confirmed yet, he could add it to his balance.

## Summary of changes
- Updated migrations
- Added new payment status enum
- Updated payment entity
- Updated payment service
- Updated unit tests

## How test the changes
`yarn test`

## Related issues
[Job Launcher - Link payment with user#748](https://github.com/humanprotocol/human-protocol/issues/748)