### PR TITLE
[Job Launcher] Added job id relation to the payment

### DIFF
--- a/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
@@ -29,6 +29,7 @@ export class InitialMigration1691485394906 implements MigrationInterface {
                 "source" "hmt"."payments_source_enum" NOT NULL,
                 "status" "hmt"."payments_status_enum" NOT NULL,
                 "user_id" integer NOT NULL,
+                "job_id" integer,
                 CONSTRAINT "PK_197ab7af18c93fbb0c9b28b4a59" PRIMARY KEY ("id")
             )
         `);
@@ -133,6 +134,10 @@ export class InitialMigration1691485394906 implements MigrationInterface {
             ADD CONSTRAINT "FK_9027c8f0ba75fbc1ac46647d043" FOREIGN KEY ("user_id") REFERENCES "hmt"."users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
     await queryRunner.query(`
+            ALTER TABLE "hmt"."payments"
+            ADD CONSTRAINT "FK_f83af8ea8055b85bde0e095e400" FOREIGN KEY ("job_id") REFERENCES "hmt"."jobs"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+    await queryRunner.query(`
             ALTER TABLE "hmt"."tokens"
             ADD CONSTRAINT "FK_8769073e38c365f315426554ca5" FOREIGN KEY ("user_id") REFERENCES "hmt"."users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
         `);
