### PR TITLE
[CVAT][Recording Oracle] Add Inter Rater Agreement Measures to Recording Oracle Output

### DIFF
--- a/packages/examples/cvat/recording-oracle/poetry.lock
+++ b/packages/examples/cvat/recording-oracle/poetry.lock
@@ -1666,6 +1666,72 @@ files = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.0.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pandas-2.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4c7c9f27a4185304c7caf96dc7d91bc60bc162221152de697c98eb0b2648dd8"},
+    {file = "pandas-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f167beed68918d62bffb6ec64f2e1d8a7d297a038f86d4aed056b9493fca407f"},
+    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0c6f76a0f1ba361551f3e6dceaff06bde7514a374aa43e33b588ec10420183"},
+    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba619e410a21d8c387a1ea6e8a0e49bb42216474436245718d7f2e88a2f8d7c0"},
+    {file = "pandas-2.0.3-cp310-cp310-win32.whl", hash = "sha256:3ef285093b4fe5058eefd756100a367f27029913760773c8bf1d2d8bebe5d210"},
+    {file = "pandas-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:9ee1a69328d5c36c98d8e74db06f4ad518a1840e8ccb94a4ba86920986bb617e"},
+    {file = "pandas-2.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b084b91d8d66ab19f5bb3256cbd5ea661848338301940e17f4492b2ce0801fe8"},
+    {file = "pandas-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37673e3bdf1551b95bf5d4ce372b37770f9529743d2498032439371fc7b7eb26"},
+    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9cb1e14fdb546396b7e1b923ffaeeac24e4cedd14266c3497216dd4448e4f2d"},
+    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9cd88488cceb7635aebb84809d087468eb33551097d600c6dad13602029c2df"},
+    {file = "pandas-2.0.3-cp311-cp311-win32.whl", hash = "sha256:694888a81198786f0e164ee3a581df7d505024fbb1f15202fc7db88a71d84ebd"},
+    {file = "pandas-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6a21ab5c89dcbd57f78d0ae16630b090eec626360085a4148693def5452d8a6b"},
+    {file = "pandas-2.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4da0d45e7f34c069fe4d522359df7d23badf83abc1d1cef398895822d11061"},
+    {file = "pandas-2.0.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:32fca2ee1b0d93dd71d979726b12b61faa06aeb93cf77468776287f41ff8fdc5"},
+    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:258d3624b3ae734490e4d63c430256e716f488c4fcb7c8e9bde2d3aa46c29089"},
+    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eae3dc34fa1aa7772dd3fc60270d13ced7346fcbcfee017d3132ec625e23bb0"},
+    {file = "pandas-2.0.3-cp38-cp38-win32.whl", hash = "sha256:f3421a7afb1a43f7e38e82e844e2bca9a6d793d66c1a7f9f0ff39a795bbc5e02"},
+    {file = "pandas-2.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:69d7f3884c95da3a31ef82b7618af5710dba95bb885ffab339aad925c3e8ce78"},
+    {file = "pandas-2.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5247fb1ba347c1261cbbf0fcfba4a3121fbb4029d95d9ef4dc45406620b25c8b"},
+    {file = "pandas-2.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:81af086f4543c9d8bb128328b5d32e9986e0c84d3ee673a2ac6fb57fd14f755e"},
+    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1994c789bf12a7c5098277fb43836ce090f1073858c10f9220998ac74f37c69b"},
+    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ec591c48e29226bcbb316e0c1e9423622bc7a4eaf1ef7c3c9fa1a3981f89641"},
+    {file = "pandas-2.0.3-cp39-cp39-win32.whl", hash = "sha256:04dbdbaf2e4d46ca8da896e1805bc04eb85caa9a82e259e8eed00254d5e0c682"},
+    {file = "pandas-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:1168574b036cd8b93abc746171c9b4f1b83467438a5e45909fed645cf8692dbc"},
+    {file = "pandas-2.0.3.tar.gz", hash = "sha256:c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.1"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.1)", "SQLAlchemy (>=1.4.16)", "beautifulsoup4 (>=4.9.3)", "bottleneck (>=1.3.2)", "brotlipy (>=0.7.0)", "fastparquet (>=0.6.3)", "fsspec (>=2021.07.0)", "gcsfs (>=2021.07.0)", "html5lib (>=1.1)", "hypothesis (>=6.34.2)", "jinja2 (>=3.0.0)", "lxml (>=4.6.3)", "matplotlib (>=3.6.1)", "numba (>=0.53.1)", "numexpr (>=2.7.3)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pandas-gbq (>=0.15.0)", "psycopg2 (>=2.8.6)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "python-snappy (>=0.6.0)", "pyxlsb (>=1.0.8)", "qtpy (>=2.2.0)", "s3fs (>=2021.08.0)", "scipy (>=1.7.1)", "tables (>=3.6.1)", "tabulate (>=0.8.9)", "xarray (>=0.21.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)", "zstandard (>=0.15.2)"]
+aws = ["s3fs (>=2021.08.0)"]
+clipboard = ["PyQt5 (>=5.15.1)", "qtpy (>=2.2.0)"]
+compression = ["brotlipy (>=0.7.0)", "python-snappy (>=0.6.0)", "zstandard (>=0.15.2)"]
+computation = ["scipy (>=1.7.1)", "xarray (>=0.21.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pyxlsb (>=1.0.8)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)"]
+feather = ["pyarrow (>=7.0.0)"]
+fss = ["fsspec (>=2021.07.0)"]
+gcp = ["gcsfs (>=2021.07.0)", "pandas-gbq (>=0.15.0)"]
+hdf5 = ["tables (>=3.6.1)"]
+html = ["beautifulsoup4 (>=4.9.3)", "html5lib (>=1.1)", "lxml (>=4.6.3)"]
+mysql = ["SQLAlchemy (>=1.4.16)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.0.0)", "tabulate (>=0.8.9)"]
+parquet = ["pyarrow (>=7.0.0)"]
+performance = ["bottleneck (>=1.3.2)", "numba (>=0.53.1)", "numexpr (>=2.7.1)"]
+plot = ["matplotlib (>=3.6.1)"]
+postgresql = ["SQLAlchemy (>=1.4.16)", "psycopg2 (>=2.8.6)"]
+spss = ["pyreadstat (>=1.1.2)"]
+sql-other = ["SQLAlchemy (>=1.4.16)"]
+test = ["hypothesis (>=6.34.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.6.3)"]
+
+[[package]]
 name = "parsimonious"
 version = "0.8.1"
 description = "(Soon to be) the fastest pure-Python PEG parser I could muster"
