### PR TITLE
Feat: Add JobRequesterId to createEscrow function

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -66,7 +66,7 @@ EscrowFactory allows job launchers to create new Escrow contracts.
 
 - `createEscrow(token, trustedHandlers, jobRequesterId)`
 
-  Create a new escrow, which uses ERC20 token for payment, as well as extra trusted handlers. Job launcher is canceler itself, and the job duration is 100 days. Job Requester Id is passed to keep track of job creators.
+  Create a new escrow, which uses ERC20 token for payment, as well as extra trusted handlers. Job launcher is canceler itself, and the job duration is 100 days. Job Requester Id is passed to keep track of job creators. Here, jobRequesterId is an internal id of the Job Launcher, and it can be used to identify the jobs requested by each Job Requester without crossing data between Subgraph and database.
 
 - `hasEscrow(escrow)`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,9 +64,9 @@ On the other hand, it can be cancelled anytime.
 
 EscrowFactory allows job launchers to create new Escrow contracts.
 
-- `createEscrow(token, trustedHandlers)`
+- `createEscrow(token, trustedHandlers, jobRequesterId)`
 
-  Create a new escrow, which uses ERC20 token for payment, as well as extra trusted handlers. Job launcher is canceler itself, and the job duration is 100 days.
+  Create a new escrow, which uses ERC20 token for payment, as well as extra trusted handlers. Job launcher is canceler itself, and the job duration is 100 days. Job Requester Id is passed to keep track of job creators.
 
 - `hasEscrow(escrow)`
 

