### PR TITLE
feat: Mark storage module as deprecated

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/storage.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from typing import List, Optional
+from warnings import warn
 
 import requests
 from minio import Minio
@@ -15,6 +16,9 @@ logging.getLogger("minio").setLevel(logging.INFO)
 DEBUG = "true" in os.getenv("DEBUG", "false").lower()
 LOG = logging.getLogger("human_protocol_sdk.storage")
 LOG.setLevel(logging.DEBUG if DEBUG else logging.INFO)
+
+
+warn(f"The module {__name__} is deprecated.", DeprecationWarning, stacklevel=2)
 
 
 class StorageClientError(Exception):

--- a/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
@@ -13,6 +13,9 @@ import { UploadFile, StorageCredentials, StorageParams } from './types';
 import { isValidUrl } from './utils';
 import { HttpStatus } from './constants';
 
+/**
+ * @deprecated StorageClient is deprecated. Use Minio.Client directly.
+ */
 export class StorageClient {
   private client: Minio.Client;
   private clientParams: StorageParams;

--- a/packages/sdk/typescript/human-protocol-sdk/src/types.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/types.ts
@@ -33,6 +33,7 @@ export enum EscrowStatus {
 /**
  * AWS/GCP cloud storage access data
  * @readonly
+ * @deprecated StorageClient is deprecated. Use Minio.Client directly.
  */
 export type StorageCredentials = {
   /**
@@ -45,6 +46,9 @@ export type StorageCredentials = {
   secretKey: string;
 };
 
+/**
+ * @deprecated StorageClient is deprecated. Use Minio.Client directly.
+ */
 export type StorageParams = {
   /**
    * Request endPoint


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
We are deprecating the storage module. Now we just want to mark as deprecated, since we have some old code base which needs migration.

## Summary of changes
- Added deprecated note for Python/Node SDK.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #886

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
