### PR TITLE
[SDK] Add jobRequesterId to escrows filter

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -108,6 +108,7 @@ class EscrowFilter:
         reputation_oracle: Optional[str] = None,
         recording_oracle: Optional[str] = None,
         exchange_oracle: Optional[str] = None,
+        job_requester_id: Optional[str] = None,
         status: Optional[Status] = None,
         date_from: Optional[datetime.datetime] = None,
         date_to: Optional[datetime.datetime] = None,
@@ -121,6 +122,7 @@ class EscrowFilter:
             reputation_oracle (Optional[str]): Reputation oracle address
             recording_oracle (Optional[str]): Recording oracle address
             exchange_oracle (Optional[str]): Exchange oracle address
+            job_requester_id (Optional[str]): Job requester id
             status (Optional[Status]): Escrow status
             date_from (Optional[datetime.datetime]): Created from date
             date_to (Optional[datetime.datetime]): Created to date
@@ -153,6 +155,7 @@ class EscrowFilter:
         self.reputation_oracle = reputation_oracle
         self.recording_oracle = recording_oracle
         self.exchange_oracle = exchange_oracle
+        self.job_requester_id = job_requester_id
         self.status = status
         self.date_from = date_from
         self.date_to = date_to
@@ -802,6 +805,7 @@ class EscrowUtils:
                     "reputationOracle": filter.reputation_oracle,
                     "recordingOracle": filter.recording_oracle,
                     "exchangeOracle": filter.exchange_oracle,
+                    "jobRequesterId": filter.job_requester_id,
                     "status": filter.status.name if filter.status else None,
                     "from": int(filter.date_from.timestamp())
                     if filter.date_from
@@ -811,6 +815,6 @@ class EscrowUtils:
             )
             escrows = escrows_data["data"]["escrows"]
             for escrow in escrows:
