### PR TITLE
[SDK][Agreement] Fix value range for measures.

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/agreement/bootstrap.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/agreement/bootstrap.py
@@ -71,6 +71,7 @@ def confidence_intervals(
         idx = np.random.randint(n_data - 1, size=(n_sample,))
         sample = data[idx]
         theta_b[i] = statistic_fn(sample)
+    theta_b = theta_b[~np.isnan(theta_b)]
 
     match algorithm:
         case "percentile":
@@ -86,6 +87,7 @@ def confidence_intervals(
                 theta_jn[i] = (n_data - 1) * (
                     theta_hat - statistic_fn(data[jn_idxs[i]])
                 )
+            theta_jn = theta_jn[~np.isnan(theta_jn)]
 
             a = (np.sum(theta_jn**3) / np.sum(theta_jn**2, axis=-1) ** 1.5) / 6
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/agreement/conftest.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/agreement/conftest.py
@@ -62,7 +62,7 @@ def annotations_multiple_raters() -> np.ndarray:
     )
 
 
-annotation_generator = tuples(integers(1, 500), integers(2, 10), integers(2, 5)).map(
+annotation_generator = tuples(integers(1, 500), integers(1, 10), integers(1, 5)).map(
     lambda xs: np.random.randint(0, xs[2], size=(xs[0], xs[1]))
 )
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/agreement/test_measures.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/agreement/test_measures.py
@@ -56,6 +56,12 @@ def test_fleiss_kappa(annotations_multiple_raters):
     kappa = fleiss_kappa(annotations_multiple_raters)
     assert eq_rounded(kappa, 0.05)
 
+    single_class_annos = np.zeros((10, 3))  # all annotators gave the same labels
+    assert ~np.isnan(fleiss_kappa(single_class_annos))
+
+    single_annotator_annos = np.random.randint(0, 2, size=(10, 1))
+    assert ~np.isnan(fleiss_kappa(single_annotator_annos))
+
 
 def test_krippendorff():
     annotations = np.asarray([[0, 0, 0], [0, 1, 1]])


### PR DESCRIPTION
## Description

This PR fixes the value range for `fleiss_kappa`, `cohens_kappa` and `percentage` to stay within, even in edge cases.  

## Summary of changes

- Measures do not return `np.nan` anymore, when all annotations have the same label or annotation data contains only a single annotator. Instead 1.0 is returned and a warning is raised. This is done to ensure measures will be more robust to degenerate cases yet still inform the users about potential problems in their data. This also helps with bootstrapping, as the confidence intervals cannot be `nan` anymore.
- Extended tests to ensure value range.

## How test the changes

pytest PYTHON_SDK_DIR/test/agreement

## Related issues

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