@@ -1974,6 +2040,20 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
@@ -2554,4 +2634,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5dae3ead0fbef16d547ec6cbb501294d5df6a5bac3f21d37973bf360d9424d4b"
+content-hash = "194395c7b4ee5de1340b9ce3293b29021d814d7fb022a45787f19ff449c75afa"

--- a/packages/examples/cvat/recording-oracle/pyproject.toml
+++ b/packages/examples/cvat/recording-oracle/pyproject.toml
@@ -19,6 +19,7 @@ human-protocol-sdk = "^1.1.5"
 alembic = "^1.11.1"
 httpx = "^0.24.1"
 numpy = "^1.25.2"
+pandas = "^2.0.3"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/packages/examples/cvat/recording-oracle/src/modules/agreement/__init__.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/agreement/__init__.py
@@ -1,1 +1,2 @@
 from .measures import percent_agreement, cohens_kappa, fleiss_kappa
+from .utils import confusion_matrix_from_sequence

--- a/packages/examples/cvat/recording-oracle/src/modules/agreement/measures.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/agreement/measures.py
@@ -1,49 +1,9 @@
 import numpy as np
 
-
-def _validate_nd(M: np.ndarray, n=2):
-    """Validates that M has n dimensions."""
-    if M.ndim != n:
-        raise ValueError(f"Input must be a n-dimensional array-like.")
-
-
-def _validate_dtype_is_subtype_of(M: np.ndarray, supertype: np.dtype):
-    """Validates the data type of M is a subtype of supertype."""
-    if not issubclass(M.dtype.type, supertype):
-        raise ValueError(
-            f"Input must have a data type that is a subtype of " f"{supertype}"
-        )
-
-
-def _validate_all_positive(M: np.ndarray):
-    """
-    Validates that all entries in M are positive (including 0).
-    Raises a ValueError if not.
-    """
-    if np.any(M < 0):
-        raise ValueError("Inputs must all be positive")
-
-
-def _validate_sufficient_annotations(M, n=1):
-    """Validates that M contains enough annotations."""
-    if M.sum() <= n:
-        raise ValueError(f"Input must have more than {1} annotation.")
-
-
-def _validate_incidence_matrix(M):
-    """Validates that M is an incidence matrix."""
-    _validate_nd(M, n=2)
-    _validate_dtype_is_subtype_of(M, np.integer)
-    _validate_all_positive(M)
-    _validate_sufficient_annotations(M, n=1)
-
-
-def _validate_confusion_matrix(M):
-    """Validates that M is a confusion Matrix."""
-    _validate_incidence_matrix(M)
-
-    if M.shape[0] != M.shape[1]:
-        raise ValueError("Input must be a square matrix.")
+from .validations import (
+    validate_incidence_matrix,
+    validate_confusion_matrix,
+)
 
 
 def percent_agreement(data: np.ndarray, data_format="im") -> float:
