### PR TITLE
[Job Launcher] Improved restore password logic

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -44,7 +44,7 @@ export enum ErrorAuth {
   NotFound = 'Auth not found',
   InvalidEmailOrPassword = 'Invalid email or password',
   RefreshTokenHasExpired = 'Refresh token has expired',
-  UserNotActive = 'User not active',
+  UserNotActive = 'User not active'
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.service.spec.ts
@@ -387,6 +387,27 @@ describe('AuthService', () => {
       ).rejects.toThrow(UnauthorizedException);
     });
 
+    it('should remove existing token if it exists', async () => {
+      const userEntity = {
+        id: 1,
+        status: UserStatus.ACTIVE,
+      } as UserEntity;
+
+      userService.getByEmail = jest.fn().mockResolvedValue(userEntity);
+  
+      const existingToken = {
+        id: 2,
+        userId: userEntity.id,
+        tokenType: TokenType.PASSWORD,
+        remove: jest.fn(),
+      };
+      tokenRepository.findOne = jest.fn().mockResolvedValue(existingToken);
+  
+      await authService.forgotPassword({ email: 'user@example.com' });
+  
+      expect(existingToken.remove).toHaveBeenCalled();
+    });
+
     it('should create a new token and send email', async () => {
       userService.getByEmail = jest.fn().mockResolvedValueOnce(userEntity);
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1312,9 +1312,9 @@ describe('JobService', () => {
   describe('escrowFailedWebhook', () => {
     it('should throw BadRequestException for invalid event type', async () => {
       const dto = {
-        event_type: 'ANOTHER_EVENT' as EventType,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: 'ANOTHER_EVENT' as EventType,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
 
@@ -1325,9 +1325,9 @@ describe('JobService', () => {
 
     it('should throw NotFoundException if jobEntity is not found', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       jobRepository.findOne = jest.fn().mockResolvedValue(null);
@@ -1339,9 +1339,9 @@ describe('JobService', () => {
 
     it('should throw ConflictException if jobEntity status is not LAUNCHED', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       const mockJobEntity = {
@@ -1357,9 +1357,9 @@ describe('JobService', () => {
 
     it('should update jobEntity status to FAILED and return true if all checks pass', async () => {
       const dto = {
-        event_type: EventType.TASK_CREATION_FAILED,
-        chain_id: 1,
-        escrow_address: 'address',
+        eventType: EventType.TASK_CREATION_FAILED,
+        chainId: 1,
+        escrowAddress: 'address',
         reason: 'invalid manifest',
       };
       const mockJobEntity = { status: JobStatus.LAUNCHED, save: jest.fn() };


### PR DESCRIPTION
## Description
Generated a new token to restore the password if there was a pending token existing, the old one has to be removed first. 

## Summary of changes
- Removed existing token
- Generated new token
- Updated unit tests

## How test the changes
`yarn test`

## Related issues
[[Job Launcher] Restore password improvement#854](https://github.com/humanprotocol/human-protocol/issues/854)