### PR TITLE
Add getManifestHash function for python/typescript sdk. Allow docker-network URLs.

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -14,9 +14,10 @@ from human_protocol_sdk.utils import (
     get_erc20_interface,
     handle_transaction,
 )
-from validators import url as URL
 from web3 import Web3, contract
 from web3.middleware import geth_poa_middleware
+
+from .utils import validate_url
 
 GAS_LIMIT = int(os.getenv("GAS_LIMIT", 4712388))
 
@@ -44,7 +45,6 @@ class EscrowConfig:
         reputation_oracle_fee: Decimal,
         manifest_url: str,
         hash: str,
-        skip_manifest_url_validation: bool = False,
     ):
         """
         Initializes a Escrow instance.
@@ -72,7 +72,7 @@ class EscrowConfig:
             raise EscrowClientError("Fee must be between 0 and 100")
         if recording_oracle_fee + reputation_oracle_fee > 100:
             raise EscrowClientError("Total fee must be less than 100")
-        if not URL(manifest_url) and not skip_manifest_url_validation:
+        if not validate_url(manifest_url):
             raise EscrowClientError(f"Invalid manifest URL: {manifest_url}")
         if not hash:
             raise EscrowClientError("Invalid empty manifest hash")
@@ -321,7 +321,7 @@ class EscrowClient:
             raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
         if not hash:
             raise EscrowClientError("Invalid empty hash")
-        if not URL(url):
+        if not validate_url(url):
             raise EscrowClientError(f"Invalid URL: {url}")
         if not self.w3.eth.default_account:
             raise EscrowClientError("You must add an account to Web3 instance")
@@ -401,7 +401,7 @@ class EscrowClient:
             raise EscrowClientError(
                 f"Escrow does not have enough balance. Current balance: {balance}. Amounts: {total_amount}"
             )
-        if not URL(final_results_url):
+        if not validate_url(final_results_url):
             raise EscrowClientError(f"Invalid final results URL: {final_results_url}")
         if not final_results_hash:
             raise EscrowClientError("Invalid empty final results hash")

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -507,6 +507,24 @@ class EscrowClient:
 
         return self._get_escrow_contract(escrow_address).functions.getBalance().call()
 
+    def get_manifest_hash(self, escrow_address: str) -> str:
+        """Gets the manifest file hash.
+
+        Args:
+            escrow_address (str): Address of the escrow
+
+        Returns:
+            str: Manifest file hash
+
+        Raises:
+            EscrowClientError: If an error occurs while checking the parameters
+        """
+
+        if not Web3.is_address(escrow_address):
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
+
+        return self._get_escrow_contract(escrow_address).functions.manifestHash().call()
+
     def get_manifest_url(self, escrow_address: str) -> str:
         """Gets the manifest file URL.
 

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
@@ -7,7 +7,8 @@ from typing import List, Optional
 
 import requests
 from minio import Minio
-from validators import url as URL
+
+from .utils import validate_url
 
 logging.getLogger("minio").setLevel(logging.INFO)
 
