### PR TITLE
Add signature to all webhook calls sent and received in Recording Oracle

### DIFF
--- a/packages/apps/fortune/recording-oracle/src/common/constants/index.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/constants/index.ts
@@ -1,1 +1,2 @@
 export const EXCHANGE_INVALID_ENDPOINT = '/invalid-solution';
+export const HEADER_SIGNATURE_KEY = 'human-signature';

--- a/packages/apps/fortune/recording-oracle/src/common/enums/role.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/enums/role.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  Exchange = 'exchange',
+  Reputation = 'reputation',
+}

--- a/packages/apps/fortune/recording-oracle/src/common/guards/index.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './signature.auth';

--- a/packages/apps/fortune/recording-oracle/src/common/guards/signature.auth.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/guards/signature.auth.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { SignatureAuthGuard } from './signature.auth';
+import { verifySignature } from '../utils/signature';
+import { ChainId, EscrowUtils } from '@human-protocol/sdk';
+import { MOCK_ADDRESS } from '../../../test/constants';
+import { Role } from '../enums/role';
+
+jest.mock('../../common/utils/signature');
+
+jest.mock('@human-protocol/sdk', () => ({
+  ...jest.requireActual('@human-protocol/sdk'),
+  EscrowUtils: {
+    getEscrow: jest.fn().mockResolvedValue({
+      exchangeOracle: '0x1234567890123456789012345678901234567891',
+      reputationOracle: '0x1234567890123456789012345678901234567892',
+    }),
+  },
+}));
+
+describe('SignatureAuthGuard', () => {
+  let guard: SignatureAuthGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: SignatureAuthGuard,
+          useValue: new SignatureAuthGuard([Role.Exchange, Role.Reputation]),
+        },
+      ],
+    }).compile();
+
+    guard = module.get<SignatureAuthGuard>(SignatureAuthGuard);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    let context: ExecutionContext;
+    let mockRequest: any;
+
+    beforeEach(() => {
+      mockRequest = {
+        switchToHttp: jest.fn().mockReturnThis(),
+        getRequest: jest.fn().mockReturnThis(),
+        headers: {},
+        body: {},
+        originalUrl: '',
+      };
+      context = {
+        switchToHttp: jest.fn().mockReturnThis(),
+        getRequest: jest.fn(() => mockRequest),
+      } as any as ExecutionContext;
+    });
+
+    it('should return true if signature is verified', async () => {
+      mockRequest.headers['header-signature-key'] = 'validSignature';
+      mockRequest.body = {
+        escrowAddress: MOCK_ADDRESS,
+        chainId: ChainId.LOCALHOST,
+      };
+      (verifySignature as jest.Mock).mockReturnValue(true);
+
+      const result = await guard.canActivate(context as any);
+      expect(result).toBeTruthy();
+      expect(EscrowUtils.getEscrow).toHaveBeenCalledWith(
+        ChainId.LOCALHOST,
+        MOCK_ADDRESS,
+      );
+    });
+
+    it('should throw unauthorized exception if signature is not verified', async () => {
+      (verifySignature as jest.Mock).mockReturnValue(false);
+
+      await expect(guard.canActivate(context as any)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw unauthorized exception for unrecognized oracle type', async () => {
+      mockRequest.originalUrl = '/some/random/path';
+      await expect(guard.canActivate(context as any)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+});

--- a/packages/apps/fortune/recording-oracle/src/common/guards/signature.auth.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/guards/signature.auth.ts
@@ -1,0 +1,43 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { verifySignature } from '../utils/signature';
+import { HEADER_SIGNATURE_KEY } from '../constants';
+import { EscrowUtils } from '@human-protocol/sdk';
+import { Role } from '../enums/role';
+
+@Injectable()
+export class SignatureAuthGuard implements CanActivate {
+  constructor(private role: Role[]) {}
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const data = request.body;
+    const signature = request.headers[HEADER_SIGNATURE_KEY];
+    const oracleAdresses: string[] = [];
+    try {
+      const escrowData = await EscrowUtils.getEscrow(
+        data.chainId,
+        data.escrowAddress,
+      );
+      if (this.role.includes(Role.Exchange))
+        oracleAdresses.push(escrowData.exchangeOracle!);
+      if (this.role.includes(Role.Reputation))
+        oracleAdresses.push(escrowData.reputationOracle!);
+
+      const isVerified = verifySignature(data, signature, oracleAdresses);
+
+      if (isVerified) {
+        return true;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+
+    throw new UnauthorizedException('Unauthorized');
+  }
+}

--- a/packages/apps/fortune/recording-oracle/src/common/utils/signature.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/signature.spec.ts
@@ -1,0 +1,115 @@
+import { verifySignature, recoverSigner, signMessage } from './signature';
+import { MOCK_ADDRESS, MOCK_WEB3_PRIVATE_KEY } from '../../../test/constants';
+
+jest.doMock('ethers', () => {
+  return {
+    utils: {
+      get verifyMessage() {
+        return jest.fn((message, signature) => {
+          if (message === 'valid-message' && signature === 'valid-signature') {
+            return 'recovered-address';
+          } else {
+            throw new Error('Invalid signature');
+          }
+        });
+      },
+    },
+  };
+});
+
+describe('Signature utility', () => {
+  describe('verifySignature', () => {
+    it('should return true for valid signature', async () => {
+      const message = 'Hello, this is a signed message!';
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      const result = verifySignature(message, signature, [MOCK_ADDRESS]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should throw conflict exception for signature not verified', async () => {
+      const message = 'Hello, this is a signed message!';
+
+      const invalidSignature = await signMessage(
+        message,
+        MOCK_WEB3_PRIVATE_KEY,
+      );
+      const invalidAddress = '0x1234567890123456789012345678901234567892';
+
+      expect(() => {
+        verifySignature(message, invalidSignature, [invalidAddress]);
+      }).toThrow('Signature not verified');
+    });
+
+    it('should throw conflict exception for invalid signature', () => {
+      const message = 'Hello, this is a signed message!';
+      const invalidSignature = '0xInvalidSignature';
+
+      expect(() => {
+        verifySignature(message, invalidSignature, [MOCK_ADDRESS]);
+      }).toThrow('Invalid signature');
+    });
+  });
+
+  describe('recoverSigner', () => {
+    it('should recover the correct signer', async () => {
+      const message = 'value';
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      const result = recoverSigner(message, signature);
+
+      expect(result).toBe(MOCK_ADDRESS);
+    });
+
+    it('should throw conflict exception for invalid signature', () => {
+      const message = 'Hello, this is a signed message!';
+      const invalidSignature = '0xInvalidSignature';
+
+      expect(() => {
+        recoverSigner(message, invalidSignature);
+      }).toThrow('Invalid signature');
+    });
+
+    it('should stringify message object if it is not already a string', async () => {
+      const message = { key: 'value' };
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      const recoveredAddress = recoverSigner(message, signature);
+
+      expect(recoveredAddress).toBe(MOCK_ADDRESS);
+    });
+
+    it('should not stringify message if it is already a string', async () => {
+      const message = 'valid message';
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      const recoveredAddress = recoverSigner(message, signature);
+
+      expect(recoveredAddress).toBe(MOCK_ADDRESS);
+    });
+  });
+
+  describe('signMessage', () => {
+    it('should return a valid signature', async () => {
+      const message = 'Hello, this is a test message';
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      expect(signature).toBeDefined();
+    });
+
+    it('should stringify message object if it is not already a string', async () => {
+      const message = { key: 'value' };
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      expect(signature).toBeDefined();
+    });
+
+    it('should not stringify message if it is already a string', async () => {
+      const message = 'valid message';
+      const signature = await signMessage(message, MOCK_WEB3_PRIVATE_KEY);
+
+      expect(signature).toBeDefined();
+    });
+  });
+});

--- a/packages/apps/fortune/recording-oracle/src/common/utils/signature.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/signature.ts
@@ -1,0 +1,47 @@
+import { ConflictException } from '@nestjs/common';
+import { ethers } from 'ethers';
+
+export function verifySignature(
+  message: object | string,
+  signature: string,
+  addresses: string[],
+): boolean {
+  const signer = recoverSigner(message, signature);
+
+  if (
+    !addresses.some((address) => address.toLowerCase() === signer.toLowerCase())
+  ) {
+    throw new ConflictException('Signature not verified');
+  }
+
+  return true;
+}
+
+export async function signMessage(
+  message: object | string,
+  privateKey: string,
+): Promise<string> {
+  if (typeof message !== 'string') {
+    message = JSON.stringify(message);
+  }
+
+  const wallet = new ethers.Wallet(privateKey);
+  const signature = await wallet.signMessage(message);
+
+  return signature;
+}
+
+export function recoverSigner(
+  message: object | string,
+  signature: string,
+): string {
+  if (typeof message !== 'string') {
+    message = JSON.stringify(message);
+  }
+
+  try {
+    return ethers.utils.verifyMessage(message, signature);
+  } catch (e) {
+    throw new ConflictException('Invalid signature');
+  }
+}

--- a/packages/apps/fortune/recording-oracle/src/common/utils/webhook.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/webhook.ts
@@ -2,15 +2,21 @@ import { Logger, NotFoundException } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import { ErrorJob } from '../constants/errors';
+import { signMessage } from './signature';
+import { HEADER_SIGNATURE_KEY } from '../constants';
 
 export async function sendWebhook(
   httpService: HttpService,
   logger: Logger,
   webhookUrl: string,
   webhookData: any,
+  privateKey: string,
 ): Promise<boolean> {
+  const signedBody = await signMessage(webhookData, privateKey);
   const { data } = await firstValueFrom(
-    await httpService.post(webhookUrl, webhookData),
+    await httpService.post(webhookUrl, webhookData, {
+      headers: { [HEADER_SIGNATURE_KEY]: signedBody },
+    }),
   );
 
   if (!data) {

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.controller.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.controller.spec.ts
@@ -14,6 +14,7 @@ import {
   MOCK_S3_PORT,
   MOCK_S3_SECRET_KEY,
   MOCK_S3_USE_SSL,
+  MOCK_WEB3_PRIVATE_KEY,
 } from '../../../test/constants';
 import { Web3Service } from '../web3/web3.service';
 import { JobController } from './job.controller';
@@ -50,6 +51,11 @@ describe('JobController', () => {
             port: MOCK_S3_PORT,
             useSSL: MOCK_S3_USE_SSL,
             bucket: MOCK_S3_BUCKET,
+          })),
+        ),
+        ConfigModule.forFeature(
+          registerAs('web3', () => ({
+            web3PrivateKey: MOCK_WEB3_PRIVATE_KEY,
           })),
         ),
         ConfigModule.forFeature(

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.controller.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.controller.ts
@@ -1,16 +1,17 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
-import { Public } from '@/common/decorators';
 import { JobSolutionsRequestDto } from './job.dto';
 import { JobService } from './job.service';
+import { SignatureAuthGuard } from '../../common/guards';
+import { Role } from '../../common/enums/role';
 
 @Controller('/job')
 @ApiTags('Job')
 export class JobController {
   constructor(private readonly jobService: JobService) {}
 
-  @Public()
+  @UseGuards(new SignatureAuthGuard([Role.Exchange]))
   @Post('/solve')
   public async solve(@Body() fortune: JobSolutionsRequestDto): Promise<string> {
     return await this.jobService.processJobSolution(fortune);

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.module.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.module.ts
@@ -4,12 +4,13 @@ import { ConfigModule } from '@nestjs/config';
 import { JobController } from './job.controller';
 import { JobService } from './job.service';
 import { Web3Module } from '../web3/web3.module';
-import { serverConfig } from '../../common/config';
+import { serverConfig, web3Config } from '../../common/config';
 import { StorageModule } from '../storage/storage.module';
 
 @Module({
   imports: [
     ConfigModule.forFeature(serverConfig),
+    ConfigModule.forFeature(web3Config),
     HttpModule,
     Web3Module,
     StorageModule,

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
@@ -9,7 +9,12 @@ import {
 import { ethers } from 'ethers';
 import * as Minio from 'minio';
 
-import { ServerConfigType, serverConfigKey } from '../../common/config';
+import {
+  ServerConfigType,
+  Web3ConfigType,
+  serverConfigKey,
+  web3ConfigKey,
+} from '../../common/config';
 import { ErrorJob } from '../../common/constants/errors';
 import { JobRequestType } from '../../common/enums/job';
 import {
@@ -32,6 +37,8 @@ export class JobService {
   constructor(
     @Inject(serverConfigKey)
     private serverConfig: ServerConfigType,
+    @Inject(web3ConfigKey)
+    private web3Config: Web3ConfigType,
     @Inject(Web3Service)
     private readonly web3Service: Web3Service,
     @Inject(StorageService)
@@ -189,6 +196,7 @@ export class JobService {
           chainId: jobSolution.chainId,
           escrowAddress: jobSolution.escrowAddress,
         },
+        this.web3Config.web3PrivateKey,
       );
 
       return 'The requested job is completed.';
@@ -208,6 +216,7 @@ export class JobService {
             escrowAddress: jobSolution.escrowAddress,
             workerAddress: solution.workerAddress,
           },
+          this.web3Config.web3PrivateKey,
         );
       }
     }

--- a/packages/apps/fortune/recording-oracle/test/constants.ts
+++ b/packages/apps/fortune/recording-oracle/test/constants.ts
@@ -7,7 +7,7 @@ export const MOCK_WEB3_PRIVATE_KEY =
   '5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 export const MOCK_REQUESTER_TITLE = 'Mock job title';
 export const MOCK_REQUESTER_DESCRIPTION = 'Mock job description';
-export const MOCK_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const MOCK_ADDRESS = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC';
 export const MOCK_FILE_URL = 'mockedFileUrl';
 export const MOCK_FILE_HASH = 'mockedFileHash';
 export const MOCK_FILE_KEY = 'manifest.json';

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -111,7 +111,7 @@ export class JobController {
   @Public()
   @UseGuards(SignatureAuthGuard)
   @Post('/escrow-failed-webhook')
-  public async (
+  public async(
     @Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() data: EscrowFailedWebhookDto,
   ): Promise<any> {


### PR DESCRIPTION
## Description

Add signature to all webhook calls sent and received in Exchange Oracle

## Summary of changes

- Add signature utils
- Add signature guard
- Add signature verification to all webhook endpoints
- Add signature to all webhook calls
- Update unit tests


## How test the changes
`yarn test`

## Related issues
Close #1029 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
