### PR TITLE
Implement GAS_LIMIT usage for python sdk

### DIFF
--- a/packages/examples/cvat/recording-oracle/tests/utils/setup_escrow.py
+++ b/packages/examples/cvat/recording-oracle/tests/utils/setup_escrow.py
@@ -29,10 +29,8 @@ def create_escrow(web3: Web3):
         EscrowConfig(
             RECORDING_ORACLE_ADDRESS,
             REPUTATION_ORACLE_ADDRESS,
-            EXCHANGE_ORACLE_ADDRESS,
             RECORDING_ORACLE_FEE,
             REPUTATION_ORACLE_FEE,
-            EXCHANGE_ORACLE_FEE,
             DEFAULT_URL,
             DEFAULT_HASH,
         ),

--- a/packages/sdk/python/human-protocol-sdk/example.py
+++ b/packages/sdk/python/human-protocol-sdk/example.py
@@ -66,7 +66,6 @@ if __name__ == "__main__":
         )
     )
 
-
     # process annotation data and get quality estimates
     url = "https://raw.githubusercontent.com/humanprotocol/human-protocol/efa8d3789ac35915b42435011cd0a8d36507564c/packages/sdk/python/human-protocol-sdk/example_annotations.json"
     annotations = json.loads(StorageClient.download_file_from_url(url))

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -190,3 +190,5 @@ class Role(Enum):
 
 
 ARTIFACTS_FOLDER = os.path.join(os.path.dirname(os.path.dirname(__file__)), "artifacts")
+
+GAS_LIMIT = int(os.getenv("GAS_LIMIT", 4712388))

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -167,12 +167,13 @@ class EscrowClient:
     A class used to manage escrow on the HUMAN network.
     """
 
-    def __init__(self, web3: Web3):
+    def __init__(self, web3: Web3, gas_limit: Optional[int] = None):
         """
         Initializes a Escrow instance.
 
         Args:
             web3 (Web3): The Web3 object
+            gas_limit (int): Gas limit to be provided to transaction
         """
 
         # Initialize web3 instance
@@ -196,6 +197,7 @@ class EscrowClient:
         self.factory_contract = self.w3.eth.contract(
             address=self.network["factory_address"], abi=factory_interface["abi"]
         )
+        self.gas_limit = gas_limit
 
     def create_escrow(
         self, token_address: str, trusted_handlers: List[str], job_requester_id: str
@@ -228,6 +230,7 @@ class EscrowClient:
                 token_address, trusted_handlers, job_requester_id
             ),
             EscrowClientError,
+            self.gas_limit,
         )
         return next(
             (
@@ -270,6 +273,7 @@ class EscrowClient:
                 escrow_config.hash,
             ),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def create_and_setup_escrow(
@@ -332,6 +336,7 @@ class EscrowClient:
             "Fund",
             token_contract.functions.transfer(escrow_address, amount),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def store_results(self, escrow_address: str, url: str, hash: str) -> None:
@@ -363,6 +368,7 @@ class EscrowClient:
             "Store Results",
             self._get_escrow_contract(escrow_address).functions.storeResults(url, hash),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def complete(self, escrow_address: str) -> None:
@@ -386,6 +392,7 @@ class EscrowClient:
             "Complete",
             self._get_escrow_contract(escrow_address).functions.complete(),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def bulk_payout(
@@ -445,6 +452,7 @@ class EscrowClient:
                 recipients, amounts, final_results_url, final_results_hash, txId
             ),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def cancel(self, escrow_address: str) -> None:
@@ -468,6 +476,7 @@ class EscrowClient:
             "Cancel",
             self._get_escrow_contract(escrow_address).functions.cancel(),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def abort(self, escrow_address: str) -> None:
@@ -491,6 +500,7 @@ class EscrowClient:
             "Abort",
             self._get_escrow_contract(escrow_address).functions.abort(),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def add_trusted_handlers(self, escrow_address: str, handlers: List[str]) -> None:
@@ -519,6 +529,7 @@ class EscrowClient:
                 handlers
             ),
             EscrowClientError,
+            self.gas_limit,
         )
 
     def get_balance(self, escrow_address: str) -> Decimal:

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore.py
@@ -28,7 +28,7 @@ class KVStoreClient:
     A class used to manage kvstore on the HUMAN network.
     """
 
-    def __init__(self, web3: Web3):
+    def __init__(self, web3: Web3, gas_limit: Optional[int] = None):
         """
         Initializes a KVStore instance.
 
@@ -57,6 +57,7 @@ class KVStoreClient:
         self.kvstore_contract = self.w3.eth.contract(
             address=self.network["kvstore_address"], abi=kvstore_interface["abi"]
         )
+        self.gas_limit = gas_limit
 
     def set(self, key: str, value: str) -> None:
         """
@@ -78,6 +79,7 @@ class KVStoreClient:
             "Set",
             self.kvstore_contract.functions.set(key, value),
             KVStoreClientError,
