### PR TITLE
[Job Launcher] Exchange Oracle webhook

### DIFF
--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
@@ -61,8 +61,8 @@ export class JobService {
     };
 
     this.storageClient = new StorageClient(
-      storageCredentials,
       this.storageParams,
+      storageCredentials,
     );
   }
 

--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -12,6 +12,8 @@ export enum ErrorJob {
   ResultValidationFailed = 'Result validation failed',
   InvalidRequestType = 'Invalid job type',
   JobParamsValidationFailed = 'Job parameters validation failed',
+  InvalidEventType = 'Invalid event type',
+  NotLaunched = 'Not launched' 
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/common/constants/index.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/index.ts
@@ -20,3 +20,5 @@ export const MAINNET_CHAIN_IDS = [
 
 export const SENDGRID_API_KEY_REGEX =
   /^SG\.[A-Za-z0-9-_]{22}\.[A-Za-z0-9-_]{43}$/;
+
+export const HEADER_SIGNATURE_KEY = 'human-signature';

--- a/packages/apps/job-launcher/server/src/common/enums/webhook.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/webhook.ts
@@ -3,3 +3,8 @@ export enum EventType {
   ESCROW_CANCELED = 'escrow_canceled',
   TASK_CREATION_FAILED = 'task_creation_failed',
 }
+
+export enum OracleType {
+  FORTUNE = 'fortune',
+  CVAT = 'cvat',
+}

--- a/packages/apps/job-launcher/server/src/common/guards/index.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/index.ts
@@ -1,1 +1,2 @@
 export * from './jwt.auth';
+export * from './signature.auth';

--- a/packages/apps/job-launcher/server/src/common/guards/signature.auth.spec.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/signature.auth.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SignatureAuthGuard } from './signature.auth';
+import { verifySignature } from '../utils/signature';
+import { MOCK_ADDRESS } from '../../../test/constants';
+
+jest.mock('../../common/utils/signature');
+
+describe('SignatureAuthGuard', () => {
+  let guard: SignatureAuthGuard;
+  let mockConfigService: Partial<ConfigService>;
+  
+  beforeEach(async () => {
+    mockConfigService = {
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SignatureAuthGuard,
+        { provide: ConfigService, useValue: mockConfigService }
+      ],
+    }).compile();
+
+    guard = module.get<SignatureAuthGuard>(SignatureAuthGuard);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    let context: ExecutionContext;
+    let mockRequest: any;
+
+    beforeEach(() => {
+      mockRequest = {
+        switchToHttp: jest.fn().mockReturnThis(),
+        getRequest: jest.fn().mockReturnThis(),
+        headers: {},
+        body: {},
+        originalUrl: '',
+      };
+      context = {
+        switchToHttp: jest.fn().mockReturnThis(),
+        getRequest: jest.fn(() => mockRequest)
+      } as any as ExecutionContext;
+    });
+
+    it('should return true if signature is verified', async () => {
+      mockRequest.headers['header-signature-key'] = 'validSignature';
+      jest.spyOn(guard, 'determineAddress').mockReturnValue('someAddress');
+      (verifySignature as jest.Mock).mockReturnValue(true);
+
+      const result = await guard.canActivate(context as any);
+      expect(result).toBeTruthy();
+    });
+
+    it('should throw unauthorized exception if signature is not verified', async () => {
+      jest.spyOn(guard, 'determineAddress').mockReturnValue('someAddress');
+      (verifySignature as jest.Mock).mockReturnValue(false);
+
+      await expect(guard.canActivate(context as any)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw unauthorized exception for unrecognized oracle type', async () => {
+      mockRequest.originalUrl = '/some/random/path';
+      await expect(guard.canActivate(context as any)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('determineAddress', () => {
+    it('should return the correct address if originalUrl contains the fortune oracle type', () => {
+      const mockRequest = { originalUrl: '/somepath/fortune/anotherpath' };
+      const expectedAddress = MOCK_ADDRESS;
+      mockConfigService.get = jest.fn().mockReturnValue(expectedAddress);
+
+      const result = guard.determineAddress(mockRequest);
+
+      expect(result).toEqual(expectedAddress);
+    });
+
+    it('should return the correct address if originalUrl contains the cvat oracle type', () => {
+      const mockRequest = { originalUrl: '/somepath/cvat/anotherpath' };
+      const expectedAddress = MOCK_ADDRESS;
+      mockConfigService.get = jest.fn().mockReturnValue(expectedAddress);
+
+      const result = guard.determineAddress(mockRequest);
+
+      expect(result).toEqual(expectedAddress);
+    });
+
+    it('should throw BadRequestException for unrecognized oracle type', () => {
+      const mockRequest = { originalUrl: '/some/random/path' };
+
+      expect(() => {
+        guard.determineAddress(mockRequest);
+      }).toThrow(BadRequestException);
+    });
+
+  });
+});

--- a/packages/apps/job-launcher/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/signature.auth.ts
@@ -1,0 +1,52 @@
+
+import { BadRequestException, CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { verifySignature } from '../utils/signature';
+import { HEADER_SIGNATURE_KEY } from '../constants';
+import { ConfigService } from '@nestjs/config';
+import { ConfigNames } from '../config';
+import { OracleType } from '../enums/webhook';
+
+@Injectable()
+export class SignatureAuthGuard implements CanActivate {
+  constructor(
+    public readonly configService: ConfigService
+  ) {}
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    
+    const data = request.body;
+    const signature = request.headers[HEADER_SIGNATURE_KEY]; 
+
+    try {
+      const address = this.determineAddress(request);
+      const isVerified = verifySignature(data, signature, address)
+
+      if (isVerified) {
+        return true;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+
+    throw new UnauthorizedException('Unauthorized');
+  }
+
+  public determineAddress(request: any): string {
+    const originalUrl = request.originalUrl;
+    const parts = originalUrl.split('/');
+    const oracleType = parts[2];
+
+    if (oracleType === OracleType.FORTUNE) {
+      return this.configService.get<string>(
+        ConfigNames.FORTUNE_EXCHANGE_ORACLE_ADDRESS,
+      )!
+    } else if (oracleType === OracleType.CVAT) {
+      return this.configService.get<string>(
+        ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS,
+      )!
+    } else {
+      throw new BadRequestException('Unable to determine address from origin URL');
+    }
+  }
+}

--- a/packages/apps/job-launcher/server/src/common/types/request.ts
+++ b/packages/apps/job-launcher/server/src/common/types/request.ts
@@ -1,3 +1,6 @@
 export interface RequestWithUser extends Request {
   user: any;
 }
+export interface RequestWithWeb3Address extends Request {
+  web3Address: any;
+}

--- a/packages/apps/job-launcher/server/src/common/types/request.ts
+++ b/packages/apps/job-launcher/server/src/common/types/request.ts
@@ -1,6 +1,3 @@
 export interface RequestWithUser extends Request {
   user: any;
 }
-export interface RequestWithWeb3Address extends Request {
-  web3Address: any;
-}

--- a/packages/apps/job-launcher/server/src/common/utils/signature.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/signature.ts
@@ -37,7 +37,7 @@ export function recoverSigner(
   if (typeof message !== 'string') {
     message = JSON.stringify(message);
   }
-
+  
   try {
     return ethers.utils.verifyMessage(message, signature);
   } catch (e) {

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -86,7 +86,7 @@ export class JobController {
 
   @Public()
   @UseGuards(SignatureAuthGuard)
-  @Post('/cvat/escrow-failed-webhook')
+  @Post('/:oracleType/escrow-failed-webhook')
   public async (
     @Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() data: EscrowFailedWebhookDto,

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -86,7 +86,7 @@ export class JobController {
 
   @Public()
   @UseGuards(SignatureAuthGuard)
-  @Post('/cvat/escrow-failed-webhook')
+  @Post('/webhook/escrow-failed')
   public async (
     @Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() data: EscrowFailedWebhookDto,

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard, SignatureAuthGuard } from '../../common/guards';
-import { RequestWithUser, RequestWithWeb3Address } from '../../common/types';
+import { RequestWithUser } from '../../common/types';
 import { JobFortuneDto, JobCvatDto, JobListDto, JobCancelDto, EscrowFailedWebhookDto } from './job.dto';
 import { JobService } from './job.service';
 import { JobRequestType, JobStatusFilter } from '../../common/enums/job';

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   DefaultValuePipe,
   Get,
+  Headers,
   Param,
   Patch,
   Post,
@@ -11,12 +12,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
-import { JwtAuthGuard } from '../../common/guards';
-import { RequestWithUser } from '../../common/types';
-import { JobFortuneDto, JobCvatDto, JobListDto, JobCancelDto } from './job.dto';
+import { JwtAuthGuard, SignatureAuthGuard } from '../../common/guards';
+import { RequestWithUser, RequestWithWeb3Address } from '../../common/types';
+import { JobFortuneDto, JobCvatDto, JobListDto, JobCancelDto, EscrowFailedWebhookDto } from './job.dto';
 import { JobService } from './job.service';
 import { JobRequestType, JobStatusFilter } from '../../common/enums/job';
 import { Public } from '../../common/decorators';
+import { HEADER_SIGNATURE_KEY } from 'src/common/constants';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -80,5 +82,15 @@ export class JobController {
   @Get('/cron/cancel')
   public async cancelCronJob(): Promise<any> {
     return this.jobService.cancelCronJob();
+  }
+
+  @Public()
+  @UseGuards(SignatureAuthGuard)
+  @Post('/cvat/escrow-failed-webhook')
+  public async (
+    @Headers(HEADER_SIGNATURE_KEY) _: string,
+    @Body() data: EscrowFailedWebhookDto,
+  ): Promise<any> {
+    return this.jobService.escrowFailedWebhook(data);
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -86,7 +86,7 @@ export class JobController {
 
   @Public()
   @UseGuards(SignatureAuthGuard)
-  @Post('/webhook/escrow-failed')
+  @Post('/cvat/escrow-failed-webhook')
   public async (
     @Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() data: EscrowFailedWebhookDto,

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -17,7 +17,7 @@ import {
   JobStatus,
   JobStatusFilter,
 } from '../../common/enums/job';
-import { EventType } from '../../common/enums/webhook';
+import { EventType, OracleType } from '../../common/enums/webhook';
 
 export class JobCreateDto {
   public chainId: ChainId;

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -224,3 +224,23 @@ export class JobListDto {
   fundAmount: number;
   status: JobStatusFilter;
 }
+
+export class EscrowFailedWebhookDto {
+  @ApiProperty({
+    enum: ChainId,
+  })
+  @IsEnum(ChainId)
+  public chain_id: ChainId;
+
+  @ApiProperty()
+  @IsString()
+  public escrow_address: string;
+
+  @ApiProperty()
+  @IsEnum(EventType)
+  public event_type: EventType;
+
+  @ApiProperty()
+  @IsString()
+  public reason: string;
+}

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1,7 +1,7 @@
 import { createMock } from '@golevelup/ts-jest';
 import { ChainId, EscrowClient, EscrowStatus, StorageClient } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
-import { BadGatewayException, NotFoundException } from '@nestjs/common';
+import { BadGatewayException, BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import {
@@ -1163,6 +1163,40 @@ describe('JobService', () => {
           take: limit,
         },
       );
+    });
+  });
+
+  describe('escrowFailedWebhook', () => {
+    it('should throw BadRequestException for invalid event type', async () => {
+      const dto = { event_type: 'ANOTHER_EVENT' as EventType, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+
+      await expect(jobService.escrowFailedWebhook(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException if jobEntity is not found', async () => {
+      const dto = { event_type: EventType.TASK_CREATION_FAILED, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      jobRepository.findOne = jest.fn().mockResolvedValue(null);
+
+      await expect(jobService.escrowFailedWebhook(dto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException if jobEntity status is not LAUNCHED', async () => {
+      const dto = { event_type: EventType.TASK_CREATION_FAILED, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      const mockJobEntity = { status: 'ANOTHER_STATUS' as JobStatus, save: jest.fn() };
+      jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
+
+      await expect(jobService.escrowFailedWebhook(dto)).rejects.toThrow(ConflictException);
+    });
+
+    it('should update jobEntity status to FAILED and return true if all checks pass', async () => {
+      const dto = { event_type: EventType.TASK_CREATION_FAILED, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      const mockJobEntity = { status: JobStatus.LAUNCHED, save: jest.fn() };
+      jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
+
+      const result = await jobService.escrowFailedWebhook(dto);
+      expect(result).toBe(true);
+      expect(mockJobEntity.status).toBe(JobStatus.FAILED);
+      expect(mockJobEntity.save).toHaveBeenCalled();
     });
   });
 });

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -66,8 +66,8 @@ export class WebhookService {
     this.bucket = this.configService.get<string>(ConfigNames.S3_BUCKET)!;
 
     this.storageClient = new StorageClient(
-      storageCredentials,
       this.storageParams,
+      storageCredentials,
     );
   }
 


### PR DESCRIPTION
## Description
There may be a case where [CVAT] Exchange Oracle fails to create a task on the CVAT side and throws an error, and it should be able to notify the job launcher of this. Now, the job launcher will be notified about errors and performing the necessary actions with the escrow.

## Summary of changes
- Implemented new endpoint to controller.
- Implemented webhook logic to the service.
- Created and updated unit tests.

## How test the changes
**POST /cvat/escrow-failed-webhook**
```
Payload:
{
  "escrow_address": "0x60C5185b06CEa5cA7d3BDE8f1292Bfb8729E24d5", 
  "chain_id": 80001, 
  "event_type": "task_creation_failed", 
  "reason": "invalid manifest"
}

Signature:
0x5c89bb473d912ec0299a3577f8ed73216f6647227b1de2dc45911b895944937300ec62c152eca353be21e3043437e1fb03d1f057abc0a7e24acc484df19004ff1b

Address:
0x93DcC58cDDCB026984821DF7bbef46400E20394C
```
`yarn test`

## Related issues
[[Job Launcher] [CVAT] Exchange Oracle notification webhook#790](https://github.com/humanprotocol/human-protocol/issues/790)