### PR TITLE
[Job Launcher] Fixed job cancellation statuses

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -13,6 +13,7 @@ export enum ErrorJob {
   InvalidRequestType = 'Invalid job type',
   JobParamsValidationFailed = 'Job parameters validation failed',
   InvalidEventType = 'Invalid event type',
+  InvalidStatusCancellation = 'Job has an invalid status for cancellation',
   NotLaunched = 'Not launched',
 }
 

--- a/packages/apps/job-launcher/server/src/common/constants/index.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/index.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@human-protocol/sdk';
-import { JobRequestType } from '../enums/job';
+import { JobRequestType, JobStatus } from '../enums/job';
 
 export const NS = 'hmt';
 export const COINGECKO_API_URL =
@@ -25,3 +25,5 @@ export const SENDGRID_API_KEY_REGEX =
 export const HEADER_SIGNATURE_KEY = 'human-signature';
 
 export const CVAT_JOB_TYPES = [JobRequestType.IMAGE_BOXES, JobRequestType.IMAGE_POINTS]
+
+export const CANCEL_JOB_STATUSES = [JobStatus.PENDING, JobStatus.PAID, JobStatus.LAUNCHED]

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -536,35 +536,20 @@ describe('JobService', () => {
       expect(mockJobEntity.save).toHaveBeenCalled();
     });
 
-    it('should throw not found exception if job not found', async () => {
-      jobRepository.findOne = jest.fn().mockResolvedValue(undefined);
-
-      await expect(
-        jobService.requestToCancelJob(userId, jobId),
-      ).rejects.toThrow(NotFoundException);
-    });
-  });
-
-  describe('requestToCancelJob', () => {
-    const jobId = 1;
-    const userId = 123;
-
-    it('should cancel the job', async () => {
+    it('should throw invalid status cancellation', async () => {
       const mockJobEntity: Partial<JobEntity> = {
         id: jobId,
         userId,
-        status: JobStatus.LAUNCHED,
+        status: JobStatus.CANCELED,
         chainId: ChainId.LOCALHOST,
         save: jest.fn().mockResolvedValue(true),
       };
 
       jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
-
-      const result = await jobService.requestToCancelJob(userId, jobId);
-
-      expect(result).toEqual(true);
-      expect(jobRepository.findOne).toHaveBeenCalledWith({ id: jobId, userId });
-      expect(mockJobEntity.save).toHaveBeenCalled();
+    
+      await expect(
+        jobService.requestToCancelJob(userId, jobId),
+      ).rejects.toThrow(ConflictException);
     });
 
     it('should throw not found exception if job not found', async () => {
@@ -1312,9 +1297,9 @@ describe('JobService', () => {
   describe('escrowFailedWebhook', () => {
     it('should throw BadRequestException for invalid event type', async () => {
       const dto = {
-        event_type: 'ANOTHER_EVENT' as EventType,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: 'ANOTHER_EVENT' as EventType,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
 
@@ -1325,9 +1310,9 @@ describe('JobService', () => {
 
     it('should throw NotFoundException if jobEntity is not found', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       jobRepository.findOne = jest.fn().mockResolvedValue(null);
@@ -1339,9 +1324,9 @@ describe('JobService', () => {
 
     it('should throw ConflictException if jobEntity status is not LAUNCHED', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       const mockJobEntity = {
@@ -1357,9 +1342,9 @@ describe('JobService', () => {
 
     it('should update jobEntity status to FAILED and return true if all checks pass', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       const mockJobEntity = { status: JobStatus.LAUNCHED, save: jest.fn() };

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -68,7 +68,7 @@ import {
 import { JobEntity } from './job.entity';
 import { JobRepository } from './job.repository';
 import { RoutingProtocolService } from './routing-protocol.service';
-import { JOB_RETRIES_COUNT_THRESHOLD } from '../../common/constants';
+import { CANCEL_JOB_STATUSES, JOB_RETRIES_COUNT_THRESHOLD } from '../../common/constants';
 import { SortDirection } from '../../common/enums/collection';
 import { EventType } from '../../common/enums/webhook';
 import {
@@ -337,6 +337,11 @@ export class JobService {
     if (!jobEntity) {
       this.logger.log(ErrorJob.NotFound, JobService.name);
       throw new NotFoundException(ErrorJob.NotFound);
+    }
+
+    if (!CANCEL_JOB_STATUSES.includes(jobEntity.status)) {
+      this.logger.log(ErrorJob.InvalidStatusCancellation, JobService.name);
+      throw new ConflictException(ErrorJob.InvalidStatusCancellation);
     }
 
     jobEntity.status = JobStatus.TO_CANCEL;


### PR DESCRIPTION
## Description
Fixed a bug in which escrow can be canceled at any status.

## Summary of changes
- Updated `requestToCancelJob` method.
- Updated tests

## How test the changes
`yarn test`

## Related issues
[[Job Launcher] Completed or canceled jobs cannot be cancelled#990](https://github.com/humanprotocol/human-protocol/issues/990)