@@ -58,11 +18,11 @@ def percent_agreement(data: np.ndarray, data_format="im") -> float:
     data = np.asarray(data)
 
     if data_format == "cm":
-        _validate_confusion_matrix(data)
+        validate_confusion_matrix(data)
         return np.diag(data).sum() / data.sum()
 
     # implicitly assumes incidence matrix
-    _validate_incidence_matrix(data)
+    validate_incidence_matrix(data)
 
     n_raters = np.max(data)
     item_agreements = np.sum(data * data, 1) - n_raters

--- a/packages/examples/cvat/recording-oracle/src/modules/agreement/utils.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/agreement/utils.py
@@ -26,7 +26,7 @@ def confusion_matrix_from_sequence(
 
     # filter NaN values
     M = np.vstack((a, b)).T  # 2 x N Matrix
-    if M.dtype.kind == "U":  # string types
+    if M.dtype.kind in "UO":  # string types
         mask = M != "nan"
     else:
         mask = ~np.isnan(M)

--- a/packages/examples/cvat/recording-oracle/src/modules/agreement/utils.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/agreement/utils.py
@@ -1,0 +1,51 @@
+import numpy as np
+from typing import Sequence, Optional
+from .validations import validate_nd, validate_equal_shape, validate_same_dtype
+
+
+def confusion_matrix_from_sequence(
+    a: Sequence, b: Sequence, labels: Optional[Sequence] = None
+):
+    """Generate an N X N confusion matrix from the given sequence of values
+        a and b, where N is the number of unique labels.
+
+    Args:
+        a: A sequence of labels.
+        b: Another sequence of labels.
+        labels: The labels contained in the records. Must contain all labels in
+            the given records and may contain labels that are not found in the
+            records.
+    """
+    a = np.asarray(a)
+    b = np.asarray(b)
+
+    validate_same_dtype(a, b)
+    validate_nd(a, 1)
+    validate_nd(b, 1)
+    validate_equal_shape(a, b)
+
+    # filter NaN values
+    M = np.vstack((a, b)).T  # 2 x N Matrix
+    if M.dtype.kind == "U":  # string types
+        mask = M != "nan"
+    else:
+        mask = ~np.isnan(M)
+    a, b = M[np.all(mask, axis=1)].T
+
+    # create list of unique labels
+    if labels is None:
+        labels = np.concatenate([a, b])
+    labels = np.unique(labels)
+
+    # convert labels to indices
+    label_to_id = {label: i for i, label in enumerate(labels)}
+    map_fn = np.vectorize(lambda x: label_to_id[x])
+    a = map_fn(a)
+    b = map_fn(b)
+
+    # get indices and counts to populate confusion matrix
+    confusion_matrix = np.zeros((labels.size, labels.size), dtype=int)
+    ijs, counts = np.unique(np.vstack([a, b]), axis=1, return_counts=True)
+    confusion_matrix[ijs[0], ijs[1]] = counts
+
+    return confusion_matrix

--- a/packages/examples/cvat/recording-oracle/src/modules/agreement/validations.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/agreement/validations.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+
+def validate_nd(M: np.ndarray, n=2):
+    """Validates that M has n dimensions."""
+    if M.ndim != n:
+        raise ValueError(f"Input must be a {n}-dimensional array-like.")
+
+
+def validate_dtype_is_subtype_of(M: np.ndarray, supertype: np.dtype):
+    """Validates the data type of M is a subtype of supertype."""
+    if not issubclass(M.dtype.type, supertype):
+        raise ValueError(
+            f"Input must have a data type that is a subtype of " f"{supertype}"
+        )
+
+
+def validate_is_numeric(M: np.ndarray):
+    """Validates that the data type of M is a number type"""
+    if (
+        M.dtype.kind not in np.typecodes["AllFloat"]
+        and M.dtype.kind not in np.typecodes["AllInteger"]
+    ):
+        raise ValueError("Input data type must be a numeric type.")
+
+
+def validate_all_positive(M: np.ndarray):
+    """
+    Validates that all entries in M are positive (including 0).
+    Raises a ValueError if not.
+    """
+    if np.any(M < 0):
+        raise ValueError("Inputs must all be positive")
+
+
+def validate_sufficient_annotations(M: np.ndarray, n=1):
+    """Validates that M contains enough annotations."""
+    if M.sum() <= n:
+        raise ValueError(f"Input must have more than {1} annotation.")
+
+
+def validate_incidence_matrix(M: np.ndarray):
+    """Validates that M is an incidence matrix."""
+    validate_nd(M, n=2)
+    validate_is_numeric(M)
+    validate_all_positive(M)
+    validate_sufficient_annotations(M, n=1)
+
+
+def validate_confusion_matrix(M):
+    """Validates that M is a confusion Matrix."""
+    validate_incidence_matrix(M)
+
+    if M.shape[0] != M.shape[1]:
+        raise ValueError("Input must be a square matrix.")
+
+
+def validate_equal_shape(a: np.ndarray, b: np.ndarray):
+    """Validates that a and b have the same shape."""
+    if a.shape != b.shape:
+        raise ValueError("All inputs must have the same shape.")
+
+
+def validate_same_dtype(a: np.ndarray, b: np.ndarray):
+    """Validates that a and b share the same data type."""
+    if a.dtype.kind != b.dtype.kind:
+        raise ValueError("All inputs must have the same kind of dtype.")

--- a/packages/examples/cvat/recording-oracle/src/modules/webhook/api_schema.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/webhook/api_schema.py
@@ -1,7 +1,11 @@
+from typing import Mapping, Optional, Generic, Sequence, TypeVar
+
 from pydantic import BaseModel, validator
 
 from src.constants import Networks
 from src.modules.chain.web3 import validate_address
+
+T = TypeVar("T")
 
 
 class OracleWebhook(BaseModel):
@@ -26,3 +30,33 @@ class OracleWebhook(BaseModel):
 
 class OracleWebhookResponse(BaseModel):
     id: str
+
+
+class ImageLabelBinaryFinalResult(BaseModel):
+    url: str
+    label: str
+    label_counts: Mapping[str, int]
+    score: float
+
+
+class AgreementEstimate(BaseModel):
+    score: float
+    interval: Optional[tuple[float, float]]
+    alpha: Optional[float]
+
+
+class ResultDataset(BaseModel, Generic[T]):
+    dataset_scores: Mapping[str, AgreementEstimate]
+    data_points: Sequence[T]
+
+
+class WorkerPerformanceResult(BaseModel):
+    worker_id: str
+    consensus_annotations: int
+    total_annotations: int
+    score: float
+
+
+class ImageLabelBinaryJobResults(BaseModel):
+    dataset: ResultDataset[ImageLabelBinaryFinalResult]
+    worker_performance: Sequence[WorkerPerformanceResult]

--- a/packages/examples/cvat/recording-oracle/src/modules/webhook/process_intermediate_results.py
+++ b/packages/examples/cvat/recording-oracle/src/modules/webhook/process_intermediate_results.py
@@ -1,43 +1,153 @@
 from collections import Counter
+from functools import partial
+import numpy as np
 
+from modules.webhook.api_schema import (
+    ImageLabelBinaryFinalResult,
+    ResultDataset,
+    WorkerPerformanceResult,
+    ImageLabelBinaryJobResults,
+)
 from src.constants import JobTypes
+from src.modules.agreement import cohens_kappa, fleiss_kappa, percent_agreement
+from src.modules.agreement.utils import confusion_matrix_from_sequence
+import pandas as pd
+
+from typing import Sequence, Mapping, TypeVar
+
+T = TypeVar("T")
+S = TypeVar("S")
 
 
-def process_image_label_binary_intermediate_results(intermediate_results: str) -> dict:
-    final_results = [
-        {
-            "url": item["url"],
-            "final_answer": Counter(
-                answer["tag"] for answer in item["answers"]
-            ).most_common(1)[0][0],
-            "correct": [
-                answer["assignee"]
-                for answer in item["answers"]
-                if answer["tag"]
-                == Counter(answer["tag"] for answer in item["answers"]).most_common(1)[
-                    0
-                ][0]
-            ],
-            "wrong": [
-                answer["assignee"]
-                for answer in item["answers"]
-                if answer["tag"]
-                != Counter(answer["tag"] for answer in item["answers"]).most_common(1)[
-                    0
-                ][0]
-            ],
-        }
-        for item in intermediate_results
+def _id_map(a: Sequence[T]) -> dict[int, T]:
+    return {i: x for i, x in enumerate(np.unique(a))}
+
+
+def _reverse_map(d: Mapping[T, S]) -> Mapping[S, T]:
+    return {v: k for k, v in d.items()}
+
+
+def _calculate_kappa_from_series(
+    series_a: pd.Series, series_b: pd.Series, labels: Sequence = None
+):
+    # get only intersecting annotations
+    df = pd.concat([series_a, series_b], join="inner", axis=1)
+
+    # disjoint sets of annotations
+    if len(df) == 0:
+        return np.NaN
+
+    a = df.iloc[:, 0]
+    b = df.iloc[:, 1]
+    return cohens_kappa(confusion_matrix_from_sequence(a, b, labels=labels))
+
+
+def process_image_label_binary_intermediate_results(
+    intermediate_results: list[dict],
+) -> ImageLabelBinaryJobResults:
+    # turn into record format
+    records = []
+    for item in intermediate_results:
+        url = item["url"]
+        for answer in item["answers"]:
+            records.append(
+                {"url": url, "assignee": answer["assignee"], "tag": answer["tag"]}
+            )
+    records = pd.DataFrame.from_records(records)
+
+    # calculate final dataset by majority vote
+    tags = np.unique(records["tag"])
+    id_to_tag = _id_map(tags)
+    by_url_tag = records.groupby("url")["tag"]
+    tag_counts = by_url_tag.value_counts().unstack("tag").fillna(0).astype(int)
+
+    ###
+    # Calculate Dataset
+    ##
+    dataset = (
+        tag_counts.apply(np.argmax, axis=1).map(id_to_tag).rename("label").to_frame()
+    )
+
+    dataset["label_counts"] = (
+        records.groupby(["url"])["tag"]
+        .value_counts()
+        .unstack()
+        .fillna(0)
+        .to_dict(orient="records")
+    )
+
+    # calculate percentage of votes for consensus label
+    def calc_label_score(label_counts):
+        c = Counter(label_counts)
+        count = c.most_common(1)[0][1]
+        return count / c.total()
+
+    dataset["score"] = dataset["label_counts"].map(calc_label_score)
+
+    # calculate dataset wide statistics
+    dataset_scores = {
+        "fleiss_kappa": {
+            "score": fleiss_kappa(tag_counts),
+            "interval": None,
+            "alpha": None,
+        },
+        "avg_percent_agreement_across_labels": {
+            "score": percent_agreement(tag_counts),
+            "interval": None,
+            "alpha": None,
+        },
+    }
+
+    ###
+    # Calculate Worker Performance Result
+    ###
+
+    # assign majority answer information to records
+    records.set_index(["url", "assignee"], inplace=True)
+    records["matches_majority"] = records["tag"].eq(dataset["label"]).astype(int)
+
+    # calculate statistics for assignees
+    calc_majority_kappa = partial(
+        _calculate_kappa_from_series, series_b=dataset["label"], labels=tags
+    )
+
+    assignee_statistics = (
+        records.reset_index()
+        .set_index("url")
+        .groupby(["assignee"])
+        .agg(
+            consensus_annotations=("matches_majority", np.sum),
+            total_annotations=("tag", "count"),
+            score=("tag", calc_majority_kappa),
+        )
+        .reset_index()
+        .rename(columns={"assignee": "worker_id"})
+    )
+
+    # prepare response
+    result_dataset = ResultDataset(
+        dataset_scores=dataset_scores,
+        data_points=[
+            ImageLabelBinaryFinalResult(**data_point)
+            for data_point in dataset.reset_index().to_dict(orient="records")
+        ],
+    )
+
+    worker_performance = [
+        WorkerPerformanceResult(**result)
+        for result in assignee_statistics.to_dict(orient="records")
     ]
 
-    return final_results
+    results = ImageLabelBinaryJobResults(
+        dataset=result_dataset, worker_performance=worker_performance
+    )
+
+    return results
 
 
-def process_intermediate_results(intermediate_results: dict, job_type: str) -> dict:
+def process_intermediate_results(intermediate_results: list[dict], job_type: str):
     match job_type:
         case JobTypes.image_label_binary.value:
-            final_results = process_image_label_binary_intermediate_results(
-                intermediate_results
-            )
-
-    return final_results
+            return process_image_label_binary_intermediate_results(intermediate_results)
+        case _:
+            raise ValueError(f'job_type "{job_type}" did not match any valid job type.')

--- a/packages/examples/cvat/recording-oracle/tests/testresources/recording_oracle_dummy_input.json
+++ b/packages/examples/cvat/recording-oracle/tests/testresources/recording_oracle_dummy_input.json
@@ -1,0 +1,321 @@
+[
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/1.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/2.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/3.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/4.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/5.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/6.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/7.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/8.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/9.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/10.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/11.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/12.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/13.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/14.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/15.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/16.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/17.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": "dummy_label"
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": ""
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/18.png"
+  },
+  {
+    "answers": [
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b36",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b37",
+        "tag": ""
+      },
+      {
+        "assignee": "0x0755D4d722a4a201c1C5A4B5E614D913e7747b38",
+        "tag": "dummy_label"
+      }
+    ],
+    "url": "https://test.storage.googleapis.com/19.png"
+  }
+]

