### PR TITLE
add signature header for crypto payment

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
@@ -92,7 +92,7 @@ export const CryptoPayForm = ({
           await tx.wait();
 
           // create crypto payment record
-          await paymentService.createCryptoPayment({
+          await paymentService.createCryptoPayment(signer, {
             chainId: jobRequest.chainId,
             transactionHash: tx.hash,
           });

--- a/packages/apps/job-launcher/client/src/components/TopUpAccount/CryptoTopUpForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/TopUpAccount/CryptoTopUpForm.tsx
@@ -60,7 +60,7 @@ export const CryptoTopUpForm = () => {
       const transactionHash = tx.hash;
 
       // create crypto payment record
-      await paymentService.createCryptoPayment({
+      await paymentService.createCryptoPayment(signer, {
         chainId: chain?.id,
         transactionHash,
       });
@@ -68,7 +68,7 @@ export const CryptoTopUpForm = () => {
       dispatch(fetchUserBalanceAsync());
 
       setIsSuccess(true);
-    } catch (err: any) {
+    } catch (err) {
       setErrorMessage(err?.response?.data?.message ?? err?.message);
       setIsSuccess(false);
     }

--- a/packages/apps/job-launcher/client/src/constants/payment.ts
+++ b/packages/apps/job-launcher/client/src/constants/payment.ts
@@ -1,1 +1,3 @@
 export const JOB_LAUNCHER_FEE = 1; // 1%
+
+export const PAYMENT_SIGNATURE_KEY = 'human-signature';

--- a/packages/apps/job-launcher/client/src/services/payment.ts
+++ b/packages/apps/job-launcher/client/src/services/payment.ts
@@ -1,8 +1,16 @@
+import { Signer } from 'ethers';
+import { PAYMENT_SIGNATURE_KEY } from '../constants/payment';
 import { CryptoPaymentRequest, FiatPaymentRequest } from '../types';
 import api from '../utils/api';
 
-export const createCryptoPayment = async (body: CryptoPaymentRequest) => {
-  await api.post('/payment/crypto', body);
+export const createCryptoPayment = async (
+  signer: Signer,
+  body: CryptoPaymentRequest
+) => {
+  const signature = await signer.signMessage(JSON.stringify(body));
+  await api.post('/payment/crypto', body, {
+    headers: { [PAYMENT_SIGNATURE_KEY]: signature },
+  });
 };
 
 export const createFiatPayment = async (body: FiatPaymentRequest) => {


### PR DESCRIPTION
## Description

This will close #1018 , added the signature to request header so that we can verify on back-end

## Summary of changes

- generated the signature using `signMessage`
- added that signature to the request header when POST `/payment/crypto`
