### PR TITLE
[SDK][Python] Get escrow data from Subgraph

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -814,3 +814,39 @@ class EscrowUtils:
                 escrow[0]["chain_id"] = chain_id
             escrow_addresses.extend(escrows)
         return escrow_addresses
+
+    @staticmethod
+    def get_escrow(
+        chain_id: ChainId,
+        escrow_address: str,
+    ) -> dict:
+        """Returns the escrow for a given address.
+
+        Args:
+            chain_id (ChainId): Network in which the escrow has been deployed
+            escrow_address (str): Address of the escrow
+
+        Returns:
+            dict: Escrow data
+        """
+        from human_protocol_sdk.gql.escrow import (
+            get_escrow_query,
+        )
+
+        if chain_id not in set(chain_id.value for chain_id in ChainId):
+            raise EscrowClientError(f"Invalid ChainId")
+
+        if not Web3.is_address(escrow_address):
+            raise EscrowClientError(f"Invalid escrow address: {escrow_address}")
+
+        network = NETWORKS[ChainId(chain_id)]
+
+        escrow = get_data_from_subgraph(
+            network["subgraph_url"],
+            query=get_escrow_query(),
+            params={
+                "escrowAddress": escrow_address,
+            },
+        )
+
+        return escrow["data"]["escrow"]

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
@@ -69,3 +69,18 @@ query GetEscrows(
         from_clause="createdAt_gte: $from" if filter.date_from else "",
         to_clause="createdAt_lte: $to" if filter.date_from else "",
     )
+
+
+def get_escrow_query():
+    return """
+query GetEscrow(
+    $escrowAddress: String!
+) {{
+    escrow(id: $escrowAddress) {{
+      ...EscrowFields
+    }}
+}}
+{escrow_fragment}
+""".format(
+        escrow_fragment=escrow_fragment
+    )


### PR DESCRIPTION
## Description

Use subgraph to get all the data related to escrow, oracles, balance, token, etc in get details endpoint.
We will need to add function to the sdk that returns all the information stored in an escrow passing the address as parameter

## How test the changes

`make run-test`

## Related issues
#915 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