--- a/packages/examples/cvat/recording-oracle/tests/unit/modules/agreement/conftest.py
+++ b/packages/examples/cvat/recording-oracle/tests/unit/modules/agreement/conftest.py
@@ -24,6 +24,10 @@ def bin_2r_im() -> np.ndarray:
 
 @pytest.fixture
 def bin_mr_im() -> np.ndarray:
+    """
+    Returns an incidence matrix (item x class) for a binary classification
+    problem with multiple raters.
+    """
     return np.asarray(
         [[3, 0], [2, 1], [2, 1], [2, 1], [1, 2], [0, 3], [0, 3], [1, 2], [1, 2], [1, 2]]
     )
@@ -31,9 +35,35 @@ def bin_mr_im() -> np.ndarray:
 
 @pytest.fixture
 def single_anno_cm() -> np.ndarray:
+    """Returns a confusion matrix with only a single annotation."""
     return np.asarray([[1, 0], [0, 0]])
 
 
 @pytest.fixture
 def wrong_dtype_cm() -> np.ndarray:
-    return np.asarray([[1.0, 2.0], [3.0, 4.0]])
+    """Returns a confusion matrix with the wrong dtype."""
+    return np.asarray([["a", "b"], ["c", "d"]])
+
+
+@pytest.fixture
+def seq_labels():
+    """Returns sequence containing labels."""
+    return np.asarray(["a", "b", "c"])
+
+
+@pytest.fixture
+def seq_labels_nan():
+    """Returns a sequence containing labels and nan values."""
+    return np.asarray([np.NaN, "b", "c"])
+
+
+@pytest.fixture
+def seq_values():
+    """Returns a sequence containing values."""
+    return [1, 2, 3, 4]
+
+
+@pytest.fixture
+def seq_labels_long():
+    """Returns a sequence containing more values."""
+    return np.asarray(["e", "f", "g", "h"])

