### PR TITLE
[Job Launcher] Fix case comparison and obtain partial and paid escrows

### DIFF
--- a/packages/apps/job-launcher/server/src/common/utils/status.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/status.ts
@@ -1,5 +1,5 @@
 import { EscrowStatus } from '@human-protocol/sdk';
-import { JobStatus, JobStatusFilter } from '../enums/job';
+import { JobStatusFilter } from '../enums/job';
 
 export function filterToEscrowStatus(
   filterStatus: JobStatusFilter,

--- a/packages/apps/job-launcher/server/src/common/utils/status.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/status.ts
@@ -3,13 +3,13 @@ import { JobStatusFilter } from '../enums/job';
 
 export function filterToEscrowStatus(
   filterStatus: JobStatusFilter,
-): EscrowStatus {
+): EscrowStatus[] {
   switch (filterStatus) {
     case JobStatusFilter.COMPLETED:
-      return EscrowStatus.Complete;
+      return [EscrowStatus.Complete];
     case JobStatusFilter.CANCELED:
-      return EscrowStatus.Cancelled;
+      return [EscrowStatus.Cancelled];
     default:
-      return EscrowStatus.Launched;
+      return [EscrowStatus.Launched, EscrowStatus.Partial, EscrowStatus.Paid];
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1149,7 +1149,7 @@ describe('JobService', () => {
         limit,
       );
     });
-    it.only('should call subgraph and database with LAUNCHED status', async () => {
+    it('should call subgraph and database with LAUNCHED status', async () => {
       const jobEntityMock = [
         {
           status: JobStatus.LAUNCHED,

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1149,7 +1149,7 @@ describe('JobService', () => {
         limit,
       );
     });
-    it('should call subgraph and database with LAUNCHED status', async () => {
+    it.only('should call subgraph and database with LAUNCHED status', async () => {
       const jobEntityMock = [
         {
           status: JobStatus.LAUNCHED,
@@ -1190,7 +1190,7 @@ describe('JobService', () => {
       ]);
       expect(jobRepository.findJobsByEscrowAddresses).toHaveBeenCalledWith(
         userId,
-        [MOCK_ADDRESS],
+        [MOCK_ADDRESS, MOCK_ADDRESS, MOCK_ADDRESS],
       );
     });
     it('should call subgraph and database with CANCELLED status', async () => {

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -491,29 +491,20 @@ export class JobService {
     limit: number,
   ): Promise<EscrowData[]> {
     const escrows: EscrowData[] = [];
-    escrows.push(
-      ...(await EscrowUtils.getEscrows({
-        networks,
-        jobRequesterId: userId.toString(),
-        status: filterToEscrowStatus(status),
-      })),
-    );
+    const statuses = filterToEscrowStatus(status);
 
-    if (status === JobStatusFilter.LAUNCHED) {
+    for (const escrowStatus in statuses) {
       escrows.push(
         ...(await EscrowUtils.getEscrows({
           networks,
           jobRequesterId: userId.toString(),
-          status: EscrowStatus.Partial,
+          status: escrowStatus as any,
+          launcher: this.web3Service.getSigner(networks[0]).address,
         })),
       );
-      escrows.push(
-        ...(await EscrowUtils.getEscrows({
-          networks,
-          jobRequesterId: userId.toString(),
-          status: EscrowStatus.Paid,
-        })),
-      );
+    }
+
+    if (statuses.length > 1) {
       escrows.sort((a, b) => Number(b.createdAt) - Number(a.createdAt));
     }
 


### PR DESCRIPTION
## Description

Fix problem when job launcher is not returning the list of Launched escrow properly and get the escrows with status Partial or Paid when user request Launched jobs in getJobList

## Summary of changes

Add case comparison between database and subgraph data and obtain partial and paid escrows lists

## How test the changes

`yarn test`

## Related issues
Closes #1108 #1118 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