--- a/packages/core/contracts/EscrowFactory.sol
+++ b/packages/core/contracts/EscrowFactory.sol
@@ -19,6 +19,7 @@ contract EscrowFactory is OwnableUpgradeable, UUPSUpgradeable {
     address public staking;
 
     event Launched(address token, address escrow);
+    event LaunchedV2(address token, address escrow, string jobRequesterId);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -39,7 +40,8 @@ contract EscrowFactory is OwnableUpgradeable, UUPSUpgradeable {
 
     function createEscrow(
         address token,
-        address[] memory trustedHandlers
+        address[] memory trustedHandlers,
+        string memory jobRequesterId
     ) public returns (address) {
         bool hasAvailableStake = IStaking(staking).hasAvailableStake(
             msg.sender
@@ -59,7 +61,7 @@ contract EscrowFactory is OwnableUpgradeable, UUPSUpgradeable {
         counter++;
         escrowCounters[address(escrow)] = counter;
         lastEscrow = address(escrow);
-        emit Launched(token, lastEscrow);
+        emit LaunchedV2(token, lastEscrow, jobRequesterId);
         return lastEscrow;
     }
 

--- a/packages/core/contracts/test/EscrowFactoryV0.sol
+++ b/packages/core/contracts/test/EscrowFactoryV0.sol
@@ -19,6 +19,7 @@ contract EscrowFactoryV0 is OwnableUpgradeable, UUPSUpgradeable {
     address public staking;
 
     event Launched(address token, address escrow);
+    event LaunchedV2(address token, address escrow, string jobRequesterId);
 
     function initialize(address _staking) external payable virtual initializer {
         __Ownable_init_unchained();
@@ -34,7 +35,8 @@ contract EscrowFactoryV0 is OwnableUpgradeable, UUPSUpgradeable {
 
     function createEscrow(
         address token,
-        address[] memory trustedHandlers
+        address[] memory trustedHandlers,
+        string memory jobRequesterId
     ) public returns (address) {
         bool hasAvailableStake = IStaking(staking).hasAvailableStake(
             msg.sender
@@ -54,7 +56,7 @@ contract EscrowFactoryV0 is OwnableUpgradeable, UUPSUpgradeable {
         counter++;
         escrowCounters[address(escrow)] = counter;
         lastEscrow = address(escrow);
-        emit Launched(token, lastEscrow);
+        emit LaunchedV2(token, lastEscrow, jobRequesterId);
         return lastEscrow;
     }
 

--- a/packages/core/test/EscrowFactory.ts
+++ b/packages/core/test/EscrowFactory.ts
@@ -13,6 +13,7 @@ describe('EscrowFactory', function () {
 
   let token: HMToken, escrowFactory: EscrowFactory, staking: Staking;
 
+  const jobRequesterId = 'job-requester-id';
   const minimumStake = 2;
   const lockPeriod = 2;
 
@@ -22,10 +23,10 @@ describe('EscrowFactory', function () {
     const result = await (
       await escrowFactory
         .connect(operator)
-        .createEscrow(token.address, trustedHandlers)
+        .createEscrow(token.address, trustedHandlers, jobRequesterId)
     ).wait();
     const event = result.events?.find(({ topics }) =>
-      topics.includes(ethers.utils.id('Launched(address,address)'))
+      topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
     )?.args;
 
     return event;
@@ -96,7 +97,11 @@ describe('EscrowFactory', function () {
     await expect(
       escrowFactory
         .connect(operator)
-        .createEscrow(token.address, [await reputationOracle.getAddress()])
+        .createEscrow(
+          token.address,
+          [await reputationOracle.getAddress()],
+          jobRequesterId
+        )
     ).to.be.revertedWith('Needs to stake HMT tokens to create an escrow.');
   });
 
@@ -113,10 +118,10 @@ describe('EscrowFactory', function () {
     await expect(
       escrowFactory
         .connect(operator)
-        .createEscrow(token.address, trustedHandlers)
+        .createEscrow(token.address, trustedHandlers, jobRequesterId)
     )
-      .to.emit(escrowFactory, 'Launched')
-      .withArgs(token.address, anyValue);
+      .to.emit(escrowFactory, 'LaunchedV2')
+      .withArgs(token.address, anyValue, jobRequesterId);
   });
 
   it('Should find the newly created escrow from deployed escrow', async () => {
@@ -152,7 +157,11 @@ describe('EscrowFactory', function () {
     await expect(
       escrowFactory
         .connect(operator)
-        .createEscrow(token.address, [await reputationOracle.getAddress()])
+        .createEscrow(
+          token.address,
+          [await reputationOracle.getAddress()],
+          jobRequesterId
+        )
     ).to.be.revertedWith('Needs to stake HMT tokens to create an escrow.');
   });
 

--- a/packages/core/test/RewardPool.ts
+++ b/packages/core/test/RewardPool.ts
@@ -25,6 +25,7 @@ describe('RewardPool', function () {
   const minimumStake = 2;
   const lockPeriod = 2;
   const rewardFee = 2;
+  const jobRequesterId = 'job-requester-id';
 
   this.beforeAll(async () => {
     [
@@ -136,10 +137,14 @@ describe('RewardPool', function () {
       const result = await (
         await escrowFactory
           .connect(operator)
-          .createEscrow(token.address, [await validator.getAddress()])
+          .createEscrow(
+            token.address,
+            [await validator.getAddress()],
+            jobRequesterId
+          )
       ).wait();
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       expect(event?.token).to.equal(token.address, 'token address is correct');
@@ -226,10 +231,14 @@ describe('RewardPool', function () {
       const result = await (
         await escrowFactory
           .connect(operator)
-          .createEscrow(token.address, [await validator.getAddress()])
+          .createEscrow(
+            token.address,
+            [await validator.getAddress()],
+            jobRequesterId
+          )
       ).wait();
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       expect(event?.token).to.equal(token.address, 'token address is correct');

--- a/packages/core/test/Staking.ts
+++ b/packages/core/test/Staking.ts
@@ -27,6 +27,7 @@ describe('Staking', function () {
   const minimumStake = 2;
   const lockPeriod = 2;
   const rewardFee = 1;
+  const jobRequesterId = 'job-requester-id';
 
   let owner: Signer,
     validator: Signer,
@@ -252,10 +253,14 @@ describe('Staking', function () {
       const result = await (
         await escrowFactory
           .connect(operator)
-          .createEscrow(token.address, [await validator.getAddress()])
+          .createEscrow(
+            token.address,
+            [await validator.getAddress()],
+            jobRequesterId
+          )
       ).wait();
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       expect(event?.token).to.equal(token.address, 'token address is correct');
@@ -350,10 +355,14 @@ describe('Staking', function () {
       const result = await (
         await escrowFactory
           .connect(operator)
-          .createEscrow(token.address, [await validator.getAddress()])
+          .createEscrow(
+            token.address,
+            [await validator.getAddress()],
+            jobRequesterId
+          )
       ).wait();
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       expect(event?.token).to.equal(token.address, 'token address is correct');
@@ -542,10 +551,14 @@ describe('Staking', function () {
         const result = await (
           await escrowFactory
             .connect(operator)
-            .createEscrow(token.address, [await validator.getAddress()])
+            .createEscrow(
+              token.address,
+              [await validator.getAddress()],
+              jobRequesterId
+            )
         ).wait();
         const event = result.events?.find(({ topics }) =>
-          topics.includes(ethers.utils.id('Launched(address,address)'))
+          topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
         )?.args;
 
         expect(event?.token).to.equal(
@@ -608,10 +621,14 @@ describe('Staking', function () {
         const result = await (
           await escrowFactory
             .connect(operator)
-            .createEscrow(token.address, [await validator.getAddress()])
+            .createEscrow(
+              token.address,
+              [await validator.getAddress()],
+              jobRequesterId
+            )
         ).wait();
         const event = result.events?.find(({ topics }) =>
-          topics.includes(ethers.utils.id('Launched(address,address)'))
+          topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
         )?.args;
 
         expect(event?.token).to.equal(
@@ -667,10 +684,14 @@ describe('Staking', function () {
       const result = await (
         await escrowFactory
           .connect(operator)
-          .createEscrow(token.address, [await validator.getAddress()])
+          .createEscrow(
+            token.address,
+            [await validator.getAddress()],
+            jobRequesterId
+          )
       ).wait();
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       expect(event?.token).to.equal(token.address, 'token address is correct');
@@ -857,14 +878,18 @@ describe('Staking', function () {
       const result = await (
         await escrowFactory
           .connect(operator)
-          .createEscrow(token.address, [
-            await validator.getAddress(),
-            await reputationOracle.getAddress(),
-            await recordingOracle.getAddress(),
-          ])
+          .createEscrow(
+            token.address,
+            [
+              await validator.getAddress(),
+              await reputationOracle.getAddress(),
+              await recordingOracle.getAddress(),
+            ],
+            jobRequesterId
+          )
       ).wait();
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       expect(event?.token).to.equal(token.address, 'token address is correct');

--- a/packages/examples/fortune/launcher/server/src/plugins/escrow.ts
+++ b/packages/examples/fortune/launcher/server/src/plugins/escrow.ts
@@ -117,13 +117,13 @@ class Escrow {
       factoryAddress
     );
     const gas = await escrowFactory.methods
-      .createEscrow(token, [])
+      .createEscrow(token, [], jobRequester)
       .estimateGas({ from: jobRequester });
     const gasPrice = await web3.eth.getGasPrice();
     const result = await escrowFactory.methods
-      .createEscrow(token, [])
+      .createEscrow(token, [], jobRequester)
       .send({ from: jobRequester, gas, gasPrice });
-    return result.events.Launched.returnValues.escrow;
+    return result.events.LaunchedV2.returnValues.escrow;
   }
 
   async fundEscrow(

--- a/packages/examples/fortune/reputation-oracle/src/services/escrow.test.ts
+++ b/packages/examples/fortune/reputation-oracle/src/services/escrow.test.ts
@@ -124,7 +124,7 @@ describe('Fortune', () => {
 
   beforeEach(async () => {
     await escrowFactory.methods
-      .createEscrow(token.options.address, [launcher.address])
+      .createEscrow(token.options.address, [launcher.address], 'job-requester')
       .send({ from: launcher.address });
 
     escrowAddress = await escrowFactory.methods.lastEscrow().call();

--- a/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
+++ b/packages/sdk/python/human-protocol-sdk/test/e2e/test_staking.py
@@ -40,12 +40,15 @@ class StakingTestCase(unittest.TestCase):
         tx_hash = self.staking_client.factory_contract.functions.createEscrow(
             self.staking_client.hmtoken_contract.address,
             [self.gas_payer.address],
+            "job-requester",
         ).transact()
 
         tx_receipt = self.staking_client.w3.eth.wait_for_transaction_receipt(tx_hash)
 
-        events = self.staking_client.factory_contract.events.Launched().process_receipt(
-            tx_receipt
+        events = (
+            self.staking_client.factory_contract.events.LaunchedV2().process_receipt(
+                tx_receipt
+            )
         )
         self.escrow_address = events[0].get("args", {}).get("escrow", "")
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -268,6 +268,7 @@ class EscrowTestCase(unittest.TestCase):
         self.escrow.factory_contract.functions.createEscrow = mock_function_create
         escrow_address = "0x1234567890123456789012345678901234567890"
         token_address = "0x1234567890123456789012345678901234567890"
+        job_requester_id = "job-requester"
         trusted_handlers = [self.w3.eth.default_account]
 
         with patch("human_protocol_sdk.escrow.handle_transaction") as mock_function:
@@ -275,11 +276,13 @@ class EscrowTestCase(unittest.TestCase):
                 mock_function_next.return_value = SimpleNamespace(
                     args=SimpleNamespace(escrow=escrow_address)
                 )
-                response = self.escrow.create_escrow(token_address, trusted_handlers)
+                response = self.escrow.create_escrow(
+                    token_address, trusted_handlers, job_requester_id
+                )
 
                 self.assertEqual(response, escrow_address)
                 mock_function_create.assert_called_once_with(
-                    token_address, trusted_handlers
+                    token_address, trusted_handlers, job_requester_id
                 )
                 mock_function_next.assert_called_once()
 
@@ -293,17 +296,19 @@ class EscrowTestCase(unittest.TestCase):
     def test_create_escrow_invalid_token(self):
         token_address = "invalid_address"
         trusted_handlers = [self.w3.eth.default_account]
+        job_requester_id = "job-requester"
 
         with self.assertRaises(EscrowClientError) as cm:
-            self.escrow.create_escrow(token_address, trusted_handlers)
+            self.escrow.create_escrow(token_address, trusted_handlers, job_requester_id)
         self.assertEqual(f"Invalid token address: {token_address}", str(cm.exception))
 
     def test_create_escrow_invalid_handler(self):
         token_address = "0x1234567890123456789012345678901234567890"
         trusted_handlers = ["invalid_address"]
+        job_requester_id = "job-requester"
 
         with self.assertRaises(EscrowClientError) as cm:
-            self.escrow.create_escrow(token_address, trusted_handlers)
+            self.escrow.create_escrow(token_address, trusted_handlers, job_requester_id)
         self.assertEqual(
             f"Invalid handler address: {trusted_handlers[0]}", str(cm.exception)
         )
@@ -318,8 +323,11 @@ class EscrowTestCase(unittest.TestCase):
 
         token_address = "0x1234567890123456789012345678901234567890"
         trusted_handlers = ["0x1234567890123456789012345678901234567890"]
+        job_requester_id = "job-requester"
         with self.assertRaises(EscrowClientError) as cm:
-            escrowClient.create_escrow(token_address, trusted_handlers)
+            escrowClient.create_escrow(
+                token_address, trusted_handlers, job_requester_id
+            )
         self.assertEqual("You must add an account to Web3 instance", str(cm.exception))
 
     def test_setup(self):
@@ -465,6 +473,7 @@ class EscrowTestCase(unittest.TestCase):
         escrow_address = "0x1234567890123456789012345678901234567890"
         token_address = "0x1234567890123456789012345678901234567890"
         trusted_handlers = [self.w3.eth.default_account]
+        job_requester_id = "job-requester"
         escrow_config = EscrowConfig(
             "0x1234567890123456789012345678901234567890",
             "0x1234567890123456789012345678901234567890",
@@ -479,12 +488,12 @@ class EscrowTestCase(unittest.TestCase):
                     args=SimpleNamespace(escrow=escrow_address)
                 )
                 response = self.escrow.create_and_setup_escrow(
-                    token_address, trusted_handlers, escrow_config
+                    token_address, trusted_handlers, job_requester_id, escrow_config
                 )
 
                 self.assertEqual(response, escrow_address)
                 mock_function_create.assert_called_once_with(
-                    token_address, trusted_handlers
+                    token_address, trusted_handlers, job_requester_id
                 )
                 mock_function_next.assert_called_once()
 
@@ -505,6 +514,7 @@ class EscrowTestCase(unittest.TestCase):
         self.escrow.setup = MagicMock()
         token_address = "invalid_address"
         trusted_handlers = [self.w3.eth.default_account]
+        job_requester_id = "job-requester"
         escrow_config = EscrowConfig(
             "0x1234567890123456789012345678901234567890",
             "0x1234567890123456789012345678901234567890",
@@ -516,7 +526,7 @@ class EscrowTestCase(unittest.TestCase):
 
         with self.assertRaises(EscrowClientError) as cm:
             self.escrow.create_and_setup_escrow(
-                token_address, trusted_handlers, escrow_config
+                token_address, trusted_handlers, job_requester_id, escrow_config
             )
         self.assertEqual(f"Invalid token address: {token_address}", str(cm.exception))
         self.escrow.setup.assert_not_called()
@@ -525,6 +535,7 @@ class EscrowTestCase(unittest.TestCase):
         self.escrow.setup = MagicMock()
         token_address = "0x1234567890123456789012345678901234567890"
         trusted_handlers = ["invalid_address"]
+        job_requester_id = "job-requester"
         escrow_config = EscrowConfig(
             "0x1234567890123456789012345678901234567890",
             "0x1234567890123456789012345678901234567890",
@@ -536,7 +547,7 @@ class EscrowTestCase(unittest.TestCase):
 
         with self.assertRaises(EscrowClientError) as cm:
             self.escrow.create_and_setup_escrow(
-                token_address, trusted_handlers, escrow_config
+                token_address, trusted_handlers, job_requester_id, escrow_config
             )
         self.assertEqual(
             f"Invalid handler address: {trusted_handlers[0]}", str(cm.exception)
@@ -554,6 +565,7 @@ class EscrowTestCase(unittest.TestCase):
         escrowClient.setup = MagicMock()
         token_address = "0x1234567890123456789012345678901234567890"
         trusted_handlers = ["0x1234567890123456789012345678901234567890"]
+        job_requester_id = "job-requester"
         escrow_config = EscrowConfig(
             "0x1234567890123456789012345678901234567890",
             "0x1234567890123456789012345678901234567890",
@@ -565,7 +577,7 @@ class EscrowTestCase(unittest.TestCase):
 
         with self.assertRaises(EscrowClientError) as cm:
             escrowClient.create_and_setup_escrow(
-                token_address, trusted_handlers, escrow_config
+                token_address, trusted_handlers, job_requester_id, escrow_config
             )
         self.assertEqual("You must add an account to Web3 instance", str(cm.exception))
         escrowClient.setup.assert_not_called()

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -103,7 +103,8 @@ export class EscrowClient {
   @requiresSigner
   public async createEscrow(
     tokenAddress: string,
-    trustedHandlers: string[]
+    trustedHandlers: string[],
+    jobRequesterId: string
   ): Promise<string> {
     if (!ethers.utils.isAddress(tokenAddress)) {
       throw ErrorInvalidTokenAddress;
@@ -119,12 +120,13 @@ export class EscrowClient {
       const result: ContractReceipt = await (
         await this.escrowFactoryContract.createEscrow(
           tokenAddress,
-          trustedHandlers
+          trustedHandlers,
+          jobRequesterId
         )
       ).wait();
 
       const event = result.events?.find(({ topics }) =>
-        topics.includes(ethers.utils.id('Launched(address,address)'))
+        topics.includes(ethers.utils.id('LaunchedV2(address,address,string)'))
       )?.args;
 
       if (!event) {
@@ -229,12 +231,14 @@ export class EscrowClient {
   async createAndSetupEscrow(
     tokenAddress: string,
     trustedHandlers: string[],
+    jobRequesterId: string,
     escrowConfig: IEscrowConfig
   ): Promise<string> {
     try {
       const escrowAddress = await this.createEscrow(
         tokenAddress,
-        trustedHandlers
+        trustedHandlers,
+        jobRequesterId
       );
 
       await this.setup(escrowAddress, escrowConfig);

--- a/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
@@ -185,6 +185,7 @@ describe('EscrowClient', () => {
     test('should create an escrow and return its address', async () => {
       const tokenAddress = ethers.constants.AddressZero;
       const trustedHandlers = [ethers.constants.AddressZero];
+      const jobRequesterId = 'job-requester';
       const expectedEscrowAddress = ethers.constants.AddressZero;
 
       // Create a spy object for the createEscrow method
@@ -194,7 +195,7 @@ describe('EscrowClient', () => {
           wait: async () => ({
             events: [
               {
-                topics: [ethers.utils.id('Launched(address,address)')],
+                topics: [ethers.utils.id('LaunchedV2(address,address,string)')],
                 args: {
                   escrow: expectedEscrowAddress,
                 },
@@ -205,12 +206,14 @@ describe('EscrowClient', () => {
 
       const result = await escrowClient.createEscrow(
         tokenAddress,
-        trustedHandlers
+        trustedHandlers,
+        jobRequesterId
       );
 
       expect(createEscrowSpy).toHaveBeenCalledWith(
         tokenAddress,
-        trustedHandlers
+        trustedHandlers,
+        jobRequesterId
       );
       expect(result).toBe(expectedEscrowAddress);
     });
@@ -218,18 +221,19 @@ describe('EscrowClient', () => {
     test('should throw an error if the create an escrow fails', async () => {
       const tokenAddress = ethers.constants.AddressZero;
       const trustedHandlers = [ethers.constants.AddressZero];
+      const jobRequesterId = 'job-requester';
 
       escrowClient.escrowFactoryContract.createEscrow.mockRejectedValueOnce(
         new Error()
       );
 
       await expect(
-        escrowClient.createEscrow(tokenAddress, trustedHandlers)
+        escrowClient.createEscrow(tokenAddress, trustedHandlers, jobRequesterId)
       ).rejects.toThrow();
 
       expect(
         escrowClient.escrowFactoryContract.createEscrow
-      ).toHaveBeenCalledWith(tokenAddress, trustedHandlers);
+      ).toHaveBeenCalledWith(tokenAddress, trustedHandlers, jobRequesterId);
     });
   });
 
@@ -439,6 +443,8 @@ describe('EscrowClient', () => {
       const escrowAddress = ethers.constants.AddressZero;
       const tokenAddress = ethers.constants.AddressZero;
       const trustedHandlers = [ethers.constants.AddressZero];
+      const jobRequesterId = 'job-requester';
+
       const escrowConfig = {
         recordingOracle: ethers.constants.AddressZero,
         reputationOracle: ethers.constants.AddressZero,
@@ -455,12 +461,14 @@ describe('EscrowClient', () => {
       await escrowClient.createAndSetupEscrow(
         tokenAddress,
         trustedHandlers,
+        jobRequesterId,
         escrowConfig
       );
 
       expect(escrowClient.createEscrow).toHaveBeenCalledWith(
         tokenAddress,
-        trustedHandlers
+        trustedHandlers,
+        jobRequesterId
       );
       expect(escrowClient.escrowContract.setup).toHaveBeenCalledWith(
         ethers.constants.AddressZero,

--- a/packages/sdk/typescript/subgraph/schema.graphql
+++ b/packages/sdk/typescript/subgraph/schema.graphql
@@ -54,6 +54,7 @@ type Escrow @entity {
   recordingOracleFee: BigInt
   intermediateResultsUrl: String # string
   finalResultsUrl: String # string
+  jobRequesterId: String # string
   createdAt: BigInt!
 }
 

--- a/packages/sdk/typescript/subgraph/src/mapping/EscrowFactory.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/EscrowFactory.ts
@@ -1,4 +1,7 @@
-import { Launched } from '../../generated/EscrowFactory/EscrowFactory';
+import {
+  Launched,
+  LaunchedV2,
+} from '../../generated/EscrowFactory/EscrowFactory';
 import { Escrow } from '../../generated/schema';
 import { Escrow as EscrowTemplate } from '../../generated/templates';
 import { createOrLoadEscrowStatistics } from './Escrow';
@@ -13,6 +16,45 @@ export function handleLaunched(event: Launched): void {
   entity.createdAt = event.block.timestamp;
   entity.address = event.params.escrow;
   entity.token = event.params.token;
+  entity.factoryAddress = event.address;
+  entity.launcher = event.transaction.from;
+
+  entity.balance = ZERO_BI;
+  entity.amountPaid = ZERO_BI;
+  entity.totalFundedAmount = ZERO_BI;
+
+  entity.status = 'Launched';
+
+  // Update escrow statistics
+  const statsEntity = createOrLoadEscrowStatistics();
+  statsEntity.totalEscrowCount = statsEntity.totalEscrowCount.plus(ONE_BI);
+  statsEntity.save();
+
+  entity.count = statsEntity.totalEscrowCount;
+  entity.save();
+
+  // Create escrow template
+  EscrowTemplate.create(event.params.escrow);
+
+  // Update escrow amount day data
+  const eventDayData = getEventDayData(event);
+  eventDayData.dailyEscrowCount = eventDayData.dailyEscrowCount.plus(ONE_BI);
+  eventDayData.save();
+
+  // Increase amount of jobs launched by leader
+  const leader = createOrLoadLeader(event.transaction.from);
+  leader.amountJobsLaunched = leader.amountJobsLaunched.plus(ONE_BI);
+  leader.save();
+}
+
+export function handleLaunchedV2(event: LaunchedV2): void {
+  // Create Escrow entity
+  const entity = new Escrow(event.params.escrow.toHex());
+
+  entity.createdAt = event.block.timestamp;
+  entity.address = event.params.escrow;
+  entity.token = event.params.token;
+  entity.jobRequesterId = event.params.jobRequesterId;
   entity.factoryAddress = event.address;
   entity.launcher = event.transaction.from;
 

--- a/packages/sdk/typescript/subgraph/template.yaml
+++ b/packages/sdk/typescript/subgraph/template.yaml
@@ -23,6 +23,8 @@ dataSources:
       eventHandlers:
         - event: Launched(address,address)
           handler: handleLaunched
+        - event: LaunchedV2(address,address,string)
+          handler: handleLaunchedV2
   - kind: ethereum
     name: HMToken
     network: '{{ network }}'


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes
We need to add JobRequesterId to createEscrow function of EscrowFactory.

<!-- At a high level, what parts of the code did you change and why? -->
- Added jobRequesterId to createEscrow function.
- Emit new event `LaunchedV2` with additional param.
- Added handler in subgraph
- Updated SDK function & doc

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #842 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