--- a/packages/examples/cvat/recording-oracle/tests/unit/modules/agreement/test_measures.py
+++ b/packages/examples/cvat/recording-oracle/tests/unit/modules/agreement/test_measures.py
@@ -19,7 +19,7 @@ def test_percent_agreement(bin_2r_cm, bin_2r_im, single_anno_cm, wrong_dtype_cm)
     with pytest.raises(ValueError, match="must be a square"):
         percent_agreement(bin_2r_im, "cm")
 
-    with pytest.raises(ValueError, match="is a subtype of"):
+    with pytest.raises(ValueError, match="must be a numeric"):
         percent_agreement(wrong_dtype_cm)
 
 

--- a/packages/examples/cvat/recording-oracle/tests/unit/modules/agreement/test_utils.py
+++ b/packages/examples/cvat/recording-oracle/tests/unit/modules/agreement/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+from src.modules.agreement import confusion_matrix_from_sequence
+import numpy as np
+
+
+def test_confusion_matrix_from_sequence(
+    seq_values, seq_labels, seq_labels_nan, seq_labels_long, bin_2r_cm
+):
+    assert np.all(confusion_matrix_from_sequence(seq_values, seq_values) == np.eye(4))
+    assert np.all(
+        confusion_matrix_from_sequence(seq_labels, seq_labels_nan) == np.eye(2)
+    )
+
+    with pytest.raises(ValueError, match="same shape"):
+        confusion_matrix_from_sequence(seq_labels_long, seq_labels_nan)
+
+    with pytest.raises(ValueError, match="1-dimensional"):
+        confusion_matrix_from_sequence(seq_values, bin_2r_cm)
+
+    with pytest.raises(ValueError, match="must have the same kind of dtype"):
+        confusion_matrix_from_sequence(seq_values, seq_labels_nan)

