### PR TITLE
Job Launcher - fix bugs of job launcher

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/payment.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/payment.ts
@@ -2,4 +2,5 @@ import { ICoingeckoTokenId } from '../interfaces';
 
 export const CoingeckoTokenId: ICoingeckoTokenId = {
   hmt: 'human-protocol',
+  usdt: 'tether',
 };

--- a/packages/apps/job-launcher/server/src/common/enums/payment.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/payment.ts
@@ -45,6 +45,7 @@ export enum Currency {
 
 export enum TokenId {
   HMT = 'hmt',
+  USDT = 'usdt',
 }
 
 export enum PaymentSource {
@@ -74,5 +75,3 @@ export enum StripePaymentStatus {
   REQUIRES_PAYMENT_METHOD = 'requires_payment_method',
   SUCCEEDED = 'succeeded',
 }
-
-

--- a/packages/apps/job-launcher/server/src/common/utils/decimal.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/decimal.ts
@@ -1,6 +1,5 @@
 import Decimal from 'decimal.js';
 
-
 export function mul(a: number, b: number): number {
   const decimalA = new Decimal(a);
   const decimalB = new Decimal(b);

--- a/packages/apps/job-launcher/server/src/common/utils/index.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/index.ts
@@ -14,8 +14,9 @@ export async function getRate(from: string, to: string): Promise<number> {
 
   if (Object.values(TokenId).includes(to as TokenId)) {
     [from, to] = [CoingeckoTokenId[to], from];
-  } else {
     reversed = true;
+  } else {
+    [from, to] = [CoingeckoTokenId[from], to];
   }
 
   const httpService = new HttpService();

--- a/packages/apps/job-launcher/server/src/common/utils/index.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/index.ts
@@ -1,32 +1,33 @@
-import { firstValueFrom } from "rxjs";
-import { CoingeckoTokenId } from "../constants/payment";
-import { TokenId } from "../enums/payment";
-import { COINGECKO_API_URL } from "../constants";
-import { NotFoundException } from "@nestjs/common";
-import { ErrorCurrency } from "../constants/errors";
-import { HttpService } from "@nestjs/axios";
+import { firstValueFrom } from 'rxjs';
+import { CoingeckoTokenId } from '../constants/payment';
+import { TokenId } from '../enums/payment';
+import { COINGECKO_API_URL } from '../constants';
+import { NotFoundException } from '@nestjs/common';
+import { ErrorCurrency } from '../constants/errors';
+import { HttpService } from '@nestjs/axios';
 
 export async function getRate(from: string, to: string): Promise<number> {
-    let reversed = false;
-
-    if (Object.values(TokenId).includes(to as TokenId)) {
-      [from, to] = [CoingeckoTokenId[to], from];
-    } else {
-      reversed = true;
-    }
-
-    const httpService = new HttpService()
-     const { data } = await firstValueFrom(
-       httpService.get(
-         `${COINGECKO_API_URL}?ids=${from}&vs_currencies=${to}`,
-       ),
-     ) as any;
-
-    if (!data[from] || !data[from][to]) {
-      throw new NotFoundException(ErrorCurrency.PairNotFound);
-    }
-
-    const rate = data[from][to];
-
-    return reversed ? 1 / rate : rate;
+  if (from === to) {
+    return 1;
   }
+  let reversed = false;
+
+  if (Object.values(TokenId).includes(to as TokenId)) {
+    [from, to] = [CoingeckoTokenId[to], from];
+  } else {
+    reversed = true;
+  }
+
+  const httpService = new HttpService();
+  const { data } = (await firstValueFrom(
+    httpService.get(`${COINGECKO_API_URL}?ids=${from}&vs_currencies=${to}`),
+  )) as any;
+
+  if (!data[from] || !data[from][to]) {
+    throw new NotFoundException(ErrorCurrency.PairNotFound);
+  }
+
+  const rate = data[from][to];
+
+  return reversed ? 1 / rate : rate;
+}

--- a/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
@@ -191,13 +191,13 @@ export class InitialMigration1691485394906 implements MigrationInterface {
             DROP TABLE "hmt"."payments"
         `);
     await queryRunner.query(`
+            DROP TYPE "hmt"."payments_status_enum"
+        `);
+    await queryRunner.query(`
             DROP TYPE "hmt"."payments_source_enum"
         `);
     await queryRunner.query(`
             DROP TYPE "hmt"."payments_type_enum"
-        `);
-    await queryRunner.query(`
-            DROP TYPE "hmt"."payments_status_enum"
         `);
     await queryRunner.dropSchema(NS);
   }

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.service.spec.ts
@@ -506,6 +506,7 @@ describe('AuthService', () => {
     const userEntity: Partial<UserEntity> = {
       id: 1,
       email: 'user@example.com',
+      status: UserStatus.PENDING,
     };
 
     const tokenEntity = {

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.service.ts
@@ -78,7 +78,7 @@ export class AuthService {
       tokenType: TokenType.EMAIL,
       user: userEntity,
     });
-    
+
     await this.sendgridService.sendEmail({
       to: data.email,
       subject: 'Verify your email',
@@ -167,7 +167,7 @@ Click ${this.feURL}/verify?token=${tokenEntity.uuid} to complete sign up.`,
     this.sendgridService.sendEmail({
       to: tokenEntity.user.email,
       subject: 'Password changed',
-      text: 'Password is changed successfully!',
+      text: 'Password has been changed successfully!',
     });
 
     await tokenEntity.remove();
@@ -194,7 +194,7 @@ Click ${this.feURL}/verify?token=${tokenEntity.uuid} to complete sign up.`,
   ): Promise<void> {
     const userEntity = await this.userService.getByEmail(data.email);
 
-    if (!userEntity) {
+    if (!userEntity || userEntity?.status != UserStatus.PENDING) {
       throw new NotFoundException(ErrorUser.NotFound);
     }
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Post,
+  Query,
   Request,
   UseGuards,
 } from '@nestjs/common';
@@ -33,11 +34,18 @@ export class JobController {
     @Request() req: RequestWithUser,
     @Body() data: JobImageLabelBinaryDto,
   ): Promise<number> {
-    return this.jobService.createJob(req.user.id, JobRequestType.IMAGE_LABEL_BINARY, data);
+    return this.jobService.createJob(
+      req.user.id,
+      JobRequestType.IMAGE_LABEL_BINARY,
+      data,
+    );
   }
 
   @Get('/result')
-  public async getResult(@Request() req: any): Promise<any> {
-    return this.jobService.getResult(req.user?.id);
+  public async getResult(
+    @Request() req: RequestWithUser,
+    @Query('jobId') jobId: number,
+  ): Promise<any> {
+    return this.jobService.getResult(req.user.id, jobId);
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -4,8 +4,12 @@ import { HttpService } from '@nestjs/axios';
 import { BadGatewayException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
-import { BigNumber, FixedNumber, ethers } from 'ethers';
-import { ErrorBucket, ErrorJob, ErrorWeb3 } from '../../common/constants/errors';
+import { ethers } from 'ethers';
+import {
+  ErrorBucket,
+  ErrorJob,
+  ErrorWeb3,
+} from '../../common/constants/errors';
 import {
   PaymentSource,
   PaymentStatus,
@@ -30,11 +34,12 @@ import {
   MOCK_REPUTATION_ORACLE_FEE,
   MOCK_REQUESTER_DESCRIPTION,
   MOCK_REQUESTER_TITLE,
+  MOCK_JOB_ID,
+  MOCK_USER_ID,
 } from '../../../test/constants';
 import { PaymentService } from '../payment/payment.service';
 import { Web3Service } from '../web3/web3.service';
 import {
-  CreateJobDto,
   FortuneFinalResultDto,
   FortuneManifestDto,
   ImageLabelBinaryFinalResultDto,
@@ -67,17 +72,17 @@ jest.mock('@human-protocol/sdk', () => ({
 }));
 
 jest.mock('../../common/utils', () => ({
-  getRate: jest.fn().mockImplementation(() => 1.5)
+  getRate: jest.fn().mockImplementation(() => 1.5),
 }));
 
 describe('JobService', () => {
   let jobService: JobService,
-      jobRepository: JobRepository,
-      paymentRepository: PaymentRepository,
-      paymentService: PaymentService,
-      createPaymentMock: any,
-      routingProtocolService: RoutingProtocolService,
-      web3Service: Web3Service;
+    jobRepository: JobRepository,
+    paymentRepository: PaymentRepository,
+    paymentService: PaymentService,
+    createPaymentMock: any,
+    routingProtocolService: RoutingProtocolService,
+    web3Service: Web3Service;
 
   const signerMock = {
     address: MOCK_ADDRESS,
@@ -109,7 +114,7 @@ describe('JobService', () => {
           case 'WEB3_PRIVATE_KEY':
             return MOCK_PRIVATE_KEY;
           case 'S3_BUCKET':
-            return MOCK_BUCKET_NAME
+            return MOCK_BUCKET_NAME;
         }
       }),
     };
@@ -125,7 +130,10 @@ describe('JobService', () => {
           },
         },
         { provide: JobRepository, useValue: createMock<JobRepository>() },
-        { provide: PaymentRepository, useValue: createMock<PaymentRepository>() },
+        {
+          provide: PaymentRepository,
+          useValue: createMock<PaymentRepository>(),
+        },
         { provide: PaymentService, useValue: createMock<PaymentService>() },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: HttpService, useValue: createMock<HttpService>() },
@@ -155,7 +163,7 @@ describe('JobService', () => {
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
       fundAmount: 10,
     };
-    
+
     let getUserBalanceMock: any;
 
     beforeEach(() => {
@@ -171,7 +179,7 @@ describe('JobService', () => {
       const fundAmount = 10;
       const rate = 1.5;
       const fee = (MOCK_JOB_LAUNCHER_FEE / 100) * fundAmount;
-      
+
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
@@ -185,7 +193,7 @@ describe('JobService', () => {
         currency: TokenId.HMT,
         amount: -(fundAmount + fee),
         rate: rate,
-        status: PaymentStatus.SUCCEEDED
+        status: PaymentStatus.SUCCEEDED,
       });
       expect(jobRepository.create).toHaveBeenCalledWith({
         chainId: fortuneJobDto.chainId,
@@ -210,7 +218,10 @@ describe('JobService', () => {
         .spyOn(routingProtocolService, 'selectNetwork')
         .mockReturnValue(ChainId.MOONBEAM);
 
-      await jobService.createJob(userId, JobRequestType.FORTUNE, { ...fortuneJobDto, chainId: undefined });
+      await jobService.createJob(userId, JobRequestType.FORTUNE, {
+        ...fortuneJobDto,
+        chainId: undefined,
+      });
 
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
       expect(jobRepository.create).toHaveBeenCalledWith({
@@ -228,7 +239,7 @@ describe('JobService', () => {
     it('should throw an exception for invalid chain id provided', async () => {
       web3Service.validateChainId = jest.fn(() => {
         throw new Error(ErrorWeb3.InvalidTestnetChainId);
-      })
+      });
 
       await expect(
         jobService.createJob(userId, JobRequestType.FORTUNE, fortuneJobDto),
@@ -253,7 +264,6 @@ describe('JobService', () => {
 
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-
       jest.spyOn(jobRepository, 'create').mockResolvedValue(undefined!);
 
       await expect(
@@ -270,7 +280,7 @@ describe('JobService', () => {
       chainId: MOCK_CHAIN_ID,
       submissionsRequired: MOCK_SUBMISSION_REQUIRED,
       dataUrl: MOCK_FILE_URL,
-      labels: ["cat", 'dog'],
+      labels: ['cat', 'dog'],
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
       requesterAccuracyTarget: 0.95,
       fundAmount: 10,
@@ -294,7 +304,11 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-      await jobService.createJob(userId, JobRequestType.IMAGE_LABEL_BINARY, imageLabelBinaryJobDto);
+      await jobService.createJob(
+        userId,
+        JobRequestType.IMAGE_LABEL_BINARY,
+        imageLabelBinaryJobDto,
+      );
 
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
       expect(paymentRepository.create).toHaveBeenCalledWith({
@@ -304,7 +318,7 @@ describe('JobService', () => {
         currency: TokenId.HMT,
         amount: -(fundAmount + fee),
         rate: 1.5,
-        status: PaymentStatus.SUCCEEDED
+        status: PaymentStatus.SUCCEEDED,
       });
       expect(jobRepository.create).toHaveBeenCalledWith({
         chainId: imageLabelBinaryJobDto.chainId,
@@ -329,7 +343,10 @@ describe('JobService', () => {
         .spyOn(routingProtocolService, 'selectNetwork')
         .mockReturnValue(ChainId.MOONBEAM);
 
-      await jobService.createJob(userId, JobRequestType.IMAGE_LABEL_BINARY, { ...imageLabelBinaryJobDto, chainId: undefined });
+      await jobService.createJob(userId, JobRequestType.IMAGE_LABEL_BINARY, {
+        ...imageLabelBinaryJobDto,
+        chainId: undefined,
+      });
 
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
       expect(jobRepository.create).toHaveBeenCalledWith({
@@ -347,10 +364,14 @@ describe('JobService', () => {
     it('should throw an exception for invalid chain id provided', async () => {
       web3Service.validateChainId = jest.fn(() => {
         throw new Error(ErrorWeb3.InvalidTestnetChainId);
-      })
+      });
 
       await expect(
-        jobService.createJob(userId, JobRequestType.IMAGE_LABEL_BINARY, imageLabelBinaryJobDto),
+        jobService.createJob(
+          userId,
+          JobRequestType.IMAGE_LABEL_BINARY,
+          imageLabelBinaryJobDto,
+        ),
       ).rejects.toThrowError(ErrorWeb3.InvalidTestnetChainId);
     });
 
@@ -364,7 +385,11 @@ describe('JobService', () => {
       getUserBalanceMock.mockResolvedValue(userBalance);
 
       await expect(
-        jobService.createJob(userId, JobRequestType.IMAGE_LABEL_BINARY, imageLabelBinaryJobDto),
+        jobService.createJob(
+          userId,
+          JobRequestType.IMAGE_LABEL_BINARY,
+          imageLabelBinaryJobDto,
+        ),
       ).rejects.toThrowError(ErrorJob.NotEnoughFunds);
     });
 
@@ -373,11 +398,14 @@ describe('JobService', () => {
 
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-
       jest.spyOn(jobRepository, 'create').mockResolvedValue(undefined!);
 
       await expect(
-        jobService.createJob(userId, JobRequestType.IMAGE_LABEL_BINARY, imageLabelBinaryJobDto),
+        jobService.createJob(
+          userId,
+          JobRequestType.IMAGE_LABEL_BINARY,
+          imageLabelBinaryJobDto,
+        ),
       ).rejects.toThrowError(ErrorJob.NotCreated);
     });
   });
@@ -560,11 +588,9 @@ describe('JobService', () => {
       const fundAmount = 10;
 
       (EscrowClient.build as any).mockImplementation(() => ({
-        createAndSetupEscrow: jest
-          .fn()
-          .mockResolvedValue(MOCK_ADDRESS),
+        createAndSetupEscrow: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       }));
-      
+
       jobService.sendWebhook = jest.fn().mockResolvedValue(true);
 
       const manifest: ImageLabelBinaryManifestDto = {
@@ -577,8 +603,10 @@ describe('JobService', () => {
         requestType: JobRequestType.IMAGE_LABEL_BINARY,
       };
 
-      getManifestMock.mockResolvedValue(manifest as ImageLabelBinaryManifestDto);
-  
+      getManifestMock.mockResolvedValue(
+        manifest as ImageLabelBinaryManifestDto,
+      );
+
       const mockJobEntity: Partial<JobEntity> = {
         chainId: 1,
         manifestUrl: MOCK_FILE_URL,
@@ -590,11 +618,16 @@ describe('JobService', () => {
 
       await jobService.launchJob(mockJobEntity as JobEntity);
 
-      expect(mockTokenContract.transfer).toHaveBeenCalledWith(MOCK_ADDRESS, mockJobEntity.fundAmount);
+      expect(mockTokenContract.transfer).toHaveBeenCalledWith(
+        MOCK_ADDRESS,
+        mockJobEntity.fundAmount,
+      );
       expect(mockJobEntity.escrowAddress).toBe(MOCK_ADDRESS);
       expect(mockJobEntity.status).toBe(JobStatus.LAUNCHED);
       expect(mockJobEntity.save).toHaveBeenCalled();
-      expect(jobService.getManifest).toHaveBeenCalledWith(mockJobEntity.manifestUrl);
+      expect(jobService.getManifest).toHaveBeenCalledWith(
+        mockJobEntity.manifestUrl,
+      );
     });
 
     it('should throw an error if the manifest validation failed', async () => {
@@ -704,8 +737,8 @@ describe('JobService', () => {
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
       fundAmount: 10,
       dataUrl: MOCK_FILE_URL,
-      labels: ["cat", "dog"],
-      requesterAccuracyTarget: 0.95
+      labels: ['cat', 'dog'],
+      requesterAccuracyTarget: 0.95,
     };
 
     let uploadFilesMock: any;
@@ -726,7 +759,9 @@ describe('JobService', () => {
         },
       ]);
 
-      const result = await jobService.saveManifest(imageLabelBinaryManifestParams);
+      const result = await jobService.saveManifest(
+        imageLabelBinaryManifestParams,
+      );
 
       expect(result).toEqual({
         manifestUrl: MOCK_FILE_URL,
@@ -817,7 +852,7 @@ describe('JobService', () => {
 
     it('should download and return the manifest', async () => {
       const fundAmount = 10;
-      
+
       const manifest: FortuneManifestDto = {
         submissionsRequired: 10,
         requesterTitle: MOCK_REQUESTER_TITLE,
@@ -869,9 +904,12 @@ describe('JobService', () => {
         solution: 'good',
       };
 
+      (EscrowClient.build as any).mockImplementation(() => ({
+        getResultsUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
+      }));
       downloadFileFromUrlMock.mockResolvedValue(fortuneResult);
 
-      const result = await jobService.getResult(MOCK_FILE_URL);
+      const result = await jobService.getResult(MOCK_USER_ID, MOCK_JOB_ID);
 
       expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
         MOCK_FILE_URL,
@@ -889,7 +927,7 @@ describe('JobService', () => {
 
       downloadFileFromUrlMock.mockResolvedValue(imageBinaryResult);
 
-      const result = await jobService.getResult(MOCK_FILE_URL);
+      const result = await jobService.getResult(MOCK_USER_ID, MOCK_JOB_ID);
 
       expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
         MOCK_FILE_URL,
@@ -900,9 +938,9 @@ describe('JobService', () => {
     it('should throw a NotFoundException if the result is not found', async () => {
       downloadFileFromUrlMock.mockResolvedValue(null);
 
-      await expect(jobService.getResult(MOCK_FILE_URL)).rejects.toThrowError(
-        new NotFoundException(ErrorJob.ResultNotFound),
-      );
+      await expect(
+        jobService.getResult(MOCK_USER_ID, MOCK_JOB_ID),
+      ).rejects.toThrowError(new NotFoundException(ErrorJob.ResultNotFound));
       expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(
         MOCK_FILE_URL,
       );
@@ -915,7 +953,9 @@ describe('JobService', () => {
         solutionNotFortune: 'good',
       });
 
-      await expect(jobService.getResult(MOCK_FILE_URL)).rejects.toThrowError(
+      await expect(
+        jobService.getResult(MOCK_USER_ID, MOCK_JOB_ID),
+      ).rejects.toThrowError(
         new NotFoundException(ErrorJob.ResultValidationFailed),
       );
       expect(StorageClient.downloadFileFromUrl).toHaveBeenCalledWith(

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -54,7 +54,9 @@ import { JobService } from './job.service';
 import { HMToken__factory } from '@human-protocol/core/typechain-types';
 import { RoutingProtocolService } from './routing-protocol.service';
 import { PaymentRepository } from '../payment/payment.repository';
+import { div, mul } from '../../common/utils/decimal';
 
+const rate = 1.5;
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
   EscrowClient: {
@@ -72,7 +74,7 @@ jest.mock('@human-protocol/sdk', () => ({
 }));
 
 jest.mock('../../common/utils', () => ({
-  getRate: jest.fn().mockImplementation(() => 1.5),
+  getRate: jest.fn().mockImplementation(() => rate),
 }));
 
 describe('JobService', () => {
@@ -154,7 +156,6 @@ describe('JobService', () => {
   });
 
   describe('createJob', () => {
-    const rate = 0.5;
     const userId = 1;
     const fortuneJobDto: JobFortuneDto = {
       chainId: MOCK_CHAIN_ID,
@@ -177,7 +178,6 @@ describe('JobService', () => {
 
     it('should create a job successfully', async () => {
       const fundAmount = 10;
-      const rate = 1.5;
       const fee = (MOCK_JOB_LAUNCHER_FEE / 100) * fundAmount;
 
       const userBalance = 25;
@@ -191,8 +191,8 @@ describe('JobService', () => {
         source: PaymentSource.BALANCE,
         type: PaymentType.WITHDRAWAL,
         currency: TokenId.HMT,
-        amount: -(fundAmount + fee),
-        rate: rate,
+        amount: -mul(fundAmount + fee, rate),
+        rate: div(1, rate),
         status: PaymentStatus.SUCCEEDED,
       });
       expect(jobRepository.create).toHaveBeenCalledWith({
@@ -200,8 +200,8 @@ describe('JobService', () => {
         userId,
         manifestUrl: expect.any(String),
         manifestHash: expect.any(String),
-        fee,
-        fundAmount,
+        fee: mul(fee, rate),
+        fundAmount: mul(fundAmount, rate),
         status: JobStatus.PENDING,
         waitUntil: expect.any(Date),
       });
@@ -229,8 +229,8 @@ describe('JobService', () => {
         userId,
         manifestUrl: expect.any(String),
         manifestHash: expect.any(String),
-        fee,
-        fundAmount,
+        fee: mul(fee, rate),
+        fundAmount: mul(fundAmount, rate),
         status: JobStatus.PENDING,
         waitUntil: expect.any(Date),
       });
@@ -273,7 +273,6 @@ describe('JobService', () => {
   });
 
   describe('createJob with image label binary type', () => {
-    const rate = 0.5;
     const userId = 1;
 
     const imageLabelBinaryJobDto: JobImageLabelBinaryDto = {
@@ -316,8 +315,8 @@ describe('JobService', () => {
         source: PaymentSource.BALANCE,
         type: PaymentType.WITHDRAWAL,
         currency: TokenId.HMT,
-        amount: -(fundAmount + fee),
-        rate: 1.5,
+        amount: -mul(fundAmount + fee, rate),
+        rate: div(1, rate),
         status: PaymentStatus.SUCCEEDED,
       });
       expect(jobRepository.create).toHaveBeenCalledWith({
@@ -325,8 +324,8 @@ describe('JobService', () => {
         userId,
         manifestUrl: expect.any(String),
         manifestHash: expect.any(String),
-        fee,
-        fundAmount: fundAmount,
+        fee: mul(fee, rate),
+        fundAmount: mul(fundAmount, rate),
         status: JobStatus.PENDING,
         waitUntil: expect.any(Date),
       });
@@ -354,8 +353,8 @@ describe('JobService', () => {
         userId,
         manifestUrl: expect.any(String),
         manifestHash: expect.any(String),
-        fee,
-        fundAmount,
+        fee: mul(fee, rate),
+        fundAmount: mul(fundAmount, rate),
         status: JobStatus.PENDING,
         waitUntil: expect.any(Date),
       });

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
@@ -54,7 +54,7 @@ export class PaymentController {
   @Get('/rates')
   public async getRate(@Query() data: GetRateDto): Promise<number> {
     try {
-      return getRate(data.currency, data.token);
+      return getRate(data.from, data.to);
     } catch (e) {
       throw new Error(e);
     }

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
@@ -25,9 +25,7 @@ import { getRate } from '../../common/utils';
 @ApiTags('Payment')
 @Controller('/payment')
 export class PaymentController {
-  constructor(
-    private readonly paymentService: PaymentService,
-  ) {}
+  constructor(private readonly paymentService: PaymentService) {}
 
   @Post('/fiat')
   public async createFiatPayment(

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
@@ -5,7 +5,6 @@ import {
   PaymentSource,
   PaymentStatus,
   PaymentType,
-  TokenId,
 } from '../../common/enums/payment';
 import { ChainId } from '@human-protocol/sdk';
 
@@ -53,15 +52,11 @@ export class PaymentCreateDto {
 }
 
 export class GetRateDto {
-  @ApiProperty({
-    enum: TokenId,
-  })
-  @IsEnum(TokenId)
-  public token: TokenId;
+  @ApiProperty()
+  @IsString()
+  public from: string;
 
-  @ApiProperty({
-    enum: Currency,
-  })
-  @IsEnum(Currency)
-  public currency: Currency;
+  @ApiProperty()
+  @IsString()
+  public to: string;
 }

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
@@ -208,9 +208,10 @@ describe('PaymentService', () => {
       };
 
       const paymentData = {
-        status: 'succeeded',
+        status: StripePaymentStatus.SUCCEEDED,
         amount: 100,
-        currency: Currency.EUR,
+        amount_received: 100,
+        currency: Currency.USD,
       };
 
       retrievePaymentIntentMock.mockResolvedValue(paymentData);
@@ -229,6 +230,8 @@ describe('PaymentService', () => {
       const paymentData = {
         status: StripePaymentStatus.CANCELED,
         amount: 100,
+        amount_received: 0,
+        currency: Currency.USD,
       };
 
       retrievePaymentIntentMock.mockResolvedValue(paymentData);
@@ -247,6 +250,8 @@ describe('PaymentService', () => {
       const paymentData = {
         status: StripePaymentStatus.REQUIRES_PAYMENT_METHOD,
         amount: 100,
+        amount_received: 0,
+        currency: Currency.USD,
       };
 
       retrievePaymentIntentMock.mockResolvedValue(paymentData);
@@ -265,6 +270,8 @@ describe('PaymentService', () => {
       const paymentData = {
         status: 'unknown_status',
         amount: 100,
+        amount_received: 0,
+        currency: Currency.USD,
       };
 
       retrievePaymentIntentMock.mockResolvedValue(paymentData);

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
@@ -31,7 +31,7 @@ import { mul } from '../../common/utils/decimal';
 jest.mock('@human-protocol/sdk');
 
 jest.mock('../../common/utils', () => ({
-  getRate: jest.fn().mockImplementation(() => 1.5)
+  getRate: jest.fn().mockImplementation(() => 1.5),
 }));
 
 describe('PaymentService', () => {
@@ -150,7 +150,8 @@ describe('PaymentService', () => {
       expect(result).toEqual(paymentIntent.client_secret);
     });
 
-    it('should throw a bad request exception if transaction already exist', async () => {0
+    it('should throw a bad request exception if transaction already exist', async () => {
+      0;
       const dto = {
         amount: 100,
         currency: Currency.USD,
@@ -172,7 +173,8 @@ describe('PaymentService', () => {
       ).rejects.toThrowError(ErrorPayment.TransactionAlreadyExists);
     });
 
-    it('should throw a bad request exception if the payment intent creation fails', async () => {0
+    it('should throw a bad request exception if the payment intent creation fails', async () => {
+      0;
       const dto = {
         amount: 100,
         currency: Currency.USD,
@@ -360,7 +362,7 @@ describe('PaymentService', () => {
         source: PaymentSource.CRYPTO,
         type: PaymentType.DEPOSIT,
         currency: TokenId.HMT,
-        amount: mul(10, 1.5),
+        amount: 10,
         rate: 1.5,
         transaction: MOCK_TRANSACTION_HASH,
         chainId: ChainId.LOCALHOST,
@@ -538,7 +540,7 @@ describe('PaymentService', () => {
           status: PaymentStatus.SUCCEEDED,
         },
         {
-          amount: -(180),
+          amount: -180,
           rate: 1,
           type: PaymentType.WITHDRAWAL,
           status: PaymentStatus.SUCCEEDED,

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
@@ -131,6 +131,8 @@ export class PaymentService {
       userId,
       transaction: data.paymentId,
       status: PaymentStatus.PENDING,
+      amount: div(paymentData.amount_received, 100),
+      currency: paymentData.currency,
     });
 
     if (!paymentEntity) {

--- a/packages/apps/job-launcher/server/src/modules/user/user.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/user/user.service.ts
@@ -15,7 +15,6 @@ import { UserRepository } from './user.repository';
 import { ValidatePasswordDto } from '../auth/auth.dto';
 import { ErrorUser } from '../../common/constants/errors';
 import { PaymentService } from '../payment/payment.service';
-import { ethers } from 'ethers';
 import { IUserBalance } from '../../common/interfaces';
 import { Currency } from '../../common/enums/payment';
 

--- a/packages/apps/job-launcher/server/test/constants.ts
+++ b/packages/apps/job-launcher/server/test/constants.ts
@@ -29,7 +29,10 @@ export const MOCK_REFRESH_TOKEN = 'refresh_token';
 export const MOCK_ACCESS_TOKEN_HASHED = 'access_token_hashed';
 export const MOCK_REFRESH_TOKEN_HASHED = 'refresh_token_hashed';
 export const MOCK_EXPIRES_IN = 1000000000000000;
+export const MOCK_USER_ID = 1;
+export const MOCK_JOB_ID = 1;
 
-export const MOCK_SENDGRID_API_KEY = 'SG.xxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+export const MOCK_SENDGRID_API_KEY =
+  'SG.xxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 export const MOCK_SENDGRID_FROM_EMAIL = 'info@hmt.ai';
 export const MOCK_SENDGRID_FROM_NAME = 'John Doe';


### PR DESCRIPTION
## Description

Erros fixed after manual testing

## Summary of changes

1. Fix in getrates for cases where from and to are the same. For example for usd to usd coingecko return 0.9... instead of 1.
2. Don't send verification email to users that are not in pending status.
3. Fix getResult endpoint. Previous implementation didn't make sense.
4. Fix math round in create fiat payment. Cannot round "randomly". Use decimals library and Math.Ceil to round up.
5. Save payment id instead of payment secret when creating a fiat payment.
6. In createCryptoPayment and chainId to findOne call, since we might have the same transaction hash in different chains.
7. Create job endpoint is considering that the fundAmount is HMT, but it should be USD.

## How test the changes

yarn test

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
