### PR TITLE
[Job Launcher] Verify sender of crypto payment

### DIFF
--- a/packages/apps/job-launcher/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/signature.auth.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   CanActivate,
   ExecutionContext,
   Injectable,
@@ -18,18 +17,16 @@ export class SignatureAuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
 
     const data = request.body;
-    const signature = request.headers[HEADER_SIGNATURE_KEY]; 
+    const signature = request.headers[HEADER_SIGNATURE_KEY];
     const oracleAdresses = [
       this.configService.get<string>(
         ConfigNames.FORTUNE_EXCHANGE_ORACLE_ADDRESS,
       )!,
-      this.configService.get<string>(
-        ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS,
-      )!
-    ]
-    
+      this.configService.get<string>(ConfigNames.CVAT_EXCHANGE_ORACLE_ADDRESS)!,
+    ];
+
     try {
-      const isVerified = verifySignature(data, signature, oracleAdresses)
+      const isVerified = verifySignature(data, signature, oracleAdresses);
 
       if (isVerified) {
         return true;

--- a/packages/apps/job-launcher/server/src/common/utils/signature.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/signature.ts
@@ -9,7 +9,9 @@ export function verifySignature(
 ): boolean {
   const signer = recoverSigner(message, signature);
 
-  if (!addresses.some(address => address.toLowerCase() === signer.toLowerCase())) {
+  if (
+    !addresses.some((address) => address.toLowerCase() === signer.toLowerCase())
+  ) {
     throw new ConflictException(ErrorSignature.SignatureNotVerified);
   }
 

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
@@ -51,7 +51,6 @@ export class PaymentController {
     @Request() req: RequestWithUser,
     @Body() data: PaymentCryptoCreateDto,
   ): Promise<boolean> {
-    console.log(JSON.stringify(data));
     return this.paymentService.createCryptoPayment(
       req.user.id,
       data,

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.controller.ts
@@ -6,6 +6,7 @@ import {
   Query,
   Request,
   UseGuards,
+  Headers,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../common/guards';
@@ -19,6 +20,7 @@ import {
 } from './payment.dto';
 import { PaymentService } from './payment.service';
 import { getRate } from '../../common/utils';
+import { HEADER_SIGNATURE_KEY } from 'src/common/constants';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -45,10 +47,16 @@ export class PaymentController {
 
   @Post('/crypto')
   public async createCryptoPayment(
-    @Request() req: any,
+    @Headers(HEADER_SIGNATURE_KEY) signature: string,
+    @Request() req: RequestWithUser,
     @Body() data: PaymentCryptoCreateDto,
   ): Promise<boolean> {
-    return this.paymentService.createCryptoPayment(req.user.id, data);
+    console.log(JSON.stringify(data));
+    return this.paymentService.createCryptoPayment(
+      req.user.id,
+      data,
+      signature,
+    );
   }
 
   @Get('/rates')

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
@@ -6,7 +6,7 @@ import { PaymentRepository } from './payment.repository';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
 import { createMock } from '@golevelup/ts-jest';
-import { ErrorPayment } from '../../common/constants/errors';
+import { ErrorPayment, ErrorSignature } from '../../common/constants/errors';
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
 import {
   Currency,
@@ -20,17 +20,24 @@ import { TX_CONFIRMATION_TRESHOLD } from '../../common/constants';
 import {
   MOCK_ADDRESS,
   MOCK_PAYMENT_ID,
+  MOCK_SIGNATURE,
   MOCK_TRANSACTION_HASH,
 } from '../../../test/constants';
 import { Web3Service } from '../web3/web3.service';
 import { HMToken__factory } from '@human-protocol/core/typechain-types';
 import { ChainId, NETWORKS } from '@human-protocol/sdk';
 import { PaymentEntity } from './payment.entity';
+import { verifySignature } from '../../common/utils/signature';
+import { ConflictException } from '@nestjs/common';
 
 jest.mock('@human-protocol/sdk');
 
 jest.mock('../../common/utils', () => ({
   getRate: jest.fn().mockImplementation(() => 1.5),
+}));
+
+jest.mock('../../common/utils/signature', () => ({
+  verifySignature: jest.fn().mockReturnValue(true),
 }));
 
 describe('PaymentService', () => {
@@ -320,6 +327,7 @@ describe('PaymentService', () => {
 
     afterEach(() => {
       jest.restoreAllMocks();
+      (verifySignature as jest.Mock).mockRestore();
     });
 
     it('should create a crypto payment successfully', async () => {
@@ -332,6 +340,7 @@ describe('PaymentService', () => {
       const token = 'hmt';
 
       const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
         logs: [
           {
             data: ethers.utils.parseUnits('10').toString(),
@@ -357,7 +366,11 @@ describe('PaymentService', () => {
       findOneMock.mockResolvedValue(null);
       createPaymentMock.mockResolvedValue(true);
 
-      const result = await paymentService.createCryptoPayment(userId, dto);
+      const result = await paymentService.createCryptoPayment(
+        userId,
+        dto,
+        MOCK_SIGNATURE,
+      );
 
       expect(paymentRepository.findOne).toHaveBeenCalledWith({
         transaction: dto.transactionHash,
@@ -387,6 +400,7 @@ describe('PaymentService', () => {
       const token = 'hmt';
 
       const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
         logs: [
           {
             data: ethers.utils.parseUnits('10').toString(),
@@ -411,7 +425,7 @@ describe('PaymentService', () => {
       mockTokenContract.symbol.mockResolvedValue(token);
 
       await expect(
-        paymentService.createCryptoPayment(userId, dto),
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
       ).rejects.toThrowError(ErrorPayment.UnsupportedToken);
     });
 
@@ -425,6 +439,7 @@ describe('PaymentService', () => {
       const unsupportedToken = 'doge';
 
       const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
         logs: [
           {
             data: ethers.utils.parseUnits('10').toString(),
@@ -449,8 +464,33 @@ describe('PaymentService', () => {
       mockTokenContract.symbol.mockResolvedValue(unsupportedToken);
 
       await expect(
-        paymentService.createCryptoPayment(userId, dto),
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
       ).rejects.toThrowError(ErrorPayment.UnsupportedToken);
+    });
+
+    it('should throw a signature error if the signature is wrong', async () => {
+      const userId = 1;
+      const dto = {
+        chainId: ChainId.POLYGON_MUMBAI,
+        transactionHash: MOCK_TRANSACTION_HASH,
+      };
+      (verifySignature as jest.Mock).mockImplementation(() => {
+        throw new ConflictException(ErrorSignature.SignatureNotVerified);
+      });
+
+      const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
+        logs: [],
+        confirmations: TX_CONFIRMATION_TRESHOLD,
+      };
+
+      jsonRpcProviderMock.getTransactionReceipt.mockResolvedValue(
+        transactionReceipt,
+      );
+
+      await expect(
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
+      ).rejects.toThrowError(ErrorSignature.SignatureNotVerified);
     });
 
     it('should throw a not found exception if the transaction is not found by hash', async () => {
@@ -463,7 +503,7 @@ describe('PaymentService', () => {
       jsonRpcProviderMock.getTransactionReceipt.mockResolvedValue(null);
 
       await expect(
-        paymentService.createCryptoPayment(userId, dto),
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
       ).rejects.toThrowError(ErrorPayment.TransactionNotFoundByHash);
     });
 
@@ -475,6 +515,7 @@ describe('PaymentService', () => {
       };
 
       const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
         logs: [],
         confirmations: TX_CONFIRMATION_TRESHOLD,
       };
@@ -484,7 +525,7 @@ describe('PaymentService', () => {
       );
 
       await expect(
-        paymentService.createCryptoPayment(userId, dto),
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
       ).rejects.toThrowError(ErrorPayment.InvalidTransactionData);
     });
 
@@ -496,6 +537,7 @@ describe('PaymentService', () => {
       };
 
       const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
         logs: [
           {
             data: ethers.utils.parseUnits('10').toString(),
@@ -518,7 +560,7 @@ describe('PaymentService', () => {
       );
 
       await expect(
-        paymentService.createCryptoPayment(userId, dto),
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
       ).rejects.toThrowError(
         ErrorPayment.TransactionHasNotEnoughAmountOfConfirmations,
       );
@@ -534,6 +576,7 @@ describe('PaymentService', () => {
       const token = 'hmt';
 
       const transactionReceipt: Partial<TransactionReceipt> = {
+        from: MOCK_ADDRESS,
         logs: [
           {
             data: ethers.utils.parseUnits('10').toString(),
@@ -560,7 +603,7 @@ describe('PaymentService', () => {
       findOneMock.mockResolvedValue({} as any);
 
       await expect(
-        paymentService.createCryptoPayment(userId, dto),
+        paymentService.createCryptoPayment(userId, dto, MOCK_SIGNATURE),
       ).rejects.toThrowError(ErrorPayment.TransactionAlreadyExists);
     });
   });

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
@@ -32,6 +32,7 @@ import { Web3Service } from '../web3/web3.service';
 import { CoingeckoTokenId } from '../../common/constants/payment';
 import { getRate } from '../../common/utils';
 import { add, div, mul } from '../../common/utils/decimal';
+import { verifySignature } from '../../common/utils/signature';
 
 @Injectable()
 export class PaymentService {
@@ -160,6 +161,7 @@ export class PaymentService {
   public async createCryptoPayment(
     userId: number,
     dto: PaymentCryptoCreateDto,
+    signature: string,
   ): Promise<boolean> {
     this.web3Service.validateChainId(dto.chainId);
     const network = Object.values(networkMap).find(
@@ -175,6 +177,8 @@ export class PaymentService {
       this.logger.error(ErrorPayment.TransactionNotFoundByHash);
       throw new NotFoundException(ErrorPayment.TransactionNotFoundByHash);
     }
+
+    verifySignature(dto, signature, [transaction.from]);
 
     if (!transaction.logs[0] || !transaction.logs[0].data) {
       this.logger.error(ErrorPayment.InvalidTransactionData);

--- a/packages/apps/job-launcher/server/test/constants.ts
+++ b/packages/apps/job-launcher/server/test/constants.ts
@@ -30,6 +30,8 @@ export const MOCK_RECORDING_ORACLE_FEE = 5;
 export const MOCK_REPUTATION_ORACLE_FEE = 5;
 export const MOCK_TRANSACTION_HASH =
   '0xd28e4c40571530afcb25ea1890e77b2d18c35f06049980ca4fb71829f64d89dc';
+export const MOCK_SIGNATURE =
+  '0x1502ec7e795ed9c96b215e80d46d87e26141bc8d41f69ee1bfbc8d8ed9a700db62136da8ee35eadbfd678817342444dff0239508be51c1fae55d62fcdba2867e1b';
 export const MOCK_EMAIL = 'test@example.com';
 export const MOCK_PASSWORD = 'password123';
 export const MOCK_HASHED_PASSWORD = 'hashedPassword';


### PR DESCRIPTION
## Description

Add a signature to `payment/crypto` payload and verify that the message has been signed by the same address that sent the transaction hash

## Summary of changes

Add the signature to the `createCryptoPayment` method
Update tests

## How test the changes

`yarn test`

## Related issues
Close #953

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