--- a/packages/examples/cvat/recording-oracle/tests/unit/modules/webhook/conftest.py
+++ b/packages/examples/cvat/recording-oracle/tests/unit/modules/webhook/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+import json
+from pathlib import Path
+
+resource_path_root = Path(__file__).parent.parent.parent.parent / "testresources"
+
+
+@pytest.fixture
+def intermediate_results():
+    with open(resource_path_root / "recording_oracle_dummy_input.json") as f:
+        return json.load(f)

--- a/packages/examples/cvat/recording-oracle/tests/unit/modules/webhook/test_process_intermediate_results.py
+++ b/packages/examples/cvat/recording-oracle/tests/unit/modules/webhook/test_process_intermediate_results.py
@@ -1,0 +1,10 @@
+from src.modules.webhook.process_intermediate_results import (
+    process_image_label_binary_intermediate_results,
+)
+
+from src.modules.webhook.api_schema import ImageLabelBinaryJobResults
+
+
+def test_process_image_label_binary_intermediate_results(intermediate_results):
+    results = process_image_label_binary_intermediate_results(intermediate_results)
+    ImageLabelBinaryJobResults.validate(results)


### PR DESCRIPTION
## Description

This PR adds Agreement Measures to the results of the CVAT Recording Oracle and changes the output format.
Closes #761.

## Summary of changes

### Agreement Package `cvat/recording-oracle/modules/agreement`
- Minor refactoring of module structure.
  - Validation functions moved to new file (`validations.py`).
  - `utils.py` file added.
- Added new convenience function (`./utils/confusion_matrix_from_sequence` to convert sequences of data into an incidence matrix. Needed in recording oracle.
- Relaxed some validations, as the constraints were harsher than intended.

### Recording Oracle `cvat/recording-oracle/modules/webhook/process_intermediate_results.py`
- Rewrote existing processing of results of `process_image_label_binary_intermediate_results` using pandas. Should be more flexible for additions / changes in the future. The output format now looks like [this](https://www.notion.so/human-protocol/Inter-Rater-Agreement-Example-73a9b00590a742fe8219816c09f1adab?pvs=4#9a1db938ec30461583c3221ec392e99f)

## How test the changes

I added a rudimentary unit test for the `process_intermediate_results.py` function.

## Related issues

Closes #761.

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
