### PR TITLE
[Job Launcher] Added reason property to escrow failed webhook payload

### DIFF
--- a/packages/apps/job-launcher/server/src/common/interfaces/job.ts
+++ b/packages/apps/job-launcher/server/src/common/interfaces/job.ts
@@ -10,6 +10,7 @@ export interface IJob extends IBase {
   manifestUrl: string;
   manifestHash: string;
   status: JobStatus;
+  failedReason?: string;
   retriesCount?: number;
   waitUntil: Date;
 }

--- a/packages/apps/job-launcher/server/src/database/migrations/1696331060184-AddFailedReasonToJobs.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1696331060184-AddFailedReasonToJobs.ts
@@ -5,14 +5,14 @@ export class AddFailedReasonToJobs1696331060184 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
             ALTER TABLE "hmt"."jobs"
-            ADD COLUMN failedReason character varying;
+            ADD COLUMN failed_reason character varying;
         `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
             ALTER TABLE "hmt"."jobs"
-            DROP COLUMN failedReason;
+            DROP COLUMN failed_reason;
         `);
     }
 

--- a/packages/apps/job-launcher/server/src/database/migrations/1696331060184-AddFailedReasonToJobs.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1696331060184-AddFailedReasonToJobs.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddFailedReasonToJobs1696331060184 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ADD COLUMN failedReason character varying;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            DROP COLUMN failedReason;
+        `);
+    }
+
+}

--- a/packages/apps/job-launcher/server/src/modules/job/job.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.entity.ts
@@ -34,6 +34,9 @@ export class JobEntity extends BaseEntity implements IJob {
   })
   public status: JobStatus;
 
+  @Column({ type: 'varchar', nullable: true })
+  public failedReason: string;
+
   @ManyToOne(() => UserEntity, (user) => user.jobs, { eager: true })
   user: UserEntity;
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1312,9 +1312,9 @@ describe('JobService', () => {
   describe('escrowFailedWebhook', () => {
     it('should throw BadRequestException for invalid event type', async () => {
       const dto = {
-        event_type: 'ANOTHER_EVENT' as EventType,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: 'ANOTHER_EVENT' as EventType,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
 
@@ -1325,9 +1325,9 @@ describe('JobService', () => {
 
     it('should throw NotFoundException if jobEntity is not found', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       jobRepository.findOne = jest.fn().mockResolvedValue(null);
@@ -1339,9 +1339,9 @@ describe('JobService', () => {
 
     it('should throw ConflictException if jobEntity status is not LAUNCHED', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       const mockJobEntity = {
@@ -1357,17 +1357,18 @@ describe('JobService', () => {
 
     it('should update jobEntity status to FAILED and return true if all checks pass', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
-      const mockJobEntity = { status: JobStatus.LAUNCHED, save: jest.fn() };
+      const mockJobEntity = { status: JobStatus.LAUNCHED, failedReason: dto.reason, save: jest.fn() };
       jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
 
       const result = await jobService.escrowFailedWebhook(dto);
       expect(result).toBe(true);
       expect(mockJobEntity.status).toBe(JobStatus.FAILED);
+      expect(mockJobEntity.failedReason).toBe(dto.reason);
       expect(mockJobEntity.save).toHaveBeenCalled();
     });
   });

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -728,6 +728,7 @@ export class JobService {
     }
 
     jobEntity.status = JobStatus.FAILED;
+    jobEntity.failedReason = dto.reason;
     await jobEntity.save();
 
     return true;


### PR DESCRIPTION
## Description
Added reason property to escrow failed webhook payload

## Summary of changes
- Updated job service `escrowFailedWebhook` method.
- Updated unit tests.
- Added new migration.

## How test the changes
`yarn test`

## Related issues
[[Job Launcher] Add reason property to escrow failed webhook payload#978](https://github.com/humanprotocol/human-protocol/issues/978)