+            self.gas_limit,
         )
 
     def set_bulk(self, keys: List[str], values: List[str]) -> None:
@@ -104,6 +106,7 @@ class KVStoreClient:
             "Set Bulk",
             self.kvstore_contract.functions.setBulk(keys, values),
             KVStoreClientError,
+            self.gas_limit,
         )
 
     def get(self, address: str, key: str) -> str:

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
@@ -10,7 +10,7 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.types import TxReceipt
 
-from human_protocol_sdk.constants import ARTIFACTS_FOLDER
+from human_protocol_sdk.constants import ARTIFACTS_FOLDER, GAS_LIMIT
 
 logger = logging.getLogger("human_protocol_sdk.utils")
 
@@ -208,7 +208,13 @@ def get_data_from_subgraph(url: str, query: str, params: dict = None):
         )
 
 
-def handle_transaction(w3: Web3, tx_name, tx, exception):
+def handle_transaction(
+    w3: Web3,
+    tx_name: str,
+    tx,
+    exception: Exception,
+    gas_limit: Optional[int] = None,
+):
     """Executes the transaction and waits for the receipt.
 
     Args:
@@ -231,7 +237,7 @@ def handle_transaction(w3: Web3, tx_name, tx, exception):
             "You must add construct_sign_and_send_raw_middleware middleware to Web3 instance"
         )
     try:
-        tx_hash = tx.transact()
+        tx_hash = tx.transact({"gas": gas_limit or GAS_LIMIT})
         return w3.eth.wait_for_transaction_receipt(tx_hash)
     except Exception as e:
         if "reverted with reason string" in e.args[0]:

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/agreement/test_measures.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/agreement/test_measures.py
@@ -19,7 +19,6 @@ from .conftest import (
 
 
 def test_agreement(annotations, labels):
-
     # test if both interfaces match
     k_agree = agreement(annotations, measure="fleiss_kappa", labels=labels)["results"][
         "score"

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -368,6 +368,7 @@ class EscrowTestCase(unittest.TestCase):
                     "Create Escrow",
                     mock_function_create.return_value,
                     EscrowClientError,
+                    None,
                 )
 
     def test_create_escrow_invalid_token(self):
@@ -442,6 +443,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Setup",
                 mock_contract.functions.setup.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_setup_invalid_address(self):
@@ -595,12 +597,14 @@ class EscrowTestCase(unittest.TestCase):
                     "Create Escrow",
                     mock_function_create.return_value,
                     EscrowClientError,
+                    None,
                 )
                 mock_function.assert_called_with(
                     self.w3,
                     "Setup",
                     mock_contract.functions.setup.return_value,
                     EscrowClientError,
+                    None,
                 )
 
     def test_create_and_setup_escrow_invalid_token(self):
@@ -742,6 +746,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Store Results",
                 mock_contract.functions.storeResults.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_store_results_invalid_address(self):
@@ -867,6 +872,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Bulk Payout",
                 mock_contract.functions.bulkPayOut.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_bulk_payout_invalid_address(self):
@@ -1219,6 +1225,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Complete",
                 mock_contract.functions.complete.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_complete_invalid_address(self):
@@ -1299,6 +1306,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Cancel",
                 mock_contract.functions.cancel.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_cancel_invalid_address(self):
@@ -1378,6 +1386,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Abort",
                 mock_contract.functions.abort.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_abort_invalid_address(self):
@@ -1461,6 +1470,7 @@ class EscrowTestCase(unittest.TestCase):
                 "Add Trusted Handlers",
                 mock_contract.functions.addTrustedHandlers.return_value,
                 EscrowClientError,
+                None,
             )
 
     def test_add_trusted_handlers_invalid_address(self):

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_kvstore.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_kvstore.py
@@ -77,7 +77,11 @@ class KVStoreTestCase(unittest.TestCase):
 
             mock_function.assert_called_once_with(key, value)
             mock_handle_transaction.assert_called_once_with(
-                self.w3, "Set", mock_function.return_value, KVStoreClientError
+                self.w3,
+                "Set",
+                mock_function.return_value,
+                KVStoreClientError,
+                None,
             )
 
     def test_set_empty_key(self):
@@ -114,7 +118,11 @@ class KVStoreTestCase(unittest.TestCase):
 
             mock_function.assert_called_once_with(keys, values)
             mock_handle_transaction.assert_called_once_with(
-                self.w3, "Set Bulk", mock_function.return_value, KVStoreClientError
+                self.w3,
+                "Set Bulk",
+                mock_function.return_value,
+                KVStoreClientError,
+                None,
             )
 
     def test_set_bulk_empty_key(self):


### PR DESCRIPTION
## Description

To increase percentage of successfully handled transactions we need to provide custom gas limit to it to avoid `out of gas` errors.

## Summary of changes

Add gas limit to transaction.

## How test the changes

Define gas limit and deploy a job. Check gas limit of handled transaction.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