@@ -135,7 +136,7 @@ class StorageClient:
         Raises:
             StorageClientError: If an error occurs while downloading the file.
         """
-        if not URL(url):
+        if not validate_url(url):
             raise StorageClientError(f"Invalid URL: {url}")
 
         try:

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import time
+import re
 from typing import Tuple, Optional
 
 import requests
+from validators import url as URL
 from web3 import Web3
 from web3.contract import Contract
 from web3.types import TxReceipt
@@ -239,3 +241,38 @@ def handle_transaction(w3: Web3, tx_name, tx, exception):
             raise exception(f"{tx_name} transaction failed: {message}")
         else:
             raise exception(f"{tx_name} transaction failed.")
+
+
+def validate_url(url: str) -> bool:
+    """Gets the url string.
+    Args:
+        url (str): Public or private url address
+    Returns:
+        bool: Returns True if url is valid
+    Raises:
+        ValidationFailure: If the url is invalid
+    """
+
+    # validators.url tracks docker network URL as ivalid
+    pattern = re.compile(
+        r"^"
+        # protocol identifier
+        r"(?:(?:http)://)"
+        # host name
+        r"(?:(?:(?:xn--[-]{0,2})|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"
+        r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]+)"
+        # port number
+        r"(?::\d{2,5})?"
+        # resource path
+        r"(?:/[-a-z\u00a1-\uffff\U00010000-\U0010ffff0-9._~%!$&'()*+,;=:@/]*)?"
+        # query string
+        r"(?:\?\S*)?" r"$",
+        re.UNICODE | re.IGNORECASE,
+    )
+
+    result = pattern.match(url)
+
+    if not result:
+        return URL(url)
+
+    return True

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -1479,6 +1479,26 @@ class EscrowTestCase(unittest.TestCase):
             "Escrow address is not provided by the factory", str(cm.exception)
         )
 
+    def test_get_manifest_hash(self):
+        mock_contract = MagicMock()
+        mock_contract.functions.manifestHash = MagicMock()
+        mock_contract.functions.manifestHash.return_value.call.return_value = (
+            "mock_value"
+        )
+        self.escrow._get_escrow_contract = MagicMock(return_value=mock_contract)
+        escrow_address = "0x1234567890123456789012345678901234567890"
+
+        result = self.escrow.get_manifest_hash(escrow_address)
+
+        self.escrow._get_escrow_contract.assert_called_once_with(escrow_address)
+        mock_contract.functions.manifestHash.assert_called_once_with()
+        self.assertEqual(result, "mock_value")
+
+    def test_get_manifest_hash_invalid_address(self):
+        with self.assertRaises(EscrowClientError) as cm:
+            self.escrow.get_manifest_hash("invalid_address")
+        self.assertEqual(f"Invalid escrow address: invalid_address", str(cm.exception))
+
     def test_get_manifest_url(self):
         mock_contract = MagicMock()
         mock_contract.functions.manifestUrl = MagicMock()

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -100,7 +100,7 @@ class EscrowTestCase(unittest.TestCase):
         self.assertEqual(escrow_config.manifest_url, manifest_url)
         self.assertEqual(escrow_config.hash, hash)
 
-    def test_escrow_config_valid_params(self):
+    def test_escrow_config_valid_params_with_docker_network_url(self):
         recording_oracle_address = "0x1234567890123456789012345678901234567890"
         reputation_oracle_address = "0x1234567890123456789012345678901234567890"
         recording_oracle_fee = 10
@@ -115,7 +115,6 @@ class EscrowTestCase(unittest.TestCase):
             reputation_oracle_fee,
             manifest_url,
             hash,
-            True,
         )
 
         self.assertEqual(

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_utils.py
@@ -1,0 +1,15 @@
+import unittest
+from validators.utils import ValidationFailure
+
+from human_protocol_sdk.utils import validate_url
+
+
+class TestStorageClient(unittest.TestCase):
+    def test_validate_url_with_valid_url(self):
+        self.assertTrue(validate_url("https://valid-url.tst/valid"))
+
+    def test_validate_url_with_docker_network_url(self):
+        self.assertTrue(validate_url("http://test:8000/valid"))
+
+    def test_validate_url_with_invalid_url(self):
+        assert isinstance(validate_url("htt://test:8000/valid"), ValidationFailure)

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -586,6 +586,33 @@ export class EscrowClient {
   }
 
   /**
+   * Returns the manifest file hash.
+   *
+   * @param {string} escrowAddress - Address of the escrow.
+   * @returns {Promise<void>}
+   * @throws {Error} - An error object if an error occurred.
+   */
+  async getManifestHash(escrowAddress: string): Promise<string> {
+    if (!ethers.utils.isAddress(escrowAddress)) {
+      throw ErrorInvalidEscrowAddressProvided;
+    }
+
+    if (!(await this.escrowFactoryContract.hasEscrow(escrowAddress))) {
+      throw ErrorEscrowAddressIsNotProvidedByFactory;
+    }
+
+    try {
+      this.escrowContract = Escrow__factory.connect(
+        escrowAddress,
+        this.signerOrProvider
+      );
+      return this.escrowContract.manifestHash();
+    } catch (e) {
+      return throwError(e);
+    }
+  }
+
+  /**
    * Returns the manifest file URL.
    *
    * @param {string} escrowAddress - Address of the escrow.


### PR DESCRIPTION
## Description

1. Add `get_manifest_hash` function to escrow that returns stored `manifestHash` for python sdk.
2. Add `getManifestHash` for typescript sdk.
3. Extend `validators.url` to track docker network urls as valid.

## Summary of changes

`get_manifest_hash` function

## How test the changes

1. Create and setup escrow
4. Try to get hash, e.g. `escrow_client.get_manifest_hash("escrow_address")`

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
