### PR TITLE
[Job Launcher] Modify getJobByStatus to query Subgraph

### DIFF
--- a/packages/apps/job-launcher/server/src/common/enums/job.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/job.ts
@@ -9,10 +9,9 @@ export enum JobStatus {
 
 export enum JobStatusFilter {
   PENDING = 'PENDING',
-  PAID = 'PAID',
   LAUNCHED = 'LAUNCHED',
+  COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
-  TO_CANCEL = 'TO_CANCEL',
   CANCELED = 'CANCELED',
 }
 

--- a/packages/apps/job-launcher/server/src/common/enums/job.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/job.ts
@@ -2,6 +2,7 @@ export enum JobStatus {
   PENDING = 'PENDING',
   PAID = 'PAID',
   LAUNCHED = 'LAUNCHED',
+  COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
   TO_CANCEL = 'TO_CANCEL',
   CANCELED = 'CANCELED',

--- a/packages/apps/job-launcher/server/src/common/utils/status.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/status.ts
@@ -1,0 +1,15 @@
+import { EscrowStatus } from '@human-protocol/sdk';
+import { JobStatus, JobStatusFilter } from '../enums/job';
+
+export function filterToEscrowStatus(
+  filterStatus: JobStatusFilter,
+): EscrowStatus {
+  switch (filterStatus) {
+    case JobStatusFilter.COMPLETED:
+      return EscrowStatus.Complete;
+    case JobStatusFilter.CANCELED:
+      return EscrowStatus.Cancelled;
+    default:
+      return EscrowStatus.Launched;
+  }
+}

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -1,7 +1,7 @@
 import {
+  BadRequestException,
   Body,
   Controller,
-  DefaultValuePipe,
   Get,
   Headers,
   Param,
@@ -27,6 +27,7 @@ import { JobService } from './job.service';
 import { JobRequestType, JobStatusFilter } from '../../common/enums/job';
 import { Public } from '../../common/decorators';
 import { HEADER_SIGNATURE_KEY } from '../../common/constants';
+import { ChainId } from '@human-protocol/sdk';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -52,16 +53,31 @@ export class JobController {
   }
 
   @Get('/list')
+  @ApiQuery({
+    name: 'networks',
+    required: true,
+    enum: ChainId,
+    type: [String],
+    isArray: true,
+  })
   @ApiQuery({ name: 'status', required: false, enum: JobStatusFilter })
   @ApiQuery({ name: 'skip', required: false })
   @ApiQuery({ name: 'limit', required: false })
   public async getJobList(
     @Request() req: RequestWithUser,
+    @Query('networks') networks: ChainId[],
     @Query('status') status: JobStatusFilter,
-    @Query('skip', new DefaultValuePipe(null)) skip?: number,
-    @Query('limit', new DefaultValuePipe(null)) limit?: number,
-  ): Promise<JobListDto[]> {
-    return this.jobService.getJobsByStatus(req.user.id, status, skip, limit);
+    @Query('skip') skip = 0,
+    @Query('limit') limit = 10,
+  ): Promise<JobListDto[] | BadRequestException> {
+    networks = !Array.isArray(networks) ? [networks] : networks;
+    return this.jobService.getJobsByStatus(
+      networks,
+      req.user.id,
+      status,
+      skip,
+      limit,
+    );
   }
 
   @Get('/result')

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -15,11 +15,7 @@ import {
   IsEthereumAddress,
 } from 'class-validator';
 import { ChainId } from '@human-protocol/sdk';
-import {
-  JobRequestType,
-  JobStatus,
-  JobStatusFilter,
-} from '../../common/enums/job';
+import { JobRequestType, JobStatus } from '../../common/enums/job';
 import { EventType } from '../../common/enums/webhook';
 
 export class JobCreateDto {
@@ -324,7 +320,7 @@ export class JobListDto {
   escrowAddress?: string;
   network: string;
   fundAmount: number;
-  status: JobStatusFilter;
+  status: JobStatus;
 }
 
 export class EscrowFailedWebhookDto {

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1263,6 +1263,50 @@ describe('JobService', () => {
         [MOCK_ADDRESS],
       );
     });
+    it('should call subgraph and database with CANCELLED status', async () => {
+      const jobEntityMock = [
+        {
+          status: JobStatus.CANCELED,
+          fundAmount: 100,
+          userId: 1,
+          id: 1,
+          escrowAddress: MOCK_ADDRESS,
+          chainId: ChainId.LOCALHOST,
+        },
+      ];
+      const getEscrowsData = [
+        {
+          address: MOCK_ADDRESS,
+          status: EscrowStatus[EscrowStatus.Cancelled],
+        },
+      ];
+      jobRepository.findJobsByEscrowAddresses = jest
+        .fn()
+        .mockResolvedValue(jobEntityMock as any);
+      EscrowUtils.getEscrows = jest.fn().mockResolvedValue(getEscrowsData);
+
+      const results = await jobService.getJobsByStatus(
+        [ChainId.LOCALHOST],
+        userId,
+        JobStatusFilter.CANCELED,
+        skip,
+        limit,
+      );
+
+      expect(results).toMatchObject([
+        {
+          status: JobStatus.CANCELED,
+          fundAmount: 100,
+          jobId: 1,
+          escrowAddress: MOCK_ADDRESS,
+          network: NETWORKS[ChainId.LOCALHOST]?.title,
+        },
+      ]);
+      expect(jobRepository.findJobsByEscrowAddresses).toHaveBeenCalledWith(
+        userId,
+        [MOCK_ADDRESS],
+      );
+    });
   });
 
   describe('escrowFailedWebhook', () => {

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -76,7 +76,6 @@ import { JobService } from './job.service';
 import { div, mul } from '../../common/utils/decimal';
 import { PaymentRepository } from '../payment/payment.repository';
 import { RoutingProtocolService } from './routing-protocol.service';
-import { In } from 'typeorm';
 import { EventType } from '../../common/enums/webhook';
 import { PaymentEntity } from '../payment/payment.entity';
 import Decimal from 'decimal.js';
@@ -1190,40 +1189,34 @@ describe('JobService', () => {
 
     it('should call the database with PENDING status', async () => {
       jobService.getJobsByStatus(
-        [ChainId.POLYGON_MUMBAI],
+        [ChainId.LOCALHOST],
         userId,
         JobStatusFilter.PENDING,
         skip,
         limit,
       );
-      expect(jobRepository.find).toHaveBeenCalledWith(
-        {
-          status: In([JobStatus.PENDING, JobStatus.PAID]),
-          userId: userId,
-        },
-        {
-          skip: skip,
-          take: limit,
-        },
+      expect(jobRepository.findJobsByStatusFilter).toHaveBeenCalledWith(
+        [ChainId.LOCALHOST],
+        userId,
+        JobStatusFilter.PENDING,
+        skip,
+        limit,
       );
     });
     it('should call the database with FAILED status', async () => {
       jobService.getJobsByStatus(
-        [ChainId.POLYGON_MUMBAI],
+        [ChainId.LOCALHOST],
         userId,
         JobStatusFilter.FAILED,
         skip,
         limit,
       );
-      expect(jobRepository.find).toHaveBeenCalledWith(
-        {
-          status: In([JobStatus.FAILED]),
-          userId: userId,
-        },
-        {
-          skip: skip,
-          take: limit,
-        },
+      expect(jobRepository.findJobsByStatusFilter).toHaveBeenCalledWith(
+        [ChainId.LOCALHOST],
+        userId,
+        JobStatusFilter.FAILED,
+        skip,
+        limit,
       );
     });
     it('should call subgraph and database with LAUNCHED status', async () => {
@@ -1243,7 +1236,9 @@ describe('JobService', () => {
           status: EscrowStatus[EscrowStatus.Launched],
         },
       ];
-      jobRepository.find = jest.fn().mockResolvedValue(jobEntityMock as any);
+      jobRepository.findJobsByEscrowAddresses = jest
+        .fn()
+        .mockResolvedValue(jobEntityMock as any);
       EscrowUtils.getEscrows = jest.fn().mockResolvedValue(getEscrowsData);
 
       const results = await jobService.getJobsByStatus(
@@ -1259,14 +1254,14 @@ describe('JobService', () => {
           status: JobStatus.LAUNCHED,
           fundAmount: 100,
           jobId: 1,
-          address: MOCK_ADDRESS,
+          escrowAddress: MOCK_ADDRESS,
           network: NETWORKS[ChainId.LOCALHOST]?.title,
         },
       ]);
-      expect(jobRepository.find).toHaveBeenCalledWith({
-        userId: userId,
-        escrowAddress: In([MOCK_ADDRESS]),
-      });
+      expect(jobRepository.findJobsByEscrowAddresses).toHaveBeenCalledWith(
+        userId,
+        [MOCK_ADDRESS],
+      );
     });
   });
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -3,6 +3,7 @@ import {
   ChainId,
   EscrowClient,
   EscrowStatus,
+  EscrowUtils,
   NETWORKS,
   StakingClient,
   StorageClient,
@@ -67,7 +68,7 @@ import {
 import { JobEntity } from './job.entity';
 import { JobRepository } from './job.repository';
 import { RoutingProtocolService } from './routing-protocol.service';
-import { CVAT_JOB_TYPES, JOB_RETRIES_COUNT_THRESHOLD } from '../../common/constants';
+import { JOB_RETRIES_COUNT_THRESHOLD } from '../../common/constants';
 import { SortDirection } from '../../common/enums/collection';
 import { EventType } from '../../common/enums/webhook';
 import {
@@ -75,7 +76,6 @@ import {
   HMToken__factory,
 } from '@human-protocol/core/typechain-types';
 import Decimal from 'decimal.js';
-import { EscrowUtils } from '@human-protocol/sdk';
 
 @Injectable()
 export class JobService {
@@ -260,16 +260,20 @@ export class JobService {
 
     const manifest = await this.getManifest(jobEntity.manifestUrl);
 
-    const recordingOracleConfigKey = (manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE 
-                       ? ConfigNames.FORTUNE_RECORDING_ORACLE_ADDRESS 
-                       : ConfigNames.CVAT_RECORDING_ORACLE_ADDRESS;
+    const recordingOracleConfigKey =
+      (manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE
+        ? ConfigNames.FORTUNE_RECORDING_ORACLE_ADDRESS
+        : ConfigNames.CVAT_RECORDING_ORACLE_ADDRESS;
 
-    const exchangeOracleConfigKey = (manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE 
-                       ? ConfigNames.FORTUNE_EXCHANGE_ORACLE_ADDRESS 
-                       : ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS;
+    const exchangeOracleConfigKey =
+      (manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE
+        ? ConfigNames.FORTUNE_EXCHANGE_ORACLE_ADDRESS
+        : ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS;
 
     const escrowConfig = {
-      recordingOracle: this.configService.get<string>(recordingOracleConfigKey)!,
+      recordingOracle: this.configService.get<string>(
+        recordingOracleConfigKey,
+      )!,
       reputationOracle: this.configService.get<string>(
         ConfigNames.REPUTATION_ORACLE_ADDRESS,
       )!,
@@ -411,37 +415,88 @@ export class JobService {
   }
 
   public async getJobsByStatus(
+    networks: ChainId[],
     userId: number,
     status?: JobStatusFilter,
     skip = 0,
     limit = 10,
-  ): Promise<JobListDto[]> {
-    let statusFilter: any;
-    if (status) {
-      statusFilter = In([status]);
-      if (status === JobStatusFilter.PENDING)
-        statusFilter = In([JobStatus.PENDING, JobStatus.PAID]);
+  ): Promise<JobListDto[] | BadRequestException> {
+    try {
+      let transformedJobs: JobListDto[] = [];
+      let jobs;
+
+      switch (status) {
+        case JobStatusFilter.FAILED:
+        case JobStatusFilter.PENDING:
+          let statusFilter: any;
+          if (status) {
+            statusFilter = In([status]);
+            if (status === JobStatusFilter.PENDING)
+              statusFilter = In([JobStatus.PENDING, JobStatus.PAID]);
+          }
+
+          jobs = await this.jobRepository.find(
+            {
+              userId,
+              status: statusFilter,
+            },
+            { skip: skip, take: limit },
+          );
+          transformedJobs = jobs.map((original) => ({
+            jobId: original.id,
+            address: original.escrowAddress,
+            network: NETWORKS[original.chainId as ChainId]!.title,
+            fundAmount: original.fundAmount,
+            status:
+              original.status === JobStatus.PAID
+                ? JobStatusFilter.PENDING
+                : (original.status as any),
+          }));
+          break;
+        case JobStatusFilter.CANCELED:
+        case JobStatusFilter.LAUNCHED:
+        case JobStatusFilter.COMPLETED:
+          const escrows = (
+            await EscrowUtils.getEscrows({
+              networks: networks,
+              jobRequesterId: userId.toString(),
+              status:
+                status === JobStatusFilter.LAUNCHED
+                  ? EscrowStatus.Launched
+                  : status === JobStatusFilter.COMPLETED
+                  ? EscrowStatus.Complete
+                  : EscrowStatus.Cancelled,
+            })
+          ).slice(skip, limit);
+
+          const escrowAddresses = escrows.map((escrow) => escrow.address);
+
+          jobs = await this.jobRepository.find({
+            userId,
+            escrowAddress: In(escrowAddresses),
+          });
+
+          transformedJobs = jobs.map((original) => ({
+            jobId: original.id,
+            address: original.escrowAddress,
+            network: NETWORKS[original.chainId as ChainId]!.title,
+            fundAmount: original.fundAmount,
+            status:
+              original.status === JobStatus.TO_CANCEL
+                ? JobStatus.TO_CANCEL
+                : (escrows
+                    .find((escrow) => escrow.address === original.escrowAddress)
+                    ?.status.toUpperCase() as any),
+          }));
+          break;
+      }
+      console.log('transformedJobs', transformedJobs);
+
+      return transformedJobs;
+    } catch (error) {
+      console.error(error);
+      throw new BadRequestException(error.message);
     }
-
-    const jobs = await this.jobRepository.find(
-      {
-        userId,
-        status: statusFilter,
-      },
-      { skip: skip, take: limit },
-    );
-    const transformedJobs: JobListDto[] = jobs.map((original) => ({
-      jobId: original.id,
-      address: original.escrowAddress,
-      network: NETWORKS[original.chainId as ChainId]!.title,
-      fundAmount: original.fundAmount,
-      status:
-        original.status === JobStatus.PAID
-          ? JobStatusFilter.PENDING
-          : JobStatusFilter[original.status],
-    }));
-
-    return transformedJobs;
   }
 
   public async getResult(
@@ -546,7 +601,7 @@ export class JobService {
         }
       }
     } catch (e) {
-      console.log(e)
+      console.log(e);
       this.logger.error(e);
       return;
     }
@@ -684,13 +739,13 @@ export class JobService {
     let escrow, allocation;
 
     if (escrowAddress) {
-        const stakingClient = await StakingClient.build(signer);
+      const stakingClient = await StakingClient.build(signer);
 
-        escrow = await EscrowUtils.getEscrow(chainId, escrowAddress);
-        allocation = await stakingClient.getAllocation(escrowAddress);
+      escrow = await EscrowUtils.getEscrow(chainId, escrowAddress);
+      allocation = await stakingClient.getAllocation(escrowAddress);
     }
 
-    const manifestData = await this.getManifest(manifestUrl)
+    const manifestData = await this.getManifest(manifestUrl);
     if (!manifestData) {
       throw new NotFoundException(ErrorJob.ManifestNotFound);
     }
@@ -701,63 +756,68 @@ export class JobService {
         ? (manifestData as FortuneManifestDto)
         : (manifestData as CvatManifestDto);
 
-
     const baseManifestDetails = {
       chainId,
-      tokenAddress: escrow? escrow.token : ethers.constants.AddressZero,
+      tokenAddress: escrow ? escrow.token : ethers.constants.AddressZero,
       fundAmount: escrow ? Number(escrow.totalFundedAmount) : 0,
       requesterAddress: signer.address,
       exchangeOracleAddress: escrow?.exchangeOracle,
       recordingOracleAddress: escrow?.recordingOracle,
-      reputationOracleAddress: escrow?.reputationOracle
+      reputationOracleAddress: escrow?.reputationOracle,
     };
 
-    const specificManifestDetails = (manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE
-      ? {
-          title: (manifest as FortuneManifestDto).requesterTitle,
-          description: (manifest as FortuneManifestDto).requesterDescription,
-          requestType: JobRequestType.FORTUNE,
-          submissionsRequired: (manifest as FortuneManifestDto).submissionsRequired,
-      }
-      : {
-          requestType: (manifest as CvatManifestDto).annotation.type,
-          submissionsRequired: (manifest as CvatManifestDto).annotation.job_size,
-      };
+    const specificManifestDetails =
+      (manifest as FortuneManifestDto).requestType === JobRequestType.FORTUNE
+        ? {
+            title: (manifest as FortuneManifestDto).requesterTitle,
+            description: (manifest as FortuneManifestDto).requesterDescription,
+            requestType: JobRequestType.FORTUNE,
+            submissionsRequired: (manifest as FortuneManifestDto)
+              .submissionsRequired,
+          }
+        : {
+            requestType: (manifest as CvatManifestDto).annotation.type,
+            submissionsRequired: (manifest as CvatManifestDto).annotation
+              .job_size,
+          };
 
-    const manifestDetails = { ...baseManifestDetails, ...specificManifestDetails };
+    const manifestDetails = {
+      ...baseManifestDetails,
+      ...specificManifestDetails,
+    };
 
     if (!escrowAddress) {
       return {
-          details: {
-              escrowAddress: ethers.constants.AddressZero,
-              manifestUrl,
-              manifestHash,
-              balance: 0,
-              paidOut: 0,
-          },
-          manifest: manifestDetails,
-          staking: {
-              staker: ethers.constants.AddressZero,
-              allocated: 0,
-              slashed: 0
-          }
+        details: {
+          escrowAddress: ethers.constants.AddressZero,
+          manifestUrl,
+          manifestHash,
+          balance: 0,
+          paidOut: 0,
+        },
+        manifest: manifestDetails,
+        staking: {
+          staker: ethers.constants.AddressZero,
+          allocated: 0,
+          slashed: 0,
+        },
       };
     }
 
     return {
       details: {
-          escrowAddress,
-          manifestUrl,
-          manifestHash,
-          balance: Number(ethers.utils.formatEther(escrow?.balance || 0)),
-          paidOut: Number(escrow?.amountPaid || 0),
+        escrowAddress,
+        manifestUrl,
+        manifestHash,
+        balance: Number(ethers.utils.formatEther(escrow?.balance || 0)),
+        paidOut: Number(escrow?.amountPaid || 0),
       },
       manifest: manifestDetails,
       staking: {
-          staker: allocation?.staker!,
-          allocated: allocation?.tokens.toNumber()!,
-          slashed: 0, // TODO: Retrieve slash tokens
-      }
+        staker: allocation?.staker as string,
+        allocated: allocation?.tokens.toNumber() as number,
+        slashed: 0, // TODO: Retrieve slash tokens
+      },
     };
   }
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -77,6 +77,7 @@ import {
 } from '@human-protocol/core/typechain-types';
 import Decimal from 'decimal.js';
 import { EscrowData } from '@human-protocol/sdk/dist/graphql';
+import { filterToEscrowStatus } from '../../common/utils/status';
 
 @Injectable()
 export class JobService {
@@ -470,17 +471,10 @@ export class JobService {
     skip: number,
     limit: number,
   ): Promise<EscrowData[]> {
-    const escrowStatus =
-      status === JobStatusFilter.LAUNCHED
-        ? EscrowStatus.Launched
-        : status === JobStatusFilter.COMPLETED
-        ? EscrowStatus.Complete
-        : EscrowStatus.Cancelled;
-
     const escrows = await EscrowUtils.getEscrows({
       networks,
       jobRequesterId: userId.toString(),
-      status: escrowStatus,
+      status: filterToEscrowStatus(status),
     });
 
     return escrows.slice(skip, limit);


### PR DESCRIPTION
## Description

Modify the old getJobByStatus to request the information on chain and check it against the information we have in the database to show all the escrows with their current statuses

## Summary of changes

Use the new getEscrows SDK method to request the information from Subgraph. Once we have all the escrows, we have to check them against the TO_CANCEL escrows we have in the database to update them because the TO_CANCEL status does not exist in blockchain

## How test the changes

`yarn test`

## Related issues
#936

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
