### PR TITLE
[Job Launcher] Added job cancelation cron endpoint for vercel

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -16,6 +16,7 @@ import { RequestWithUser } from 'src/common/types';
 import { JobFortuneDto, JobCvatDto, JobListDto, JobCancelDto } from './job.dto';
 import { JobService } from './job.service';
 import { JobRequestType, JobStatusFilter } from 'src/common/enums/job';
+import { Public } from 'src/common/decorators';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -67,5 +68,11 @@ export class JobController {
     @Param() params: JobCancelDto,
   ): Promise<boolean> {
     return this.jobService.requestToCancelJob(req.user.id, params.id);
+  }
+
+  @Public()
+  @Get('/cron/cancel')
+  public async cancelCronJob(): Promise<any> {
+    return this.jobService.cancelCronJob();
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.cron.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.cron.ts
@@ -41,27 +41,4 @@ export class JobCron {
       return;
     }
   }
-
-  @Cron(CronExpression.EVERY_10_SECONDS)
-  public async cancelJob() {
-    try {
-      const jobEntity = await this.jobEntityRepository.findOne({
-        where: {
-          status: JobStatus.TO_CANCEL,
-          retriesCount: LessThanOrEqual(JOB_RETRIES_COUNT_THRESHOLD),
-          waitUntil: LessThanOrEqual(new Date()),
-        },
-        order: {
-          waitUntil: SortDirection.ASC,
-        },
-      });
-
-      if (!jobEntity) return;
-
-      await this.jobService.cancelJob(jobEntity);
-    } catch (e) {
-      this.logger.error(e);
-      return;
-    }
-  }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -746,6 +746,7 @@ describe('JobService', () => {
     let escrowClientMock: any,
         getManifestMock: any,
         jobSaveMock: any,
+        findOneJobMock: any,
         findOnePaymentMock: any,
         buildMock: any,
         sendWebhookMock: any,
@@ -777,9 +778,11 @@ describe('JobService', () => {
 
       getManifestMock = jest.spyOn(jobService, 'getManifest');
       jobSaveMock = jest.spyOn(jobEntityMock, 'save');
+      findOneJobMock = jest.spyOn(jobRepository, 'findOne');
       findOnePaymentMock = jest.spyOn(paymentRepository, 'findOne');
       buildMock = jest.spyOn(EscrowClient, 'build');
       sendWebhookMock = jest.spyOn(jobService, 'sendWebhook');
+      findOneJobMock.mockResolvedValueOnce(jobEntityMock as JobCvatDto);
       findOnePaymentMock.mockResolvedValueOnce(paymentEntityMock as PaymentEntity);
     });
 
@@ -791,7 +794,7 @@ describe('JobService', () => {
       jobEntityMock.escrowAddress = undefined;
       jobSaveMock.mockResolvedValue(jobEntityMock as JobEntity);
       
-      const result = await jobService.cancelJob(jobEntityMock as any);
+      const result = await jobService.cancelCronJob();
 
       expect(result).toBe(true);
       expect(escrowClientMock.cancel).toBeCalledTimes(0);
@@ -805,7 +808,7 @@ describe('JobService', () => {
       buildMock.mockResolvedValue(escrowClientMock as any); 
 
       await expect(
-        jobService.cancelJob(jobEntityMock as any)
+        jobService.cancelCronJob()
       ).rejects.toThrowError(
         new BadGatewayException(ErrorEscrow.InvalidStatusCancellation),
       );
@@ -818,7 +821,7 @@ describe('JobService', () => {
       buildMock.mockResolvedValue(escrowClientMock as any); 
 
       await expect(
-        jobService.cancelJob(jobEntityMock as any)
+        jobService.cancelCronJob()
       ).rejects.toThrowError(
         new BadGatewayException(ErrorEscrow.InvalidBalanceCancellation),
       );
@@ -838,7 +841,7 @@ describe('JobService', () => {
       buildMock.mockResolvedValue(escrowClientMock as any);
       sendWebhookMock.mockResolvedValue(true);
       
-      const result = await jobService.cancelJob(jobEntityMock as any);
+      const result = await jobService.cancelCronJob();
 
       expect(result).toBe(true);
       expect(escrowClientMock.cancel).toHaveBeenCalledWith(jobEntityMock.escrowAddress);
@@ -878,7 +881,7 @@ describe('JobService', () => {
       buildMock.mockResolvedValue(escrowClientMock as any);
       sendWebhookMock.mockResolvedValue(true);
       
-      const result = await jobService.cancelJob(jobEntityMock as any);
+      const result = await jobService.cancelCronJob();
 
       expect(result).toBe(true);
       expect(escrowClientMock.cancel).toHaveBeenCalledWith(jobEntityMock.escrowAddress);

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -28,7 +28,7 @@ import { ConfigService } from '@nestjs/config';
 import { validate } from 'class-validator';
 import { BigNumber } from 'ethers';
 import { firstValueFrom } from 'rxjs';
-import { In, QueryFailedError } from 'typeorm';
+import { In, LessThanOrEqual, QueryFailedError } from 'typeorm';
 import { ConfigNames } from '../../common/config';
 import {
   ErrorBucket,
@@ -69,6 +69,8 @@ import { JobEntity } from './job.entity';
 import { JobRepository } from './job.repository';
 import { RoutingProtocolService } from './routing-protocol.service';
 import { EventType } from '../../common/enums/webhook';
+import { SortDirection } from '../../common/enums/collection';
+import { JOB_RETRIES_COUNT_THRESHOLD } from '../../common/constants';
 
 @Injectable()
 export class JobService {
@@ -300,66 +302,6 @@ export class JobService {
     return true;
   }
 
-  public async cancelJob(
-    jobEntity: JobEntity
-  ): Promise<boolean> {
-    const { escrowAddress } = jobEntity
-    if (escrowAddress) {
-      const signer = this.web3Service.getSigner(jobEntity.chainId);
-      const escrowClient = await EscrowClient.build(signer);
-
-      const escrowStatus = await escrowClient.getStatus(escrowAddress)
-      if (escrowStatus === EscrowStatus.Complete || escrowStatus === EscrowStatus.Paid) {
-        this.logger.log(ErrorEscrow.InvalidStatusCancellation, JobService.name);
-        throw new BadRequestException(ErrorEscrow.InvalidStatusCancellation);
-      }
-
-      const balance = await escrowClient.getBalance(escrowAddress);
-      if (balance.eq(0)) {
-        this.logger.log(ErrorEscrow.InvalidBalanceCancellation, JobService.name);
-        throw new BadRequestException(ErrorEscrow.InvalidBalanceCancellation);
-      }
-
-      await escrowClient.cancel(escrowAddress)
-
-      const manifest = await this.getManifest(jobEntity.manifestUrl);
-      if ((manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE) {
-        await this.sendWebhook(
-          this.configService.get<string>(
-            ConfigNames.FORTUNE_EXCHANGE_ORACLE_WEBHOOK_URL,
-          )!,
-          {
-            escrowAddress,
-            chainId: jobEntity.chainId,
-            eventType: EventType.ESCROW_CANCELED
-          },
-        );
-      } else {
-        await this.sendWebhook(
-          this.configService.get<string>(
-            ConfigNames.CVAT_EXCHANGE_ORACLE_WEBHOOK_URL,
-          )!,
-          {
-            escrowAddress,
-            chainId: jobEntity.chainId,
-            eventType: EventType.ESCROW_CANCELED
-          },
-        );
-      }
-    }
-
-    const paymentEntity = await this.paymentRepository.findOne({ jobId: jobEntity.id, type: PaymentType.WITHDRAWAL, status: PaymentStatus.SUCCEEDED });
-    if (paymentEntity) {
-      paymentEntity.status = PaymentStatus.FAILED;
-      await paymentEntity.save();
-    }
-
-    jobEntity.status = JobStatus.CANCELED;
-    await jobEntity.save();
-    
-    return true;
-  }
-
   public async saveManifest(
     manifest: FortuneManifestDto | CvatManifestDto,
   ): Promise<SaveManifestDto> {
@@ -522,5 +464,79 @@ export class JobService {
     }
 
     return result;
+  }
+
+  public async cancelCronJob() {
+    // TODO: Add retry policy and process failure requests https://github.com/humanprotocol/human-protocol/issues/334
+    let jobEntity = await this.jobRepository.findOne(
+      {
+        status: JobStatus.TO_CANCEL,
+        retriesCount: LessThanOrEqual(JOB_RETRIES_COUNT_THRESHOLD),
+        waitUntil: LessThanOrEqual(new Date()),
+      },
+      {
+        order: {
+          waitUntil: SortDirection.ASC,
+        },
+      },
+    );
+
+    if (!jobEntity) return;
+
+    const { escrowAddress } = jobEntity
+    if (escrowAddress) {
+      const signer = this.web3Service.getSigner(jobEntity.chainId);
+      const escrowClient = await EscrowClient.build(signer);
+
+      const escrowStatus = await escrowClient.getStatus(escrowAddress)
+      if (escrowStatus === EscrowStatus.Complete || escrowStatus === EscrowStatus.Paid) {
+        this.logger.log(ErrorEscrow.InvalidStatusCancellation, JobService.name);
+        throw new BadRequestException(ErrorEscrow.InvalidStatusCancellation);
+      }
+
+      const balance = await escrowClient.getBalance(escrowAddress);
+      if (balance.eq(0)) {
+        this.logger.log(ErrorEscrow.InvalidBalanceCancellation, JobService.name);
+        throw new BadRequestException(ErrorEscrow.InvalidBalanceCancellation);
+      }
+
+      await escrowClient.cancel(escrowAddress)
+
+      const manifest = await this.getManifest(jobEntity.manifestUrl);
+      if ((manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE) {
+        await this.sendWebhook(
+          this.configService.get<string>(
+            ConfigNames.FORTUNE_EXCHANGE_ORACLE_WEBHOOK_URL,
+          )!,
+          {
+            escrowAddress,
+            chainId: jobEntity.chainId,
+            eventType: EventType.ESCROW_CANCELED
+          },
+        );
+      } else {
+        await this.sendWebhook(
+          this.configService.get<string>(
+            ConfigNames.CVAT_EXCHANGE_ORACLE_WEBHOOK_URL,
+          )!,
+          {
+            escrowAddress,
+            chainId: jobEntity.chainId,
+            eventType: EventType.ESCROW_CANCELED
+          },
+        );
+      }
+    }
+
+    const paymentEntity = await this.paymentRepository.findOne({ jobId: jobEntity.id, type: PaymentType.WITHDRAWAL, status: PaymentStatus.SUCCEEDED });
+    if (paymentEntity) {
+      paymentEntity.status = PaymentStatus.FAILED;
+      await paymentEntity.save();
+    }
+
+    jobEntity.status = JobStatus.CANCELED;
+    await jobEntity.save();
+    
+    return true;
   }
 }


### PR DESCRIPTION
## Description
Add job cancelation cron endpoint for vercel.
Vercel doesn't allow to download scripts or css files from a different origin, it can be able to call the endpoint to finalize hob cancellation request.

## Summary of changes
- Added endpoint
- Updated unit tests
- Updated cron service

## How test the changes
[[Job Launcher] Add job cancelation cron endpoint for vercel#837](https://github.com/humanprotocol/human-protocol/issues/837)