### PR TITLE
Added directory param to listObjects method in SDK

### DIFF
--- a/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/storage.ts
@@ -152,9 +152,10 @@ export class StorageClient {
    * **Checks if a bucket exists**
    *
    * @param {string} bucket - Name of the bucket
+   * @param {string} directory - Name of the directory
    * @returns {Promise<string[]>} - A list of filenames with their extensions in the bucket
    */
-  public async listObjects(bucket: string): Promise<string[]> {
+  public async listObjects(bucket: string, directory = ''): Promise<string[]> {
     const isBucketExists = await this.client.bucketExists(bucket);
     if (!isBucketExists) {
       throw ErrorStorageBucketNotFound;
@@ -163,7 +164,7 @@ export class StorageClient {
     try {
       return new Promise((resolve, reject) => {
         const keys: string[] = [];
-        const stream = this.client.listObjectsV2(bucket, '', true, '');
+        const stream = this.client.listObjectsV2(bucket, directory, true, '');
 
         stream.on('data', (obj) => keys.push(obj.name));
         stream.on('error', reject);

--- a/packages/sdk/typescript/human-protocol-sdk/test/storage.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/storage.test.ts
@@ -228,7 +228,7 @@ describe('Storage tests', () => {
       );
     });
 
-    test('should return a list of objects with success', async () => {
+    test('should list objects without a directory prefix', async () => {
       const file1 = { key: STORAGE_TEST_FILE_VALUE };
       const hash1 = crypto
         .createHash('sha1')
@@ -243,12 +243,46 @@ describe('Storage tests', () => {
         .digest('hex');
       const key2 = `s3${hash2}.json`;
 
-      vi.spyOn(storageClient, 'listObjects').mockImplementation(() =>
-        Promise.resolve([key1, key2])
-      );
+      const mockListObject = vi
+        .spyOn(storageClient, 'listObjects')
+        .mockImplementation(() => Promise.resolve([key1, key2]));
 
       const results = await storageClient.listObjects(DEFAULT_PUBLIC_BUCKET);
 
+      expect(mockListObject).toHaveBeenCalledWith(DEFAULT_PUBLIC_BUCKET);
+      expect(results[0]).toEqual(key1);
+      expect(results[1]).toEqual(key2);
+    });
+
+    test('should list objects with a directory prefix', async () => {
+      const file1 = { key: STORAGE_TEST_FILE_VALUE };
+      const hash1 = crypto
+        .createHash('sha1')
+        .update(JSON.stringify(file1))
+        .digest('hex');
+      const key1 = `s3${hash1}.json`;
+
+      const file2 = { key: STORAGE_TEST_FILE_VALUE_2 };
+      const hash2 = crypto
+        .createHash('sha1')
+        .update(JSON.stringify(file2))
+        .digest('hex');
+      const key2 = `s3${hash2}.json`;
+      const directory = 'folder';
+
+      const mockListObject = vi
+        .spyOn(storageClient, 'listObjects')
+        .mockImplementation(() => Promise.resolve([key1, key2]));
+
+      const results = await storageClient.listObjects(
+        DEFAULT_PUBLIC_BUCKET,
+        directory
+      );
+
+      expect(mockListObject).toHaveBeenCalledWith(
+        DEFAULT_PUBLIC_BUCKET,
+        directory
+      );
       expect(results[0]).toEqual(key1);
       expect(results[1]).toEqual(key2);
     });


### PR DESCRIPTION
## Description
Extended SDK's capabilities to specifically list objects within a particular directory of a Minio bucket. This ensures better granularity when retrieving objects from Minio, especially when a bucket contains multiple datasets or directories.
In scenarios where buckets contain data from multiple sources or types, being able to target a specific directory ensures efficient and focused data retrieval.

## Summary of changes
-  Updated the listObjectsV2 method to accept an additional parameter for the directory (or use the existing prefix parameter).
- Updated the SDK documentation to reflect the changes.

```
const stream = minioClient.listObjectsV2('bucketName', 'directory/', true);
```

## How test the changes
`yarn test`

## Related issues
[[Job Launcher] [SDK] Add directory param to listObjects method in SDK#893](https://github.com/humanprotocol/human-protocol/issues/893)