-                escrow[0]["chain_id"] = chain_id
+                escrow["chain_id"] = chain_id
             escrow_addresses.extend(escrows)
         return escrow_addresses

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
@@ -11,6 +11,7 @@ fragment EscrowFields on Escrow {
     id
     intermediateResultsUrl
     launcher
+    jobRequesterId
     manifestHash
     manifestUrl
     recordingOracle
@@ -34,6 +35,7 @@ query GetEscrows(
     $reputationOracle: String
     $recordingOracle: String
     $exchangeOracle: String
+    $jobRequesterId: String
     $status: String
     $from: Int
     $to: Int
@@ -44,6 +46,7 @@ query GetEscrows(
         {reputation_oracle_clause}
         {recording_oracle_clause}
         {exchange_oracle_clause}
+        {job_requester_clause}
         {status_clause}
         {from_clause}
         {to_clause}
@@ -64,6 +67,9 @@ query GetEscrows(
         else "",
         exchange_oracle_clause="exchangeOracle: $exchangeOracle"
         if filter.exchange_oracle
+        else "",
+        job_requester_clause="jobRequesterId: $jobRequesterId"
+        if filter.job_requester_id
         else "",
         status_clause="status: $status" if filter.status else "",
         from_clause="createdAt_gte: $from" if filter.date_from else "",

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -1916,54 +1916,50 @@ class EscrowTestCase(unittest.TestCase):
     def test_get_escrows(self):
         mock_function = MagicMock()
         with patch("human_protocol_sdk.escrow.get_data_from_subgraph") as mock_function:
-            mock_escrow_1 = (
-                {
-                    "id": "0x1234567890123456789012345678901234567891",
-                    "address": "0x1234567890123456789012345678901234567891",
-                    "amountPaid": "1000000000000000000",
-                    "balance": "1000000000000000000",
-                    "count": "1",
-                    "factoryAddress": "0x1234567890123456789012345678901234567890",
-                    "finalResultsUrl": "https://example.com",
-                    "intermediateResultsUrl": "https://example.com",
-                    "launcher": "0x1234567890123456789012345678901234567891",
-                    "manifestHash": "0x1234567890123456789012345678901234567891",
-                    "manifestUrl": "https://example.com",
-                    "recordingOracle": "0x1234567890123456789012345678901234567891",
-                    "recordingOracleFee": "1000000000000000000",
-                    "reputationOracle": "0x1234567890123456789012345678901234567891",
-                    "reputationOracleFee": "1000000000000000000",
-                    "exchangeOracle": "0x1234567890123456789012345678901234567891",
-                    "exchangeOracleFee": "1000000000000000000",
-                    "status": "Pending",
-                    "token": "0x1234567890123456789012345678901234567891",
-                    "totalFundedAmount": "1000000000000000000",
-                },
-            )
-            mock_escrow_2 = (
-                {
-                    "id": "0x1234567890123456789012345678901234567892",
-                    "address": "0x1234567890123456789012345678901234567892",
-                    "amountPaid": "1000000000000000000",
-                    "balance": "1000000000000000000",
-                    "count": "1",
-                    "factoryAddress": "0x1234567890123456789012345678901234567890",
-                    "finalResultsUrl": "https://example.com",
-                    "intermediateResultsUrl": "https://example.com",
-                    "launcher": "0x1234567890123456789012345678901234567892",
-                    "manifestHash": "0x1234567890123456789012345678901234567892",
-                    "manifestUrl": "https://example.com",
-                    "recordingOracle": "0x1234567890123456789012345678901234567892",
-                    "recordingOracleFee": "1000000000000000000",
-                    "reputationOracle": "0x1234567890123456789012345678901234567892",
-                    "reputationOracleFee": "1000000000000000000",
-                    "exchangeOracle": "0x1234567890123456789012345678901234567892",
-                    "exchangeOracleFee": "1000000000000000000",
-                    "status": "Pending",
-                    "token": "0x1234567890123456789012345678901234567892",
-                    "totalFundedAmount": "1000000000000000000",
-                },
-            )
+            mock_escrow_1 = {
+                "id": "0x1234567890123456789012345678901234567891",
+                "address": "0x1234567890123456789012345678901234567891",
+                "amountPaid": "1000000000000000000",
+                "balance": "1000000000000000000",
+                "count": "1",
+                "factoryAddress": "0x1234567890123456789012345678901234567890",
+                "finalResultsUrl": "https://example.com",
+                "intermediateResultsUrl": "https://example.com",
+                "launcher": "0x1234567890123456789012345678901234567891",
+                "manifestHash": "0x1234567890123456789012345678901234567891",
+                "manifestUrl": "https://example.com",
+                "recordingOracle": "0x1234567890123456789012345678901234567891",
+                "recordingOracleFee": "1000000000000000000",
+                "reputationOracle": "0x1234567890123456789012345678901234567891",
+                "reputationOracleFee": "1000000000000000000",
+                "exchangeOracle": "0x1234567890123456789012345678901234567891",
+                "exchangeOracleFee": "1000000000000000000",
+                "status": "Pending",
+                "token": "0x1234567890123456789012345678901234567891",
+                "totalFundedAmount": "1000000000000000000",
+            }
+            mock_escrow_2 = {
+                "id": "0x1234567890123456789012345678901234567892",
+                "address": "0x1234567890123456789012345678901234567892",
+                "amountPaid": "1000000000000000000",
+                "balance": "1000000000000000000",
+                "count": "1",
+                "factoryAddress": "0x1234567890123456789012345678901234567890",
+                "finalResultsUrl": "https://example.com",
+                "intermediateResultsUrl": "https://example.com",
+                "launcher": "0x1234567890123456789012345678901234567892",
+                "manifestHash": "0x1234567890123456789012345678901234567892",
+                "manifestUrl": "https://example.com",
+                "recordingOracle": "0x1234567890123456789012345678901234567892",
+                "recordingOracleFee": "1000000000000000000",
+                "reputationOracle": "0x1234567890123456789012345678901234567892",
+                "reputationOracleFee": "1000000000000000000",
+                "exchangeOracle": "0x1234567890123456789012345678901234567892",
+                "exchangeOracleFee": "1000000000000000000",
+                "status": "Pending",
+                "token": "0x1234567890123456789012345678901234567892",
+                "totalFundedAmount": "1000000000000000000",
+            }
 
             def side_effect(subgraph_url, query, params):
                 if subgraph_url == NETWORKS[ChainId.POLYGON_MUMBAI]["subgraph_url"]:
@@ -1976,6 +1972,7 @@ class EscrowTestCase(unittest.TestCase):
             filter = EscrowFilter(
                 networks=[ChainId.POLYGON_MUMBAI.value],
                 launcher="0x1234567890123456789012345678901234567891",
+                job_requester_id="1",
                 status=Status.Pending,
                 date_from=datetime.fromtimestamp(1683811973),
                 date_to=datetime.fromtimestamp(1683812007),
@@ -1990,6 +1987,7 @@ class EscrowTestCase(unittest.TestCase):
                     "reputationOracle": None,
                     "recordingOracle": None,
                     "exchangeOracle": None,
+                    "jobRequesterId": "1",
                     "status": "Pending",
                     "from": 1683811973,
                     "to": 1683812007,
@@ -2012,14 +2010,15 @@ class EscrowTestCase(unittest.TestCase):
                     "reputationOracle": None,
                     "recordingOracle": None,
                     "exchangeOracle": None,
+                    "jobRequesterId": None,
                     "status": None,
                     "from": None,
                     "to": None,
                 },
             )
             self.assertEqual(len(filtered), 2)
-            self.assertEqual(filtered[0][0]["chain_id"], ChainId.POLYGON.value)
-            self.assertEqual(filtered[1][0]["chain_id"], ChainId.POLYGON_MUMBAI.value)
+            self.assertEqual(filtered[0]["chain_id"], ChainId.POLYGON.value)
+            self.assertEqual(filtered[1]["chain_id"], ChainId.POLYGON_MUMBAI.value)
 
     def test_get_recording_oracle_address(self):
         mock_contract = MagicMock()

--- a/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/escrow.ts
@@ -11,6 +11,7 @@ const ESCROW_FRAGMENT = gql`
     finalResultsUrl
     id
     intermediateResultsUrl
+    jobRequesterId
     launcher
     manifestHash
     manifestUrl
@@ -30,6 +31,7 @@ const ESCROW_FRAGMENT = gql`
 export const GET_ESCROWS_QUERY = (filter: IEscrowsFilter) => {
   const {
     launcher,
+    jobRequesterId,
     reputationOracle,
     recordingOracle,
     exchangeOracle,
@@ -41,6 +43,7 @@ export const GET_ESCROWS_QUERY = (filter: IEscrowsFilter) => {
   const WHERE_CLAUSE = `
     where: {
       ${launcher ? `launcher: $launcher` : ''}
+      ${jobRequesterId ? `jobRequesterId: $jobRequesterId` : ''}
       ${reputationOracle ? `reputationOracle: $reputationOracle` : ''}
       ${recordingOracle ? `recordingOracle: $recordingOracle` : ''}
       ${exchangeOracle ? `exchangeOracle: $exchangeOracle` : ''}
@@ -53,6 +56,7 @@ export const GET_ESCROWS_QUERY = (filter: IEscrowsFilter) => {
   return gql`
     query getEscrows(
       $launcher: String
+      $jobRequesterId: String
       $reputationOracle: String
       $recordingOracle: String
       $exchangeOracle: String

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -43,6 +43,7 @@ export interface IEscrowsFilter {
   reputationOracle?: string;
   recordingOracle?: string;
   exchangeOracle?: string;
+  jobRequesterId?: string;
   status?: EscrowStatus;
   from?: Date;
   to?: Date;

--- a/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
@@ -1809,9 +1809,9 @@ describe('EscrowUtils', () => {
     });
 
     test('should throw an error if chainId is invalid', async () => {
-      await expect(EscrowUtils.getEscrows({ networks: [123] })).rejects.toThrow(
-        new EthereumError(ErrorUnsupportedChainID.message)
-      );
+      await expect(
+        EscrowUtils.getEscrows({ networks: [123] } as any)
+      ).rejects.toThrow(new EthereumError(ErrorUnsupportedChainID.message));
     });
     test('should throw an error if launcher is an invalid address', async () => {
       const launcher = FAKE_ADDRESS;
@@ -1851,6 +1851,7 @@ describe('EscrowUtils', () => {
           amountPaid: '3',
           balance: '0',
           count: '1',
+          jobRequesterId: '1',
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Completed',
@@ -1863,6 +1864,7 @@ describe('EscrowUtils', () => {
           amountPaid: '0',
           balance: '3',
           count: '2',
+          jobRequesterId: '1',
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Pending',
@@ -1895,6 +1897,7 @@ describe('EscrowUtils', () => {
           amountPaid: '3',
           balance: '0',
           count: '1',
+          jobRequesterId: '1',
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Completed',
@@ -1922,6 +1925,7 @@ describe('EscrowUtils', () => {
         amountPaid: '3',
         balance: '0',
         count: '1',
+        jobRequesterId: '1',
         factoryAddress: '0x0',
         launcher: '0x0',
         status: 'Completed',
@@ -1934,6 +1938,7 @@ describe('EscrowUtils', () => {
         amountPaid: '0',
         balance: '3',
         count: '2',
+        jobRequesterId: '1',
         factoryAddress: '0x0',
         launcher: '0x0',
         status: 'Pending',
@@ -1957,6 +1962,35 @@ describe('EscrowUtils', () => {
       expect(result[1]).toEqual(mumbaiEscrow);
       expect(result[0].chainId).toEqual(ChainId.POLYGON);
       expect(result[1].chainId).toEqual(ChainId.POLYGON_MUMBAI);
+      expect(gqlFetchSpy).toHaveBeenCalled();
+    });
+
+    test('should successfully getEscrows created by a specific job requester', async () => {
+      const escrows = [
+        {
+          id: '1',
+          address: '0x0',
+          amountPaid: '3',
+          balance: '0',
+          count: '1',
+          jobRequesterId: '1',
+          factoryAddress: '0x0',
+          launcher: '0x0',
+          status: 'Completed',
+          token: '0x0',
+          totalFundedAmount: '3',
+        },
+      ];
+      const gqlFetchSpy = vi
+        .spyOn(gqlFetch, 'default')
+        .mockResolvedValue({ escrows });
+
+      const result = await EscrowUtils.getEscrows({
+        networks: [ChainId.POLYGON_MUMBAI],
+        jobRequesterId: '1',
+      });
+
+      expect(result).toEqual(escrows);
       expect(gqlFetchSpy).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Description

Add the jobRequesterId filter to retrieve all escrows created by a specific user

## Summary of changes

Use Subgraph to get filter by jobRequesterId in both SDK

## How test the changes

`yarn test` in typescript and `make run-test' in python

## Related issues

#929

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
