### PR TITLE
Fix/missing gql folder

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/setup.py
+++ b/packages/sdk/python/human-protocol-sdk/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="human-protocol-sdk",
-    version="0.0.8",
+    version="0.0.10",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/human-protocol/packages/sdk/python/human-protocol-sdk",


### PR DESCRIPTION
## Description

Add `__init__.py` file to `gql` folder. Absence of this folder cause issue that folder is not copied to result package.

## Summary of changes

Add `__init__.py` file to `gql` folder.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
