### PR TITLE
[Common] Removed `oracleType` verification

### DIFF
--- a/packages/apps/job-launcher/server/src/common/guards/signature.auth.spec.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/signature.auth.spec.ts
@@ -50,7 +50,6 @@ describe('SignatureAuthGuard', () => {
 
     it('should return true if signature is verified', async () => {
       mockRequest.headers['header-signature-key'] = 'validSignature';
-      jest.spyOn(guard, 'determineAddress').mockReturnValue('someAddress');
       (verifySignature as jest.Mock).mockReturnValue(true);
 
       const result = await guard.canActivate(context as any);
@@ -58,7 +57,6 @@ describe('SignatureAuthGuard', () => {
     });
 
     it('should throw unauthorized exception if signature is not verified', async () => {
-      jest.spyOn(guard, 'determineAddress').mockReturnValue('someAddress');
       (verifySignature as jest.Mock).mockReturnValue(false);
 
       await expect(guard.canActivate(context as any)).rejects.toThrow(UnauthorizedException);
@@ -68,36 +66,5 @@ describe('SignatureAuthGuard', () => {
       mockRequest.originalUrl = '/some/random/path';
       await expect(guard.canActivate(context as any)).rejects.toThrow(UnauthorizedException);
     });
-  });
-
-  describe('determineAddress', () => {
-    it('should return the correct address if originalUrl contains the fortune oracle type', () => {
-      const mockRequest = { originalUrl: '/somepath/fortune/anotherpath' };
-      const expectedAddress = MOCK_ADDRESS;
-      mockConfigService.get = jest.fn().mockReturnValue(expectedAddress);
-
-      const result = guard.determineAddress(mockRequest);
-
-      expect(result).toEqual(expectedAddress);
-    });
-
-    it('should return the correct address if originalUrl contains the cvat oracle type', () => {
-      const mockRequest = { originalUrl: '/somepath/cvat/anotherpath' };
-      const expectedAddress = MOCK_ADDRESS;
-      mockConfigService.get = jest.fn().mockReturnValue(expectedAddress);
-
-      const result = guard.determineAddress(mockRequest);
-
-      expect(result).toEqual(expectedAddress);
-    });
-
-    it('should throw BadRequestException for unrecognized oracle type', () => {
-      const mockRequest = { originalUrl: '/some/random/path' };
-
-      expect(() => {
-        guard.determineAddress(mockRequest);
-      }).toThrow(BadRequestException);
-    });
-
   });
 });

--- a/packages/apps/job-launcher/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/signature.auth.ts
@@ -17,10 +17,17 @@ export class SignatureAuthGuard implements CanActivate {
     
     const data = request.body;
     const signature = request.headers[HEADER_SIGNATURE_KEY]; 
-
+    const oracleAdresses = [
+      this.configService.get<string>(
+        ConfigNames.FORTUNE_EXCHANGE_ORACLE_ADDRESS,
+      )!,
+      this.configService.get<string>(
+        ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS,
+      )!
+    ]
+    
     try {
-      const address = this.determineAddress(request);
-      const isVerified = verifySignature(data, signature, address)
+      const isVerified = verifySignature(data, signature, oracleAdresses)
 
       if (isVerified) {
         return true;
@@ -30,23 +37,5 @@ export class SignatureAuthGuard implements CanActivate {
     }
 
     throw new UnauthorizedException('Unauthorized');
-  }
-
-  public determineAddress(request: any): string {
-    const originalUrl = request.originalUrl;
-    const parts = originalUrl.split('/');
-    const oracleType = parts[2];
-
-    if (oracleType === OracleType.FORTUNE) {
-      return this.configService.get<string>(
-        ConfigNames.FORTUNE_EXCHANGE_ORACLE_ADDRESS,
-      )!
-    } else if (oracleType === OracleType.CVAT) {
-      return this.configService.get<string>(
-        ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS,
-      )!
-    } else {
-      throw new BadRequestException('Unable to determine address from origin URL');
-    }
   }
 }

--- a/packages/apps/job-launcher/server/src/common/utils/signature.spec.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/signature.spec.ts
@@ -2,7 +2,6 @@ import { verifySignature, recoverSigner, signMessage } from './signature';
 import { MOCK_ADDRESS, MOCK_PRIVATE_KEY } from '../../../test/constants';
 import { ErrorSignature } from '../constants/errors';
 
-//ethers.utils.verifyMessage = jest.fn().mockResolvedValue(true);
 jest.doMock('ethers', () => {
   return {
     utils: {
@@ -25,7 +24,7 @@ describe('Signature utility', () => {
       const message = 'Hello, this is a signed message!';
       const signature = await signMessage(message, MOCK_PRIVATE_KEY);
 
-      const result = verifySignature(message, signature, MOCK_ADDRESS);
+      const result = verifySignature(message, signature, [MOCK_ADDRESS]);
 
       expect(result).toBe(true);
     });
@@ -37,7 +36,7 @@ describe('Signature utility', () => {
       const invalidAddress = '0x1234567890123456789012345678901234567892';
 
       expect(() => {
-        verifySignature(message, invalidSignature, invalidAddress);
+        verifySignature(message, invalidSignature, [invalidAddress]);
       }).toThrow(ErrorSignature.SignatureNotVerified);
     });
 
@@ -46,7 +45,7 @@ describe('Signature utility', () => {
       const invalidSignature = '0xInvalidSignature';
 
       expect(() => {
-        verifySignature(message, invalidSignature, MOCK_ADDRESS);
+        verifySignature(message, invalidSignature, [MOCK_ADDRESS]);
       }).toThrow(ErrorSignature.InvalidSignature);
     });
   });

--- a/packages/apps/job-launcher/server/src/common/utils/signature.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/signature.ts
@@ -5,11 +5,11 @@ import { ErrorSignature } from '../constants/errors';
 export function verifySignature(
   message: object | string,
   signature: string,
-  address: string,
+  addresses: string[],
 ): boolean {
   const signer = recoverSigner(message, signature);
 
-  if (signer.toLowerCase() !== address.toLowerCase()) {
+  if (!addresses.some(address => address.toLowerCase() === signer.toLowerCase())) {
     throw new ConflictException(ErrorSignature.SignatureNotVerified);
   }
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -86,7 +86,7 @@ export class JobController {
 
   @Public()
   @UseGuards(SignatureAuthGuard)
-  @Post('/:oracleType/escrow-failed-webhook')
+  @Post('/escrow-failed-webhook')
   public async (
     @Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() data: EscrowFailedWebhookDto,

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -227,15 +227,15 @@ export class EscrowFailedWebhookDto {
     enum: ChainId,
   })
   @IsEnum(ChainId)
-  public chain_id: ChainId;
+  public chainId: ChainId;
 
   @ApiProperty()
   @IsString()
-  public escrow_address: string;
+  public escrowAddress: string;
 
   @ApiProperty()
   @IsEnum(EventType)
-  public event_type: EventType;
+  public eventType: EventType;
 
   @ApiProperty()
   @IsString()

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1194,20 +1194,20 @@ describe('JobService', () => {
 
   describe('escrowFailedWebhook', () => {
     it('should throw BadRequestException for invalid event type', async () => {
-      const dto = { event_type: 'ANOTHER_EVENT' as EventType, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      const dto = { eventType: 'ANOTHER_EVENT' as EventType, chainId: 1, escrowAddress: 'address', reason: 'invalid manifest' };
 
       await expect(jobService.escrowFailedWebhook(dto)).rejects.toThrow(BadRequestException);
     });
 
     it('should throw NotFoundException if jobEntity is not found', async () => {
-      const dto = { event_type: EventType.TASK_CREATION_FAILED, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      const dto = { eventType: EventType.TASK_CREATION_FAILED, chainId: 1, escrowAddress: 'address', reason: 'invalid manifest' };
       jobRepository.findOne = jest.fn().mockResolvedValue(null);
 
       await expect(jobService.escrowFailedWebhook(dto)).rejects.toThrow(NotFoundException);
     });
 
     it('should throw ConflictException if jobEntity status is not LAUNCHED', async () => {
-      const dto = { event_type: EventType.TASK_CREATION_FAILED, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      const dto = { eventType: EventType.TASK_CREATION_FAILED, chainId: 1, escrowAddress: 'address', reason: 'invalid manifest' };
       const mockJobEntity = { status: 'ANOTHER_STATUS' as JobStatus, save: jest.fn() };
       jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
 
@@ -1215,7 +1215,7 @@ describe('JobService', () => {
     });
 
     it('should update jobEntity status to FAILED and return true if all checks pass', async () => {
-      const dto = { event_type: EventType.TASK_CREATION_FAILED, chain_id: 1, escrow_address: 'address', reason: 'invalid manifest' };
+      const dto = { eventType: EventType.TASK_CREATION_FAILED, chainId: 1, escrowAddress: 'address', reason: 'invalid manifest' };
       const mockJobEntity = { status: JobStatus.LAUNCHED, save: jest.fn() };
       jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -618,14 +618,14 @@ export class JobService {
   }
 
   public async escrowFailedWebhook(dto: EscrowFailedWebhookDto): Promise<boolean> {
-    if (dto.event_type !== EventType.TASK_CREATION_FAILED) {
+    if (dto.eventType !== EventType.TASK_CREATION_FAILED) {
       this.logger.log(ErrorJob.InvalidEventType, JobService.name);
       throw new BadRequestException(ErrorJob.InvalidEventType);
     }
 
     const jobEntity = await this.jobRepository.findOne({
-      chainId: dto.chain_id,
-      escrowAddress: dto.escrow_address,
+      chainId: dto.chainId,
+      escrowAddress: dto.escrowAddress,
     });
 
     if (!jobEntity) {

--- a/packages/apps/reputation-oracle/server/src/common/guards/signature.auth.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/signature.auth.spec.ts
@@ -50,7 +50,6 @@ describe('SignatureAuthGuard', () => {
 
     it('should return true if signature is verified', async () => {
       mockRequest.headers['header-signature-key'] = 'validSignature';
-      jest.spyOn(guard, 'determineAddress').mockReturnValue('someAddress');
       (verifySignature as jest.Mock).mockReturnValue(true);
 
       const result = await guard.canActivate(context as any);
@@ -58,7 +57,6 @@ describe('SignatureAuthGuard', () => {
     });
 
     it('should throw unauthorized exception if signature is not verified', async () => {
-      jest.spyOn(guard, 'determineAddress').mockReturnValue('someAddress');
       (verifySignature as jest.Mock).mockReturnValue(false);
 
       await expect(guard.canActivate(context as any)).rejects.toThrow(UnauthorizedException);
@@ -68,36 +66,5 @@ describe('SignatureAuthGuard', () => {
       mockRequest.originalUrl = '/some/random/path';
       await expect(guard.canActivate(context as any)).rejects.toThrow(UnauthorizedException);
     });
-  });
-
-  describe('determineAddress', () => {
-    it('should return the correct address if originalUrl contains the fortune oracle type', () => {
-      const mockRequest = { originalUrl: '/somepath/fortune/anotherpath' };
-      const expectedAddress = MOCK_ADDRESS;
-      mockConfigService.get = jest.fn().mockReturnValue(expectedAddress);
-
-      const result = guard.determineAddress(mockRequest);
-
-      expect(result).toEqual(expectedAddress);
-    });
-
-    it('should return the correct address if originalUrl contains the cvat oracle type', () => {
-      const mockRequest = { originalUrl: '/somepath/cvat/anotherpath' };
-      const expectedAddress = MOCK_ADDRESS;
-      mockConfigService.get = jest.fn().mockReturnValue(expectedAddress);
-
-      const result = guard.determineAddress(mockRequest);
-
-      expect(result).toEqual(expectedAddress);
-    });
-
-    it('should throw BadRequestException for unrecognized oracle type', () => {
-      const mockRequest = { originalUrl: '/some/random/path' };
-
-      expect(() => {
-        guard.determineAddress(mockRequest);
-      }).toThrow(BadRequestException);
-    });
-
   });
 });

--- a/packages/apps/reputation-oracle/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/signature.auth.ts
@@ -17,10 +17,17 @@ export class SignatureAuthGuard implements CanActivate {
     
     const data = request.body;
     const signature = request.headers[HEADER_SIGNATURE_KEY]; 
-
+    const oracleAdresses = [
+      this.configService.get<string>(
+        ConfigNames.FORTUNE_RECORDING_ORACLE_ADDRESS,
+      )!,
+      this.configService.get<string>(
+        ConfigNames.CVAT_RECORDING_ORACLE_ADDRESS,
+      )!
+    ]
+    
     try {
-      const address = this.determineAddress(request);
-      const isVerified = verifySignature(data, signature, address)
+      const isVerified = verifySignature(data, signature, oracleAdresses)
 
       if (isVerified) {
         return true;
@@ -30,23 +37,5 @@ export class SignatureAuthGuard implements CanActivate {
     }
 
     throw new UnauthorizedException('Unauthorized');
-  }
-
-  public determineAddress(request: any): string {
-    const originalUrl = request.originalUrl;
-    const parts = originalUrl.split('/');
-    const oracleType = parts[2];
-
-    if (oracleType === OracleType.FORTUNE) {
-      return this.configService.get<string>(
-        ConfigNames.FORTUNE_RECORDING_ORACLE_ADDRESS,
-      )!
-    } else if (oracleType === OracleType.CVAT) {
-      return this.configService.get<string>(
-        ConfigNames.CVAT_RECORDING_ORACLE_ADDRESS,
-      )!
-    } else {
-      throw new BadRequestException('Unable to determine address from origin URL');
-    }
   }
 }

--- a/packages/apps/reputation-oracle/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/signature.auth.ts
@@ -1,10 +1,9 @@
 
-import { BadRequestException, CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { verifySignature } from '../utils/signature';
 import { HEADER_SIGNATURE_KEY } from '../constants';
 import { ConfigService } from '@nestjs/config';
 import { ConfigNames } from '../config';
-import { OracleType } from '../enums/webhook';
 
 @Injectable()
 export class SignatureAuthGuard implements CanActivate {

--- a/packages/apps/reputation-oracle/server/src/common/utils/signature.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/common/utils/signature.spec.ts
@@ -24,7 +24,7 @@ describe('Signature utility', () => {
       const message = 'Hello, this is a signed message!';
       const signature = await signMessage(message, MOCK_PRIVATE_KEY);
 
-      const result = verifySignature(message, signature, MOCK_ADDRESS);
+      const result = verifySignature(message, signature, [MOCK_ADDRESS]);
 
       expect(result).toBe(true);
     });
@@ -36,7 +36,7 @@ describe('Signature utility', () => {
       const invalidAddress = '0x1234567890123456789012345678901234567892';
 
       expect(() => {
-        verifySignature(message, invalidSignature, invalidAddress);
+        verifySignature(message, invalidSignature, [invalidAddress]);
       }).toThrow(ErrorSignature.SignatureNotVerified);
     });
 
@@ -45,7 +45,7 @@ describe('Signature utility', () => {
       const invalidSignature = '0xInvalidSignature';
 
       expect(() => {
-        verifySignature(message, invalidSignature, MOCK_ADDRESS);
+        verifySignature(message, invalidSignature, [MOCK_ADDRESS]);
       }).toThrow(ErrorSignature.InvalidSignature);
     });
   });

--- a/packages/apps/reputation-oracle/server/src/common/utils/signature.ts
+++ b/packages/apps/reputation-oracle/server/src/common/utils/signature.ts
@@ -5,11 +5,11 @@ import { ErrorSignature } from '../constants/errors';
 export function verifySignature(
   message: object | string,
   signature: string,
-  address: string,
+  addresses: string[],
 ): boolean {
   const signer = recoverSigner(message, signature);
 
-  if (signer.toLowerCase() !== address.toLowerCase()) {
+  if (!addresses.some(address => address.toLowerCase() === signer.toLowerCase())) {
     throw new ConflictException(ErrorSignature.SignatureNotVerified);
   }
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.controller.ts
@@ -5,7 +5,6 @@ import { WebhookService } from './webhook.service';
 import { WebhookIncomingDto } from './webhook.dto';
 import { SignatureAuthGuard } from 'src/common/guards';
 import { HEADER_SIGNATURE_KEY } from 'src/common/constants';
-import { OracleType } from 'src/common/enums';
 
 @Public()
 @ApiTags('Webhook')
@@ -15,11 +14,9 @@ export class WebhookController {
   
   @Public()
   @UseGuards(SignatureAuthGuard)
-  @Post('/:oracleType')
+  @Post('/')
   public async createIncomingWebhook(
     @Headers(HEADER_SIGNATURE_KEY) _: string,
-    @Param('oracleType') oracleType: OracleType,
-    @Request() req: any,
     @Body() data: WebhookIncomingDto,
   ): Promise<boolean> {
     return this.webhookService.createIncomingWebhook(data);

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.dto.ts
@@ -18,15 +18,15 @@ import { BigNumber } from 'ethers';
 export class WebhookIncomingDto {
   @ApiProperty()
   @IsEnum(ChainId)
-  public chain_id: ChainId;
+  public chainId: ChainId;
 
   @ApiProperty()
   @IsEnum(EventType)
-  public event_type: EventType;
+  public eventType: EventType;
 
   @ApiProperty()
   @IsString()
-  public escrow_address: string;
+  public escrowAddress: string;
 }
 
 export class WebhookIncomingCreateDto {

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -145,17 +145,17 @@ describe('WebhookService', () => {
 
   describe('createIncomingWebhook', () => {
     const dto: WebhookIncomingDto = {
-      chain_id: ChainId.LOCALHOST,
-      event_type: EventType.TASK_FINISHED,
-      escrow_address: MOCK_ADDRESS,
+      chainId: ChainId.LOCALHOST,
+      eventType: EventType.TASK_FINISHED,
+      escrowAddress: MOCK_ADDRESS,
     };
 
     it('should create an incoming webhook entity', async () => {
       const webhookEntity: Partial<WebhookIncomingEntity> = {
         id: 1,
-        chainId: dto.chain_id,
-        eventType: dto.event_type,
-        escrowAddress: dto.escrow_address,
+        chainId: dto.chainId,
+        eventType: dto.eventType,
+        escrowAddress: dto.escrowAddress,
         status: WebhookStatus.PENDING,
         waitUntil: new Date(),
       };
@@ -167,9 +167,9 @@ describe('WebhookService', () => {
       const result = await webhookService.createIncomingWebhook(dto);
 
       expect(webhookRepository.create).toHaveBeenCalledWith({
-        chainId: dto.chain_id,
-        eventType: dto.event_type,
-        escrowAddress: dto.escrow_address,
+        chainId: dto.chainId,
+        eventType: dto.eventType,
+        escrowAddress: dto.escrowAddress,
         status: WebhookStatus.PENDING,
         waitUntil: expect.any(Date),
       });

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -84,9 +84,9 @@ export class WebhookService {
   ): Promise<boolean> {
     try { 
       const webhookEntity = await this.webhookRepository.create({
-        chainId: dto.chain_id,
-        eventType: dto.event_type,
-        escrowAddress: dto.escrow_address,
+        chainId: dto.chainId,
+        eventType: dto.eventType,
+        escrowAddress: dto.escrowAddress,
         status: WebhookStatus.PENDING,
         waitUntil: new Date(),
       });


### PR DESCRIPTION
## Description
Removed `oracleType` verification during webhook call on Job Launcher and Reputation oracle side.

## Related issues
[[Common] Remove verification oracleType during webhook call#888](https://github.com/humanprotocol/human-protocol/issues/888)
