### PR TITLE
[Fortune] [Exchange Oracle] fix: use StakingClient getLeader to get webhook url for oracles

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.spec.ts
@@ -6,9 +6,9 @@ import { Web3Service } from '../web3/web3.service';
 import { JobService } from './job.service';
 import {
   EscrowClient,
-  KVStoreClient,
   StorageClient,
   EscrowUtils,
+  StakingClient,
 } from '@human-protocol/sdk';
 import {
   MOCK_PRIVATE_KEY,
@@ -33,7 +33,7 @@ jest.mock('@human-protocol/sdk', () => ({
   EscrowClient: {
     build: jest.fn(),
   },
-  KVStoreClient: {
+  StakingClient: {
     build: jest.fn(),
   },
   StorageClient: {
@@ -160,8 +160,10 @@ describe('JobService', () => {
           .fn()
           .mockResolvedValue('0x1234567890123456789012345678901234567893'),
       }));
-      (KVStoreClient.build as any).mockImplementation(() => ({
-        get: jest.fn().mockResolvedValue(jobLauncherWebhookUrl),
+      (StakingClient.build as any).mockImplementation(() => ({
+        getLeader: jest.fn().mockResolvedValue({
+          webhookUrl: jobLauncherWebhookUrl,
+        }),
       }));
 
       httpService.axiosRef.get = jest.fn().mockResolvedValue({
@@ -263,8 +265,10 @@ describe('JobService', () => {
           .fn()
           .mockResolvedValue('0x1234567890123456789012345678901234567893'),
       }));
-      (KVStoreClient.build as any).mockImplementation(() => ({
-        get: jest.fn().mockResolvedValue(recordingOracleURLMock),
+      (StakingClient.build as any).mockImplementation(() => ({
+        getLeader: jest.fn().mockResolvedValue({
+          webhookUrl: recordingOracleURLMock,
+        }),
       }));
 
       StorageClient.downloadFileFromUrl = jest.fn().mockResolvedValue([]);
@@ -318,8 +322,10 @@ describe('JobService', () => {
           .fn()
           .mockResolvedValue('0x1234567890123456789012345678901234567893'),
       }));
-      (KVStoreClient.build as any).mockImplementation(() => ({
-        get: jest.fn().mockResolvedValue(''),
+      (StakingClient.build as any).mockImplementation(() => ({
+        getLeader: jest.fn().mockResolvedValue({
+          webhookUrl: '',
+        }),
       }));
 
       await expect(
@@ -336,8 +342,10 @@ describe('JobService', () => {
           .fn()
           .mockResolvedValue('0x1234567890123456789012345678901234567893'),
       }));
-      (KVStoreClient.build as any).mockImplementation(() => ({
-        get: jest.fn().mockResolvedValue('https://example.com/recordingoracle'),
+      (StakingClient.build as any).mockImplementation(() => ({
+        getLeader: jest.fn().mockResolvedValue({
+          webhookUrl: 'https://example.com/recordingoracle',
+        }),
       }));
 
       StorageClient.downloadFileFromUrl = jest.fn().mockResolvedValue([


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
We don't necessarily need to make a contract call to get webhook url from KVStore.
We have StakingClient that provides getLeader function, which returns all the data of the oracles.
We need to use this function to get Webhook URL of job launcher & recording oracle.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Removed KVStore contract call.
- Used `getLeader` function of  `StakingClient` for webhook URL.
- Updated relevant tests.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #1031 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
