### PR TITLE
fix: [SDK] statistics - add limit param and order by timestamp in descending order

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/statistics.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/statistics.py
@@ -79,8 +79,10 @@ query GetEscrowDayData($from: Int, $to: Int) {{
         where: {{
             {from_clause}
             {to_clause}
-
-        }}
+        }},
+        orderBy: timestamp,
+        orderDirection: desc,
+        {limit_clause}
     ) {{
       ...EventDayDataFields
     }}
@@ -90,4 +92,5 @@ query GetEscrowDayData($from: Int, $to: Int) {{
         event_day_data_fragment=event_day_data_fragment,
         from_clause="timestamp_gte: $from" if param.date_from else "",
         to_clause="timestamp_lte: $to" if param.date_to else "",
+        limit_clause="first: $limit" if param.limit else "first: 1000",
     )

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/statistics.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/statistics.py
@@ -37,6 +37,7 @@ class StatisticsParam:
         self,
         date_from: Optional[datetime.datetime] = None,
         date_to: Optional[datetime.datetime] = None,
+        limit: Optional[int] = None,
     ):
         """
         Initializes a StatisticsParam instance.
@@ -44,10 +45,12 @@ class StatisticsParam:
         Args:
             date_from (Optional[datetime.datetime]): Statistical data from date
             date_to (Optional[datetime.datetime]): Statistical data to date
+            limit (Optional[int]): Limit of statistical data
         """
 
         self.date_from = date_from
         self.date_to = date_to
+        self.limit = limit
 
 
 class StatisticsClient:

--- a/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/statistics.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/statistics.ts
@@ -69,17 +69,25 @@ export const GET_ESCROW_STATISTICS_QUERY = gql`
 `;
 
 export const GET_EVENT_DAY_DATA_QUERY = (params: IStatisticsParams) => {
-  const { from, to } = params;
+  const { from, to, limit } = params;
   const WHERE_CLAUSE = `
     where: {
       ${from !== undefined ? `timestamp_gte: $from` : ''}
       ${to !== undefined ? `timestamp_lte: $to` : ''}
     }
   `;
+  const LIMIT_CLAUSE = `
+    first: ${limit ? `$limit` : `1000`}
+  `;
 
   return gql`
     query GetEscrowDayData($from: Int, $to: Int) {
-      eventDayDatas(${WHERE_CLAUSE}) {
+      eventDayDatas(
+        ${WHERE_CLAUSE},
+        orderBy: timestamp,
+        orderDirection: desc,
+        ${LIMIT_CLAUSE}
+      ) {
         ...EventDayDataFields
       }
     }

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -51,4 +51,5 @@ export interface IKeyPair {
 export interface IStatisticsParams {
   from?: Date;
   to?: Date;
+  limit?: number;
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes
- Updated GraphQL query to use orderBy timestamp desc, and then support limit param, which is 1000 by default.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #874 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
