### PR TITLE
[SDK] [Typescript] Return transaction hash as result of cancel method

### DIFF
--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -480,7 +480,7 @@ export class EscrowClient {
    * @throws {Error} - An error object if an error occurred.
    */
   @requiresSigner
-  async cancel(escrowAddress: string): Promise<void> {
+  async cancel(escrowAddress: string): Promise<string> {
     if (!ethers.utils.isAddress(escrowAddress)) {
       throw ErrorInvalidEscrowAddressProvided;
     }
@@ -494,8 +494,10 @@ export class EscrowClient {
         escrowAddress,
         this.signerOrProvider
       );
-      await this.escrowContract.cancel();
-      return;
+      const tx = await this.escrowContract.cancel();
+      const { transactionHash } = await tx.wait();
+
+      return transactionHash;
     } catch (e) {
       return throwError(e);
     }


### PR DESCRIPTION
## Description
Returned the hash of the transaction as the result of the cancel method.
The transaction hash is required when we process a refund to the user. The idea is to wait for a transaction to receive a certain number of confirmations before we receive logs of the last transfer.

## Summary of changes
Updated `cancel method to SDK
Updated unit tests to SDK

## How test the changes
`yarn test`

## Related issues
[SDK] [Typescript] Return transaction hash as result of cancel method#916