### PR TITLE
Upload encrypted file

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/Pipfile
+++ b/packages/sdk/python/human-protocol-sdk/Pipfile
@@ -12,7 +12,7 @@ setuptools-pipfile = "*"
 [packages]
 cryptography = "*"
 minio = "*"
-validators = "*"
+validators = "==0.20.0"
 web3 = "==6.8.*"
 aiohttp = "<4.0.0"  # broken freeze in one of dependencies
 pgpy = "*"

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -48,6 +48,7 @@ class EscrowConfig:
         reputation_oracle_fee: Decimal,
         manifest_url: str,
         hash: str,
+        skip_manifest_url_validation: bool = False,
     ):
         """
         Initializes a Escrow instance.
@@ -59,6 +60,7 @@ class EscrowConfig:
             reputation_oracle_fee (Decimal): Fee percentage of the Reputation Oracle
             manifest_url (str): Manifest file url
             hash (str): Manifest file hash
+            skip_manifest_url_validation (bool): Identify wether validate manifest_url
         """
         if not Web3.is_address(recording_oracle_address):
             raise EscrowClientError(
@@ -74,7 +76,7 @@ class EscrowConfig:
             raise EscrowClientError("Fee must be between 0 and 100")
         if recording_oracle_fee + reputation_oracle_fee > 100:
             raise EscrowClientError("Total fee must be less than 100")
-        if not URL(manifest_url):
+        if not URL(manifest_url) and not skip_manifest_url_validation:
             raise EscrowClientError(f"Invalid manifest URL: {manifest_url}")
         if not hash:
             raise EscrowClientError("Invalid empty manifest hash")
@@ -187,7 +189,7 @@ class EscrowClient:
         )
         return next(
             (
-                self.factory_contract.events.Launched().processLog(log)
+                self.factory_contract.events.Launched().process_log(log)
                 for log in transaction_receipt["logs"]
                 if log["address"] == self.network["factory_address"]
             ),

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -90,6 +90,35 @@ class EscrowTestCase(unittest.TestCase):
         self.assertEqual(escrow_config.manifest_url, manifest_url)
         self.assertEqual(escrow_config.hash, hash)
 
+    def test_escrow_config_valid_params(self):
+        recording_oracle_address = "0x1234567890123456789012345678901234567890"
+        reputation_oracle_address = "0x1234567890123456789012345678901234567890"
+        recording_oracle_fee = 10
+        reputation_oracle_fee = 10
+        manifest_url = "http://test:6000"
+        hash = "test"
+
+        escrow_config = EscrowConfig(
+            recording_oracle_address,
+            reputation_oracle_address,
+            recording_oracle_fee,
+            reputation_oracle_fee,
+            manifest_url,
+            hash,
+            True,
+        )
+
+        self.assertEqual(
+            escrow_config.recording_oracle_address, recording_oracle_address
+        )
+        self.assertEqual(
+            escrow_config.reputation_oracle_address, reputation_oracle_address
+        )
+        self.assertEqual(escrow_config.recording_oracle_fee, recording_oracle_fee)
+        self.assertEqual(escrow_config.reputation_oracle_fee, reputation_oracle_fee)
+        self.assertEqual(escrow_config.manifest_url, manifest_url)
+        self.assertEqual(escrow_config.hash, hash)
+
     def test_escrow_config_invalid_address(self):
         invalid_address = "invalid_address"
         valid_address = "0x1234567890123456789012345678901234567890"


### PR DESCRIPTION
## Description

Added ability to upload encrypted file using `StorageClient.upload_files` function.
Added possibility to skip `manifest_url` validation when `EscrowConfig` is creating. For docker containers URL is tracked as invalid.
Example: `http://bucket:8888`
Fix bug inside `EscrowClient.create_escrow` function: `processLog` call replaced on `process_log` call.

## Summary of changes

Upload encrypted file.
Possibility to skip `manifest_url` validation.
Fix `EscrowClient.create_escrow` function.

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
