### PR TITLE
Fix: cvat ci test run trigger condition and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"

--- a/.github/workflows/ci-test-cvat-exchange-oracle.yaml
+++ b/.github/workflows/ci-test-cvat-exchange-oracle.yaml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'packages/examples/cvat/exchange-oracle/**'
+      - 'packages/sdk/python/human-protocol-sdk/**'
 
 jobs:
   cvat-exo-test:

--- a/.github/workflows/ci-test-cvat-recording-oracle.yaml
+++ b/.github/workflows/ci-test-cvat-recording-oracle.yaml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'packages/examples/cvat/recording-oracle/**'
+      - 'packages/sdk/python/human-protocol-sdk/**'
 
 jobs:
   cvat-exo-test:


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Dependabot alert needs to be targeting `develop` branch.
CVAT CI test should be running upon python SDK change.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Updated CVAT CI workflow configuration for the action to be triggered upon SDK change
- Added `dependabot.yml` to use `develop` as target branch for PRs.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