@@ -151,6 +156,9 @@ export class InitialMigration1691485394906 implements MigrationInterface {
         `);
     await queryRunner.query(`
             ALTER TABLE "hmt"."jobs" DROP CONSTRAINT "FK_9027c8f0ba75fbc1ac46647d043"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."payments" DROP CONSTRAINT "FK_f83af8ea8055b85bde0e095e400"
         `);
     await queryRunner.query(`
             ALTER TABLE "hmt"."payments" DROP CONSTRAINT "FK_427785468fb7d2733f59e7d7d39"

--- a/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1691485394906-InitialMigration.ts
@@ -30,6 +30,7 @@ export class InitialMigration1691485394906 implements MigrationInterface {
                 "status" "hmt"."payments_status_enum" NOT NULL,
                 "user_id" integer NOT NULL,
                 "job_id" integer,
+                CONSTRAINT "REL_f83af8ea8055b85bde0e095e40" UNIQUE ("job_id"),
                 CONSTRAINT "PK_197ab7af18c93fbb0c9b28b4a59" PRIMARY KEY ("id")
             )
         `);

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.entity.ts
@@ -1,7 +1,6 @@
 import {
   Column,
   Entity,
-  Generated,
   JoinColumn,
   OneToOne,
   PrimaryGeneratedColumn,

--- a/packages/apps/job-launcher/server/src/modules/job/job.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.entity.ts
@@ -1,10 +1,11 @@
-import { Column, Entity, Index, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
 
 import { NS } from '../../common/constants';
 import { IJob } from '../../common/interfaces';
 import { JobStatus } from '../../common/enums/job';
 import { BaseEntity } from '../../database/base.entity';
 import { UserEntity } from '../user/user.entity';
+import { PaymentEntity } from '../payment/payment.entity';
 
 @Entity({ schema: NS, name: 'jobs' })
 @Index(['chainId', 'escrowAddress'], { unique: true })
@@ -38,6 +39,9 @@ export class JobEntity extends BaseEntity implements IJob {
 
   @Column({ type: 'int' })
   public userId: number;
+
+  @OneToMany(() => PaymentEntity, (payment) => payment.job)
+  public payments: PaymentEntity[];
 
   @Column({ type: 'int', default: 0 })
   public retriesCount: number;

--- a/packages/apps/job-launcher/server/src/modules/job/job.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, OneToOne } from 'typeorm';
 
 import { NS } from '../../common/constants';
 import { IJob } from '../../common/interfaces';
@@ -40,8 +40,8 @@ export class JobEntity extends BaseEntity implements IJob {
   @Column({ type: 'int' })
   public userId: number;
 
-  @OneToMany(() => PaymentEntity, (payment) => payment.job)
-  public payments: PaymentEntity[];
+  @OneToOne(() => PaymentEntity, (payment) => payment.job)
+  public payment: PaymentEntity;
 
   @Column({ type: 'int', default: 0 })
   public retriesCount: number;

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -161,6 +161,7 @@ describe('JobService', () => {
 
   describe('createJob', () => {
     const userId = 1;
+    const jobId = 123;
     const fortuneJobDto: JobFortuneDto = {
       chainId: MOCK_CHAIN_ID,
       submissionsRequired: MOCK_SUBMISSION_REQUIRED,
@@ -187,11 +188,27 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
+      const mockJobEntity: Partial<JobEntity> = {
+        id: jobId,
+        userId: userId,
+        chainId: ChainId.LOCALHOST,
+        manifestUrl: MOCK_FILE_URL,
+        manifestHash: MOCK_FILE_HASH,
+        escrowAddress: MOCK_ADDRESS,
+        fee,
+        fundAmount,
+        status: JobStatus.PENDING,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      jobRepository.create = jest.fn().mockResolvedValue(mockJobEntity);
+
       await jobService.createJob(userId, JobRequestType.FORTUNE, fortuneJobDto);
 
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
       expect(paymentRepository.create).toHaveBeenCalledWith({
         userId,
+        jobId,
         source: PaymentSource.BALANCE,
         type: PaymentType.WITHDRAWAL,
         currency: TokenId.HMT,
@@ -278,6 +295,7 @@ describe('JobService', () => {
 
   describe('createJob with image label binary type', () => {
     const userId = 1;
+    const jobId = 123;
 
     const imageLabelBinaryJobDto: JobCvatDto = {
       chainId: MOCK_CHAIN_ID,
@@ -309,6 +327,21 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
+      const mockJobEntity: Partial<JobEntity> = {
+        id: jobId,
+        userId: userId,
+        chainId: ChainId.LOCALHOST,
+        manifestUrl: MOCK_FILE_URL,
+        manifestHash: MOCK_FILE_HASH,
+        escrowAddress: MOCK_ADDRESS,
+        fee,
+        fundAmount,
+        status: JobStatus.PENDING,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      jobRepository.create = jest.fn().mockResolvedValue(mockJobEntity);
+
       await jobService.createJob(
         userId,
         JobRequestType.IMAGE_LABEL_BINARY,
@@ -318,6 +351,7 @@ describe('JobService', () => {
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
       expect(paymentRepository.create).toHaveBeenCalledWith({
         userId,
+        jobId,
         source: PaymentSource.BALANCE,
         type: PaymentType.WITHDRAWAL,
         currency: TokenId.HMT,

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -187,6 +187,7 @@ export class JobService {
     try {
       await this.paymentRepository.create({
         userId,
+        jobId: jobEntity.id,
         source: PaymentSource.BALANCE,
         type: PaymentType.WITHDRAWAL,
         amount: -tokenTotalAmount,

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.dto.ts
@@ -49,6 +49,7 @@ export class PaymentCreateDto {
   public type?: PaymentType;
   public chainId?: number;
   public status?: PaymentStatus;
+  public jobId?: number;
 }
 
 export class GetRateDto {

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.entity.ts
@@ -3,6 +3,7 @@ import { NS } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
 import { PaymentSource, PaymentStatus, PaymentType } from '../../common/enums/payment';
 import { UserEntity } from '../user/user.entity';
+import { JobEntity } from '../job/job.entity';
 
 @Entity({ schema: NS, name: 'payments' })
 @Index(['chainId', 'transaction'], {
@@ -53,4 +54,11 @@ export class PaymentEntity extends BaseEntity {
 
   @Column({ type: 'int' })
   public userId: number;
+
+  @JoinColumn()
+  @ManyToOne(() => JobEntity, (job) => job.payments)
+  public job: JobEntity;
+
+  @Column({ type: 'int', nullable: true  })
+  public jobId: number;
 }

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne, OneToOne } from 'typeorm';
 import { NS } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
 import { PaymentSource, PaymentStatus, PaymentType } from '../../common/enums/payment';
@@ -56,7 +56,7 @@ export class PaymentEntity extends BaseEntity {
   public userId: number;
 
   @JoinColumn()
-  @ManyToOne(() => JobEntity, (job) => job.payments)
+  @OneToOne(() => JobEntity, (job) => job.payment)
   public job: JobEntity;
 
   @Column({ type: 'int', nullable: true  })


### PR DESCRIPTION
## Description
For ensure job cancelation correct, withdrawal payment related with the particular job id need to be failed, for this purpose job id field was added to payment entity.

## Summary of changes
- Added job id property to the payment entity 
- Updated migration
- Updated dto
- Updated unit tests 

**The assumption (for simplicity) that one job has one payment works. The solution implements a one-to-one relationship.**

## Related issues
[[Job Launcher] Add job id property to payment entity#834](https://github.com/humanprotocol/human-protocol/issues/834)
