### PR TITLE
[Recording Oracle] Include invalid solutions in intermediate results

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/interfaces/job.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/interfaces/job.ts
@@ -1,10 +1,5 @@
 export interface ISolution {
   workerAddress: string;
   solution: string;
-  invalid?: boolean;
-}
-
-export interface ISolutionsFile {
-  exchangeAddress: string;
-  solutions: ISolution[];
+  error?: boolean;
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.spec.ts
@@ -437,7 +437,6 @@ describe('JobService', () => {
 
   describe('processInvalidJob', () => {
     it('should mark a job solution as invalid', async () => {
-      const exchangeAddress = '0x1234567890123456789012345678901234567892';
       const workerAddress = '0x1234567890123456789012345678901234567891';
       const solution = 'test';
 
@@ -458,16 +457,13 @@ describe('JobService', () => {
       expect(storageService.minioClient.putObject).toHaveBeenCalledWith(
         MOCK_S3_BUCKET,
         `${escrowAddress}-${chainId}.json`,
-        JSON.stringify({
-          exchangeAddress,
-          solutions: [
-            {
-              workerAddress,
-              solution,
-              invalid: true,
-            },
-          ],
-        }),
+        JSON.stringify([
+          {
+            workerAddress,
+            solution,
+            error: true,
+          },
+        ]),
 
         {
           'Content-Type': 'application/json',

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -60,7 +60,7 @@ export class JobService {
     );
 
     if (
-      existingJobSolutions.filter((solution) => !solution.invalid).length >=
+      existingJobSolutions.filter((solution) => !solution.error).length >=
       manifest.submissionsRequired
     ) {
       throw new BadRequestException('This job has already been completed');
@@ -116,7 +116,6 @@ export class JobService {
       chainId,
       escrowAddress,
       workerAddress,
-      signer.address,
       solution,
     );
 
@@ -140,7 +139,7 @@ export class JobService {
     );
 
     if (foundSolution) {
-      foundSolution.invalid = true;
+      foundSolution.error = true;
     } else {
       throw new BadRequestException(
         `Solution not found in Escrow: ${invalidJobSolution.escrowAddress}`,
@@ -148,7 +147,6 @@ export class JobService {
     }
 
     await this.storageService.uploadJobSolutions(
-      this.web3Service.getSigner(invalidJobSolution.chainId).address,
       invalidJobSolution.escrowAddress,
       invalidJobSolution.chainId,
       existingJobSolutions,
@@ -159,7 +157,6 @@ export class JobService {
     chainId: ChainId,
     escrowAddress: string,
     workerAddress: string,
-    exchangeAddress: string,
     solution: string,
   ): Promise<string> {
     const existingJobSolutions = await this.storageService.downloadJobSolutions(
@@ -177,7 +174,7 @@ export class JobService {
 
     const manifest = await this.getManifest(chainId, escrowAddress);
     if (
-      existingJobSolutions.filter((solution) => !solution.invalid).length >=
+      existingJobSolutions.filter((solution) => !solution.error).length >=
       manifest.submissionsRequired
     ) {
       throw new BadRequestException('This job has already been completed');
@@ -192,7 +189,6 @@ export class JobService {
     ];
 
     const url = await this.storageService.uploadJobSolutions(
-      exchangeAddress,
       escrowAddress,
       chainId,
       newJobSolutions,

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/storage/storage.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/storage/storage.service.spec.ts
@@ -57,7 +57,6 @@ describe('Web3Service', () => {
 
   describe('uploadJobSolutions', () => {
     it('should upload the solutions correctly', async () => {
-      const exchangeAddress = '0x1234567890123456789012345678901234567892';
       const workerAddress = '0x1234567890123456789012345678901234567891';
       const escrowAddress = '0x1234567890123456789012345678901234567890';
       const chainId = ChainId.LOCALHOST;
@@ -72,7 +71,6 @@ describe('Web3Service', () => {
         solution,
       };
       const fileUrl = await storageService.uploadJobSolutions(
-        exchangeAddress,
         escrowAddress,
         chainId,
         [jobSolution],
@@ -83,15 +81,12 @@ describe('Web3Service', () => {
       expect(storageService.minioClient.putObject).toHaveBeenCalledWith(
         MOCK_S3_BUCKET,
         `${escrowAddress}-${chainId}.json`,
-        JSON.stringify({
-          exchangeAddress,
-          solutions: [
-            {
-              workerAddress,
-              solution,
-            },
-          ],
-        }),
+        JSON.stringify([
+          {
+            workerAddress,
+            solution,
+          },
+        ]),
 
         {
           'Content-Type': 'application/json',
@@ -100,7 +95,6 @@ describe('Web3Service', () => {
     });
 
     it('should fail if the bucket does not exist', async () => {
-      const exchangeAddress = '0x1234567890123456789012345678901234567892';
       const workerAddress = '0x1234567890123456789012345678901234567891';
       const escrowAddress = '0x1234567890123456789012345678901234567890';
       const chainId = ChainId.LOCALHOST;
@@ -115,16 +109,12 @@ describe('Web3Service', () => {
         solution,
       };
       await expect(
-        storageService.uploadJobSolutions(
-          exchangeAddress,
-          escrowAddress,
-          chainId,
-          [jobSolution],
-        ),
+        storageService.uploadJobSolutions(escrowAddress, chainId, [
+          jobSolution,
+        ]),
       ).rejects.toThrow('Bucket not found');
     });
     it('should fail if the file cannot be uploaded', async () => {
-      const exchangeAddress = '0x1234567890123456789012345678901234567892';
       const workerAddress = '0x1234567890123456789012345678901234567891';
       const escrowAddress = '0x1234567890123456789012345678901234567890';
       const chainId = ChainId.LOCALHOST;
@@ -143,33 +133,26 @@ describe('Web3Service', () => {
       };
 
       await expect(
-        storageService.uploadJobSolutions(
-          exchangeAddress,
-          escrowAddress,
-          chainId,
-          [jobSolution],
-        ),
+        storageService.uploadJobSolutions(escrowAddress, chainId, [
+          jobSolution,
+        ]),
       ).rejects.toThrow('File not uploaded');
     });
   });
 
   describe('downloadJobSolutions', () => {
     it('should download the file correctly', async () => {
-      const exchangeAddress = '0x1234567890123456789012345678901234567892';
       const workerAddress = '0x1234567890123456789012345678901234567891';
       const escrowAddress = '0x1234567890123456789012345678901234567890';
       const chainId = ChainId.LOCALHOST;
       const solution = 'test';
 
-      const expectedJobFile = {
-        exchangeAddress,
-        solutions: [
-          {
-            workerAddress,
-            solution,
-          },
-        ],
-      };
+      const expectedJobFile = [
+        {
+          workerAddress,
+          solution,
+        },
+      ];
 
       StorageClient.downloadFileFromUrl = jest
         .fn()

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/storage/storage.service.ts
@@ -2,7 +2,7 @@ import { ChainId, StorageClient } from '@human-protocol/sdk';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import * as Minio from 'minio';
 import { S3ConfigType, s3ConfigKey } from '../../common/config';
-import { ISolution, ISolutionsFile } from '../../common/interfaces/job';
+import { ISolution } from '../../common/interfaces/job';
 
 @Injectable()
 export class StorageService {
@@ -41,7 +41,6 @@ export class StorageService {
   }
 
   public async uploadJobSolutions(
-    exchangeAddress: string,
     escrowAddress: string,
     chainId: ChainId,
     solutions: ISolution[],
@@ -50,16 +49,11 @@ export class StorageService {
       throw new BadRequestException('Bucket not found');
     }
 
-    const content: ISolutionsFile = {
-      exchangeAddress,
-      solutions,
-    };
-
     try {
       await this.minioClient.putObject(
         this.s3Config.bucket,
         `${escrowAddress}-${chainId}.json`,
-        JSON.stringify(content),
+        JSON.stringify(solutions),
         {
           'Content-Type': 'application/json',
         },

--- a/packages/apps/fortune/recording-oracle/src/common/enums/job.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/enums/job.ts
@@ -1,3 +1,8 @@
 export enum JobRequestType {
   FORTUNE = 'FORTUNE',
 }
+
+export enum SolutionError {
+  Duplicated = 'Duplicated',
+  CurseWord = 'CurseWord',
+}

--- a/packages/apps/fortune/recording-oracle/src/common/interfaces/job.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/interfaces/job.ts
@@ -1,4 +1,4 @@
-import { JobRequestType } from '../enums/job';
+import { JobRequestType, SolutionError } from '../enums/job';
 
 export interface IManifest {
   submissionsRequired: number;
@@ -11,7 +11,7 @@ export interface IManifest {
 export interface ISolution {
   workerAddress: string;
   solution: string;
-  invalid?: boolean;
+  error?: boolean | SolutionError;
 }
 
 export interface ISolutionsFile {

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.spec.ts
@@ -27,11 +27,7 @@ import {
   MOCK_WEB3_PRIVATE_KEY,
 } from '../../../test/constants';
 import { ConfigModule, registerAs } from '@nestjs/config';
-import {
-  IManifest,
-  ISolution,
-  ISolutionsFile,
-} from '../../common/interfaces/job';
+import { IManifest, ISolution } from '../../common/interfaces/job';
 import { of } from 'rxjs';
 import { JobSolutionsRequestDto } from './job.dto';
 import { StorageService } from '../storage/storage.service';
@@ -267,23 +263,20 @@ describe('JobService', () => {
         },
       ];
 
-      const exchangeJobSolutions: ISolutionsFile = {
-        exchangeAddress: MOCK_ADDRESS,
-        solutions: [
-          {
-            workerAddress: '0x0000000000000000000000000000000000000000',
-            solution: 'Solution 1',
-          },
-          {
-            workerAddress: '0x0000000000000000000000000000000000000001',
-            solution: 'Solution 2',
-          },
-          {
-            workerAddress: '0x0000000000000000000000000000000000000002',
-            solution: 'Solution 3',
-          },
-        ],
-      };
+      const exchangeJobSolutions: ISolution[] = [
+        {
+          workerAddress: '0x0000000000000000000000000000000000000000',
+          solution: 'Solution 1',
+        },
+        {
+          workerAddress: '0x0000000000000000000000000000000000000001',
+          solution: 'Solution 2',
+        },
+        {
+          workerAddress: '0x0000000000000000000000000000000000000002',
+          solution: 'Solution 3',
+        },
+      ];
 
       StorageClient.downloadFileFromUrl = jest
         .fn()
@@ -330,19 +323,16 @@ describe('JobService', () => {
         },
       ];
 
-      const exchangeJobSolutions: ISolutionsFile = {
-        exchangeAddress: MOCK_ADDRESS,
-        solutions: [
-          {
-            workerAddress: '0x0000000000000000000000000000000000000000',
-            solution: 'Solution 1',
-          },
-          {
-            workerAddress: '0x0000000000000000000000000000000000000001',
-            solution: 'Solution 2',
-          },
-        ],
-      };
+      const exchangeJobSolutions: ISolution[] = [
+        {
+          workerAddress: '0x0000000000000000000000000000000000000000',
+          solution: 'Solution 1',
+        },
+        {
+          workerAddress: '0x0000000000000000000000000000000000000001',
+          solution: 'Solution 2',
+        },
+      ];
 
       StorageClient.downloadFileFromUrl = jest
         .fn()
@@ -391,19 +381,16 @@ describe('JobService', () => {
           solution: 'Solution 1',
         },
       ];
-      const exchangeJobSolutions: ISolutionsFile = {
-        exchangeAddress: MOCK_ADDRESS,
-        solutions: [
-          {
-            workerAddress: '0x0000000000000000000000000000000000000000',
-            solution: 'Solution 1',
-          },
-          {
-            workerAddress: '0x0000000000000000000000000000000000000001',
-            solution: 'Solution 2',
-          },
-        ],
-      };
+      const exchangeJobSolutions: ISolution[] = [
+        {
+          workerAddress: '0x0000000000000000000000000000000000000000',
+          solution: 'Solution 1',
+        },
+        {
+          workerAddress: '0x0000000000000000000000000000000000000001',
+          solution: 'Solution 2',
+        },
+      ];
 
       StorageClient.downloadFileFromUrl = jest
         .fn()
@@ -448,19 +435,16 @@ describe('JobService', () => {
           solution: 'Solution 1',
         },
       ];
-      const exchangeJobSolutions: ISolutionsFile = {
-        exchangeAddress: MOCK_ADDRESS,
-        solutions: [
-          {
-            workerAddress: '0x0000000000000000000000000000000000000000',
-            solution: 'Solution 1',
-          },
-          {
-            workerAddress: '0x0000000000000000000000000000000000000001',
-            solution: 'Solution 2',
-          },
-        ],
-      };
+      const exchangeJobSolutions: ISolution[] = [
+        {
+          workerAddress: '0x0000000000000000000000000000000000000000',
+          solution: 'Solution 1',
+        },
+        {
+          workerAddress: '0x0000000000000000000000000000000000000001',
+          solution: 'Solution 2',
+        },
+      ];
 
       StorageClient.downloadFileFromUrl = jest
         .fn()
@@ -522,37 +506,33 @@ describe('JobService', () => {
         solution: 'Solution 1',
       },
     ];
-    const exchangeJobSolutions: ISolutionsFile = {
-      exchangeAddress: MOCK_ADDRESS,
-      solutions: [
-        {
-          workerAddress: '0x0000000000000000000000000000000000000000',
-          solution: 'Solution 1',
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000001',
-          solution: 'Solution 2',
-          invalid: true,
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000002',
-          solution: 'Solution 2',
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000002',
-          solution: 'Solution 3',
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000003',
-          solution: 'Solution 3',
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000004',
-          solution: 'Solution 4',
-        },
-      ],
-    };
-
+    const exchangeJobSolutions: ISolution[] = [
+      {
+        workerAddress: '0x0000000000000000000000000000000000000000',
+        solution: 'Solution 1',
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000001',
+        solution: 'Solution 2',
+        error: true,
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000002',
+        solution: 'Solution 2',
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000002',
+        solution: 'Solution 3',
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000003',
+        solution: 'Solution 3',
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000004',
+        solution: 'Solution 4',
+      },
+    ];
     StorageClient.downloadFileFromUrl = jest
       .fn()
       .mockReturnValueOnce(manifest)
@@ -589,6 +569,7 @@ describe('JobService', () => {
   it('should call exchange oracle endpoint when solution is wrong', async () => {
     const escrowClient = {
       getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+      getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       getStatus: jest.fn().mockResolvedValue(EscrowStatus.Pending),
       getManifestUrl: jest
         .fn()
@@ -615,20 +596,16 @@ describe('JobService', () => {
         solution: 'Solution 1',
       },
     ];
-    const exchangeJobSolutions: ISolutionsFile = {
-      exchangeAddress: MOCK_ADDRESS,
-      solutions: [
-        {
-          workerAddress: '0x0000000000000000000000000000000000000000',
-          solution: 'Solution 1',
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000000',
-          solution: 'Solution 2',
-        },
-      ],
-    };
-
+    const exchangeJobSolutions: ISolution[] = [
+      {
+        workerAddress: '0x0000000000000000000000000000000000000000',
+        solution: 'Solution 1',
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000000',
+        solution: 'Solution 2',
+      },
+    ];
     StorageClient.downloadFileFromUrl = jest
       .fn()
       .mockReturnValueOnce(manifest)
@@ -646,7 +623,7 @@ describe('JobService', () => {
     const expectedBody = {
       chainId: jobSolution.chainId,
       escrowAddress: jobSolution.escrowAddress,
-      workerAddress: exchangeJobSolutions.solutions[0].workerAddress,
+      workerAddress: exchangeJobSolutions[0].workerAddress,
     };
     expect(result).toEqual('Solution are recorded.');
     expect(httpServicePostMock).toHaveBeenCalledWith(
@@ -666,6 +643,7 @@ describe('JobService', () => {
   it('should call exchange oracle endpoint when solution contain bad words', async () => {
     const escrowClient = {
       getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+      getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       getStatus: jest.fn().mockResolvedValue(EscrowStatus.Pending),
       getManifestUrl: jest
         .fn()
@@ -692,20 +670,16 @@ describe('JobService', () => {
         solution: 'Solution 1',
       },
     ];
-    const exchangeJobSolutions: ISolutionsFile = {
-      exchangeAddress: MOCK_ADDRESS,
-      solutions: [
-        {
-          workerAddress: '0x0000000000000000000000000000000000000000',
-          solution: 'Solution 1',
-        },
-        {
-          workerAddress: '0x0000000000000000000000000000000000000001',
-          solution: 'ass',
-        },
-      ],
-    };
-
+    const exchangeJobSolutions: ISolution[] = [
+      {
+        workerAddress: '0x0000000000000000000000000000000000000000',
+        solution: 'Solution 1',
+      },
+      {
+        workerAddress: '0x0000000000000000000000000000000000000001',
+        solution: 'ass',
+      },
+    ];
     StorageClient.downloadFileFromUrl = jest
       .fn()
       .mockReturnValueOnce(manifest)
@@ -721,7 +695,7 @@ describe('JobService', () => {
     const expectedBody = {
       chainId: jobSolution.chainId,
       escrowAddress: jobSolution.escrowAddress,
-      workerAddress: exchangeJobSolutions.solutions[1].workerAddress,
+      workerAddress: exchangeJobSolutions[1].workerAddress,
     };
     const result = await jobService.processJobSolution(jobSolution);
     expect(result).toEqual('Solution are recorded.');

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
@@ -16,12 +16,8 @@ import {
   web3ConfigKey,
 } from '../../common/config';
 import { ErrorJob } from '../../common/constants/errors';
-import { JobRequestType } from '../../common/enums/job';
-import {
-  IManifest,
-  ISolution,
-  ISolutionsFile,
-} from '../../common/interfaces/job';
+import { JobRequestType, SolutionError } from '../../common/enums/job';
+import { IManifest, ISolution } from '../../common/interfaces/job';
 import { checkCurseWords } from '../../common/utils/curseWords';
 import { sendWebhook } from '../../common/utils/webhook';
 import { StorageService } from '../storage/storage.service';
@@ -54,27 +50,11 @@ export class JobService {
     const uniqueSolutions: ISolution[] = [];
 
     const filteredExchangeSolution = exchangeSolutions.filter(
-      (exchangeSolution) => !exchangeSolution.invalid,
+      (exchangeSolution) => !exchangeSolution.error,
     );
 
     filteredExchangeSolution.forEach((exchangeSolution) => {
       if (errorSolutions.includes(exchangeSolution)) return;
-      const duplicatedInExchange = filteredExchangeSolution.filter(
-        (solution) =>
-          solution.workerAddress === exchangeSolution.workerAddress ||
-          solution.solution === exchangeSolution.solution,
-      );
-      if (duplicatedInExchange.length > 1) {
-        duplicatedInExchange.forEach((duplicated) => {
-          if (
-            (duplicated.solution !== exchangeSolution.solution ||
-              duplicated.workerAddress !== exchangeSolution.workerAddress) &&
-            !errorSolutions.includes(duplicated)
-          ) {
-            errorSolutions.push(duplicated);
-          }
-        });
-      }
 
       const duplicatedInRecording = recordingSolutions.filter(
         (solution) =>
@@ -83,8 +63,30 @@ export class JobService {
       );
 
       if (duplicatedInRecording.length === 0) {
+        const duplicatedInExchange = filteredExchangeSolution.filter(
+          (solution) =>
+            solution.workerAddress === exchangeSolution.workerAddress ||
+            solution.solution === exchangeSolution.solution,
+        );
+        if (duplicatedInExchange.length > 1) {
+          duplicatedInExchange.forEach((duplicated) => {
+            if (
+              (duplicated.solution !== exchangeSolution.solution ||
+                duplicated.workerAddress !== exchangeSolution.workerAddress) &&
+              !errorSolutions.includes(duplicated)
+            ) {
+              errorSolutions.push({
+                ...duplicated,
+                error: SolutionError.Duplicated,
+              });
+            }
+          });
+        }
         if (checkCurseWords(exchangeSolution.solution))
-          errorSolutions.push(exchangeSolution);
+          errorSolutions.push({
+            ...exchangeSolution,
+            error: SolutionError.CurseWord,
+          });
         else uniqueSolutions.push(exchangeSolution);
       }
     });
@@ -154,23 +156,24 @@ export class JobService {
       throw new BadRequestException(ErrorJob.AllSolutionsHaveAlreadyBeenSent);
     }
 
-    const exchangeJobSolutionsFile: ISolutionsFile =
+    const exchangeJobSolutions: ISolution[] =
       await this.storageService.download(jobSolution.solutionsUrl);
 
     const { errorSolutions, uniqueSolutions } = this.processSolutions(
-      exchangeJobSolutionsFile.solutions,
+      exchangeJobSolutions,
       existingJobSolutions,
     );
 
-    const newJobSolutions: ISolution[] = [
+    const recordingOracleSolutions: ISolution[] = [
       ...existingJobSolutions,
       ...uniqueSolutions,
+      ...errorSolutions,
     ];
 
     const jobSolutionUploaded = await this.storageService.uploadJobSolutions(
       jobSolution.escrowAddress,
       jobSolution.chainId,
-      newJobSolutions,
+      recordingOracleSolutions,
     );
 
     if (!existingJobSolutionsURL) {
@@ -187,7 +190,10 @@ export class JobService {
 
     // TODO: Remove this when KVStore is used
 
-    if (newJobSolutions.length >= submissionsRequired) {
+    if (
+      recordingOracleSolutions.filter((solution) => !solution.error).length >=
+      submissionsRequired
+    ) {
       await sendWebhook(
         this.httpService,
         this.logger,
@@ -203,7 +209,7 @@ export class JobService {
     }
     if (errorSolutions.length) {
       const exchangeOracleURL = (await kvstoreClient.get(
-        exchangeJobSolutionsFile.exchangeAddress,
+        await escrowClient.getExchangeOracleAddress(jobSolution.escrowAddress),
         'webhook_url',
       )) as string;
       for (const solution of errorSolutions) {

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -72,6 +72,7 @@ export class JobController {
     @Query('limit') limit = 10,
   ): Promise<JobListDto[] | BadRequestException> {
     networks = !Array.isArray(networks) ? [networks] : networks;
+    console.log(networks);
     return this.jobService.getJobsByStatus(
       networks,
       req.user.id,

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -72,7 +72,6 @@ export class JobController {
     @Query('limit') limit = 10,
   ): Promise<JobListDto[] | BadRequestException> {
     networks = !Array.isArray(networks) ? [networks] : networks;
-    console.log(networks);
     return this.jobService.getJobsByStatus(
       networks,
       req.user.id,


### PR DESCRIPTION
## Description

The intermediate results file should include invalid answers so the Reputation Oracle knows which workers submitted a bad solution an the reputation can be decreased

## Summary of changes

Remove ISolutionsFile interface
Add invalid answers to intermediate results
Fix tests

## How test the changes
`yarn test`

## Related issues
Close #1088 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
