### PR TITLE
[SDK] feat: add more typing to getter functions of python sdk

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/example.py
+++ b/packages/sdk/python/human-protocol-sdk/example.py
@@ -1,16 +1,13 @@
 import datetime
 import json
-from web3 import Web3
 
+from human_protocol_sdk.constants import ChainId
 from human_protocol_sdk.escrow import EscrowUtils, Status
 from human_protocol_sdk.filter import EscrowFilter
-from human_protocol_sdk.staking import StakingClient, LeaderFilter
+from human_protocol_sdk.staking import StakingUtils, LeaderFilter
 from human_protocol_sdk.statistics import StatisticsClient, StatisticsParam
 from human_protocol_sdk.storage import StorageClient
 from human_protocol_sdk.agreement import agreement
-
-# Replace with your own Alchemy URL
-ALCHEMY_URL = ""
 
 
 def get_escrow_statistics(statistics_client: StatisticsClient):
@@ -65,29 +62,35 @@ def get_escrows():
     print(
         EscrowUtils.get_escrows(
             EscrowFilter(
+                networks=[ChainId.POLYGON_MUMBAI],
                 status=Status.Pending,
                 date_from=datetime.datetime(2023, 5, 8),
                 date_to=datetime.datetime(2023, 6, 8),
-                networks=[80001],
             )
         )
     )
 
     print(
         vars(
-            EscrowUtils.get_escrow(80001, "0xf9ec66feeafb850d85b88142a7305f55e0532959")
+            EscrowUtils.get_escrow(
+                ChainId.POLYGON_MUMBAI, "0xf9ec66feeafb850d85b88142a7305f55e0532959"
+            )
         )
     )
 
 
-def get_leaders(staking_client: StakingClient):
-    leaders = staking_client.get_leaders()
+def get_leaders():
+    leaders = StakingUtils.get_leaders()
     print(leaders)
-    print(staking_client.get_leader(leaders[0]["address"]))
-    print(staking_client.get_leaders(LeaderFilter(role="Job Launcher")))
+    print(vars(StakingUtils.get_leader(ChainId.POLYGON_MUMBAI, leaders[0].address)))
+    print(
+        StakingUtils.get_leaders(
+            LeaderFilter(networks=[ChainId.POLYGON_MUMBAI], role="Job Launcher")
+        )
+    )
 
 
-def agreeement_example():
+def agreement_example():
     # process annotation data and get quality estimates
     url = "https://raw.githubusercontent.com/humanprotocol/human-protocol/efa8d3789ac35915b42435011cd0a8d36507564c/packages/sdk/python/human-protocol-sdk/example_annotations.json"
     annotations = json.loads(StorageClient.download_file_from_url(url))
@@ -107,10 +110,7 @@ def agreeement_example():
 
 
 if __name__ == "__main__":
-    alchemy_url = ALCHEMY_URL
-    w3 = Web3(Web3.HTTPProvider(alchemy_url))
-
-    statistics_client = StatisticsClient(w3)
+    statistics_client = StatisticsClient()
 
     # Run single example while testing, and remove comments before commit
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     get_payment_statistics(statistics_client)
     get_hmt_statistics(statistics_client)
 
-    agreeement_example()
+    agreement_example()
 
     get_escrows()
     get_leaders()

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow.py
@@ -97,147 +97,82 @@ class EscrowConfig:
         self.hash = hash
 
 
-class EscrowFilter:
-    """
-    A class used to filter escrow requests.
-    """
-
-    def __init__(
-        self,
-        networks: [List[ChainId]],
-        launcher: Optional[str] = None,
-        reputation_oracle: Optional[str] = None,
-        recording_oracle: Optional[str] = None,
-        exchange_oracle: Optional[str] = None,
-        job_requester_id: Optional[str] = None,
-        status: Optional[Status] = None,
-        date_from: Optional[datetime] = None,
-        date_to: Optional[datetime] = None,
-    ):
-        """
-        Initializes a EscrowFilter instance.
-
-        Args:
-            networks (List[ChainId]): Networks to request data
-            launcher (Optional[str]): Launcher address
-            reputation_oracle (Optional[str]): Reputation oracle address
-            recording_oracle (Optional[str]): Recording oracle address
-            exchange_oracle (Optional[str]): Exchange oracle address
-            status (Optional[Status]): Escrow status
-            date_from (Optional[datetime]): Created from date
-            date_to (Optional[datetime]): Created to date
-        """
-
-        if not networks or any(
-            network not in set(chain_id.value for chain_id in ChainId)
-            for network in networks
-        ):
-            raise EscrowClientError(f"Invalid ChainId")
-
-        if launcher and not Web3.is_address(launcher):
-            raise EscrowClientError(f"Invalid address: {launcher}")
-
-        if reputation_oracle and not Web3.is_address(reputation_oracle):
-            raise EscrowClientError(f"Invalid address: {reputation_oracle}")
-
-        if recording_oracle and not Web3.is_address(recording_oracle):
-            raise EscrowClientError(f"Invalid address: {recording_oracle}")
-
-        if exchange_oracle and not Web3.is_address(exchange_oracle):
-            raise EscrowClientError(f"Invalid address: {exchange_oracle}")
-
-        if date_from and date_to and date_from > date_to:
-            raise EscrowClientError(
-                f"Invalid dates: {date_from} must be earlier than {date_to}"
-            )
-
-        self.launcher = launcher
-        self.reputation_oracle = reputation_oracle
-        self.recording_oracle = recording_oracle
-        self.exchange_oracle = exchange_oracle
-        self.job_requester_id = job_requester_id
-        self.status = status
-        self.date_from = date_from
-        self.date_to = date_to
-        self.networks = networks
-
-
 class EscrowData:
     def __init__(
         self,
+        chain_id: ChainId,
         id: str,
         address: str,
-        amountPaid: str,
-        balance: str,
-        count: str,
-        factoryAddress: str,
+        amount_paid: int,
+        balance: int,
+        count: int,
+        factory_address: str,
         launcher: str,
         status: str,
         token: str,
-        totalFundedAmount: str,
-        createdAt: str,
-        chainId: int,
-        finalResultsUrl: Optional[str] = None,
-        intermediateResultsUrl: Optional[str] = None,
-        manifestHash: Optional[str] = None,
-        manifestUrl: Optional[str] = None,
-        recordingOracle: Optional[str] = None,
-        recordingOracleFee: Optional[str] = None,
-        reputationOracle: Optional[str] = None,
-        reputationOracleFee: Optional[str] = None,
-        exchangeOracle: Optional[str] = None,
-        exchangeOracleFee: Optional[str] = None,
+        total_funded_amount: int,
+        created_at: datetime,
+        final_results_url: Optional[str] = None,
+        intermediate_results_url: Optional[str] = None,
+        manifest_hash: Optional[str] = None,
+        manifest_url: Optional[str] = None,
+        recording_oracle: Optional[str] = None,
+        recording_oracle_fee: Optional[int] = None,
+        reputation_oracle: Optional[str] = None,
+        reputation_oracle_fee: Optional[int] = None,
+        exchange_oracle: Optional[str] = None,
+        exchange_oracle_fee: Optional[int] = None,
     ):
         """
         Initializes an EscrowData instance.
 
         Args:
+            chain_id (ChainId): Chain identifier
             id (str): Identifier
             address (str): Address
-            amountPaid (str): Amount paid
-            balance (str): Balance
-            count (str): Count
-            factoryAddress (str): Factory address
+            amount_paid (int): Amount paid
+            balance (int): Balance
+            count (int): Count
+            factory_address (str): Factory address
             launcher (str): Launcher
             status (str): Status
             token (str): Token
-            totalFundedAmount (str): Total funded amount
-            createdAt (str): Creation date
-            chainId (int): Chain identifier
-            finalResultsUrl (str, optional): Optional URL for final results.
-            intermediateResultsUrl (str, optional): Optional URL for intermediate results.
-            manifestHash (str, optional): Optional manifest hash.
-            manifestUrl (str, optional): Optional manifest URL.
-            recordingOracle (str, optional): Optional recording Oracle address.
-            recordingOracleFee (str, optional): Optional recording Oracle fee.
-            reputationOracle (str, optional): Optional reputation Oracle address.
-            reputationOracleFee (str, optional): Optional reputation Oracle fee.
-            exchangeOracle (str, optional): Optional exchange Oracle address.
-            exchangeOracleFee (str, optional): Optional exchange Oracle fee.
+            total_funded_amount (int): Total funded amount
+            created_at (datetime): Creation date
+            final_results_url (str, optional): Optional URL for final results.
+            intermediate_results_url (str, optional): Optional URL for intermediate results.
+            manifest_hash (str, optional): Optional manifest hash.
+            manifest_url (str, optional): Optional manifest URL.
+            recording_oracle (str, optional): Optional recording Oracle address.
+            recording_oracle_fee (int, optional): Optional recording Oracle fee.
+            reputation_oracle (str, optional): Optional reputation Oracle address.
+            reputation_oracle_fee (int, optional): Optional reputation Oracle fee.
+            exchange_oracle (str, optional): Optional exchange Oracle address.
+            exchange_oracle_fee (int, optional): Optional exchange Oracle fee.
         """
 
         self.id = id
         self.address = address
-        self.amountPaid = amountPaid
+        self.amount_paid = amount_paid
         self.balance = balance
         self.count = count
-        self.factoryAddress = factoryAddress
-        self.finalResultsUrl = finalResultsUrl
-        self.intermediateResultsUrl = intermediateResultsUrl
+        self.factory_address = factory_address
+        self.final_results_url = final_results_url
+        self.intermediate_results_url = intermediate_results_url
         self.launcher = launcher
-        self.manifestHash = manifestHash
-        self.manifestUrl = manifestUrl
-        self.recordingOracle = recordingOracle
-        self.recordingOracleFee = recordingOracleFee
-        self.reputationOracle = reputationOracle
-        self.reputationOracleFee = reputationOracleFee
-        self.exchangeOracle = exchangeOracle
-        self.exchangeOracleFee = exchangeOracleFee
+        self.manifest_hash = manifest_hash
+        self.manifest_url = manifest_url
+        self.recording_oracle = recording_oracle
+        self.recording_oracle_fee = recording_oracle_fee
+        self.reputation_oracle = reputation_oracle
+        self.reputation_oracle_fee = reputation_oracle_fee
+        self.exchange_oracle = exchange_oracle
+        self.exchange_oracle_fee = exchange_oracle_fee
         self.status = status
         self.token = token
-        self.totalFundedAmount = totalFundedAmount
-        self.createdAt = createdAt
-        self.chainId = chainId
+        self.total_funded_amount = total_funded_amount
+        self.created_at = created_at
+        self.chain_id = chain_id
 
 
 class EscrowClient:
@@ -260,7 +195,7 @@ class EscrowClient:
             self.w3.middleware_onion.inject(geth_poa_middleware, "geth_poa", layer=0)
 
         chain_id = None
-        # Load network configuration based on chainId
+        # Load network configuration based on chain_id
         try:
             chain_id = self.w3.eth.chain_id
             self.network = NETWORKS[ChainId(chain_id)]
@@ -869,7 +804,7 @@ class EscrowUtils:
 
     @staticmethod
     def get_escrows(
-        filter: EscrowFilter = EscrowFilter(networks=[ChainId.POLYGON_MUMBAI.value]),
+        filter: EscrowFilter = EscrowFilter(networks=[ChainId.POLYGON_MUMBAI]),
     ) -> List[EscrowData]:
         """Get an array of escrow addresses based on the specified filter parameters.
 
@@ -885,7 +820,7 @@ class EscrowUtils:
 
         escrows = []
         for chain_id in filter.networks:
-            network = NETWORKS[ChainId(chain_id)]
+            network = NETWORKS[chain_id]
             escrows_data = get_data_from_subgraph(
                 network["subgraph_url"],
                 query=get_escrows_query(filter),
@@ -913,28 +848,38 @@ class EscrowUtils:
             escrows.extend(
                 [
                     EscrowData(
+                        chain_id=chain_id,
                         id=escrow.get("id", ""),
                         address=escrow.get("address", ""),
-                        amountPaid=escrow.get("amountPaid", ""),
-                        balance=escrow.get("balance", ""),
-                        count=escrow.get("count", ""),
-                        factoryAddress=escrow.get("factoryAddress", ""),
+                        amount_paid=int(escrow.get("amountPaid", 0)),
+                        balance=int(escrow.get("balance", 0)),
+                        count=int(escrow.get("count", 0)),
+                        factory_address=escrow.get("factoryAddress", ""),
                         launcher=escrow.get("launcher", ""),
                         status=escrow.get("status", ""),
                         token=escrow.get("token", ""),
-                        totalFundedAmount=escrow.get("totalFundedAmount", ""),
-                        createdAt=escrow.get("createdAt", ""),
-                        chainId=chain_id,
-                        finalResultsUrl=escrow.get("finalResultsUrl", ""),
-                        intermediateResultsUrl=escrow.get("intermediateResultsUrl", ""),
-                        manifestHash=escrow.get("manifestHash", ""),
-                        manifestUrl=escrow.get("manifestUrl", ""),
-                        recordingOracle=escrow.get("recordingOracle", ""),
-                        recordingOracleFee=escrow.get("recordingOracleFee", ""),
-                        reputationOracle=escrow.get("reputationOracle", ""),
-                        reputationOracleFee=escrow.get("reputationOracleFee", ""),
-                        exchangeOracle=escrow.get("exchangeOracle", ""),
-                        exchangeOracleFee=escrow.get("exchangeOracleFee", ""),
+                        total_funded_amount=int(escrow.get("totalFundedAmount", 0)),
+                        created_at=datetime.fromtimestamp(
+                            int(escrow.get("createdAt", 0))
+                        ),
+                        final_results_url=escrow.get("finalResultsUrl", None),
+                        intermediate_results_url=escrow.get(
+                            "intermediateResultsUrl", None
+                        ),
+                        manifest_hash=escrow.get("manifestHash", None),
+                        manifest_url=escrow.get("manifestUrl", None),
+                        recording_oracle=escrow.get("recordingOracle", None),
+                        recording_oracle_fee=int(escrow.get("recordingOracleFee"))
+                        if escrow.get("recordingOracleFee", None)
+                        else None,
+                        reputation_oracle=escrow.get("reputationOracle", None),
+                        reputation_oracle_fee=int(escrow.get("reputationOracleFee"))
+                        if escrow.get("reputationOracleFee", None)
+                        else None,
+                        exchange_oracle=escrow.get("exchangeOracle", None),
+                        exchange_oracle_fee=int(escrow.get("exchangeOracleFee"))
+                        if escrow.get("exchangeOracleFee", None)
+                        else None,
                     )
                     for escrow in escrows_raw
                 ]
@@ -960,7 +905,7 @@ class EscrowUtils:
             get_escrow_query,
         )
 
-        if chain_id not in set(chain_id.value for chain_id in ChainId):
+        if chain_id.value not in set(chain_id.value for chain_id in ChainId):
             raise EscrowClientError(f"Invalid ChainId")
 
         if not Web3.is_address(escrow_address):
@@ -968,7 +913,7 @@ class EscrowUtils:
 
         network = NETWORKS[ChainId(chain_id)]
 
-        escrow = get_data_from_subgraph(
+        escrow_data = get_data_from_subgraph(
             network["subgraph_url"],
             query=get_escrow_query(),
             params={
@@ -976,32 +921,38 @@ class EscrowUtils:
             },
         )
 
-        escrow_raw = escrow["data"]["escrow"]
+        escrow = escrow_data["data"]["escrow"]
 
-        if not escrow_raw:
+        if not escrow:
             return None
 
         return EscrowData(
-            id=escrow_raw.get("id", ""),
-            address=escrow_raw.get("address", ""),
-            amountPaid=escrow_raw.get("amountPaid", ""),
-            balance=escrow_raw.get("balance", ""),
-            count=escrow_raw.get("count", ""),
-            factoryAddress=escrow_raw.get("factoryAddress", ""),
-            launcher=escrow_raw.get("launcher", ""),
-            status=escrow_raw.get("status", ""),
-            token=escrow_raw.get("token", ""),
-            totalFundedAmount=escrow_raw.get("totalFundedAmount", ""),
-            createdAt=escrow_raw.get("createdAt", ""),
-            chainId=chain_id,
-            finalResultsUrl=escrow_raw.get("finalResultsUrl", ""),
-            intermediateResultsUrl=escrow_raw.get("intermediateResultsUrl", ""),
-            manifestHash=escrow_raw.get("manifestHash", ""),
-            manifestUrl=escrow_raw.get("manifestUrl", ""),
-            recordingOracle=escrow_raw.get("recordingOracle", ""),
-            recordingOracleFee=escrow_raw.get("recordingOracleFee", ""),
-            reputationOracle=escrow_raw.get("reputationOracle", ""),
-            reputationOracleFee=escrow_raw.get("reputationOracleFee", ""),
-            exchangeOracle=escrow_raw.get("exchangeOracle", ""),
-            exchangeOracleFee=escrow_raw.get("exchangeOracleFee", ""),
+            chain_id=chain_id,
+            id=escrow.get("id", ""),
+            address=escrow.get("address", ""),
+            amount_paid=int(escrow.get("amountPaid", 0)),
+            balance=int(escrow.get("balance", 0)),
+            count=int(escrow.get("count", 0)),
+            factory_address=escrow.get("factoryAddress", ""),
+            launcher=escrow.get("launcher", ""),
+            status=escrow.get("status", ""),
+            token=escrow.get("token", ""),
+            total_funded_amount=int(escrow.get("totalFundedAmount", 0)),
+            created_at=datetime.fromtimestamp(int(escrow.get("createdAt", 0))),
+            final_results_url=escrow.get("finalResultsUrl", None),
+            intermediate_results_url=escrow.get("intermediateResultsUrl", None),
+            manifest_hash=escrow.get("manifestHash", None),
+            manifest_url=escrow.get("manifestUrl", None),
+            recording_oracle=escrow.get("recordingOracle", None),
+            recording_oracle_fee=int(escrow.get("recordingOracleFee"))
+            if escrow.get("recordingOracleFee", None)
+            else None,
+            reputation_oracle=escrow.get("reputationOracle", None),
+            reputation_oracle_fee=int(escrow.get("reputationOracleFee"))
+            if escrow.get("reputationOracleFee", None)
+            else None,
+            exchange_oracle=escrow.get("exchangeOracle", None),
+            exchange_oracle_fee=int(escrow.get("exchangeOracleFee"))
+            if escrow.get("exchangeOracleFee", None)
+            else None,
         )

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/filter.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/filter.py
@@ -24,7 +24,7 @@ class EscrowFilter:
 
     def __init__(
         self,
-        networks: [List[ChainId]],
+        networks: List[ChainId],
         launcher: Optional[str] = None,
         reputation_oracle: Optional[str] = None,
         recording_oracle: Optional[str] = None,
@@ -50,7 +50,7 @@ class EscrowFilter:
         """
 
         if not networks or any(
-            network not in set(chain_id.value for chain_id in ChainId)
+            network.value not in set(chain_id.value for chain_id in ChainId)
             for network in networks
         ):
             raise FilterError(f"Invalid ChainId")

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking.py
@@ -34,23 +34,31 @@ class StakingClientError(Exception):
     pass
 
 
-class LeaderFilter:
-    """
-    A class used to filter leaders.
-    """
-
+class AllocationData:
     def __init__(
         self,
-        role: Optional[str] = None,
+        escrow_address: str,
+        staker: str,
+        tokens: str,
+        created_at: str,
+        closed_at: str,
     ):
         """
-        Initializes a LeaderFilter instance.
+        Initializes an AllocationData instance.
 
         Args:
-            role (Optional[str]): Leader role
+            escrow_address (str): Escrow address
+            staker (str): Staker address
+            tokens (str): Amount allocated
+            created_at (str): Creation date
+            closed_at (str): Closing date
         """
 
-        self.role = role
+        self.escrow_address = escrow_address
+        self.staker = staker
+        self.tokens = tokens
+        self.created_at = created_at
+        self.closed_at = closed_at
 
 
 class StakingClient:
@@ -308,94 +316,14 @@ class StakingClient:
             StakingClientError,
         )
 
-    def get_leaders(self, filter: LeaderFilter = LeaderFilter()) -> List[dict]:
-        """Get leaders data of the protocol
-
-        Returns:
-            List[dict]: List of leaders data
-        """
-        from human_protocol_sdk.gql.staking import get_leaders_query
-
-        leaders_data = get_data_from_subgraph(
-            self.network["subgraph_url"],
-            query=get_leaders_query(filter),
-            params={"role": filter.role},
-        )
-        leaders = leaders_data["data"]["leaders"]
-
-        return [
-            {
-                "id": leader["id"],
-                "address": leader["address"],
-                "amount_staked": int(leader["amountStaked"]),
-                "amount_allocated": int(leader["amountAllocated"]),
-                "amount_locked": int(leader["amountLocked"]),
-                "locked_until_timestamp": int(leader["lockedUntilTimestamp"]),
-                "amount_withdrawn": int(leader["amountWithdrawn"]),
-                "amount_slashed": int(leader["amountSlashed"]),
-                "reputation": int(leader["reputation"]),
-                "reward": int(leader["reward"]),
-                "amount_jobs_launched": int(leader["amountJobsLaunched"]),
-                "role": leader["role"],
-                "fee": int(leader["fee"]) if leader["fee"] else None,
-                "public_key": leader["publicKey"],
-                "webhook_url": leader["webhookUrl"],
-                "url": leader["url"],
-            }
-            for leader in leaders
-        ]
-
-    def get_leader(self, address: Optional[str] = None) -> dict:
-        """Get the leader details.
-
-        Args:
-            address (Optional[str]): Address of the leader, defaults to the default account
-
-        Returns:
-            dict: Leader details
-        """
-        from human_protocol_sdk.gql.staking import get_leader_query
-
-        if not address:
-            if not self.w3.eth.default_account:
-                raise StakingClientError("No address provided")
-
-            address = self.w3.eth.default_account
-
-        leader_data = get_data_from_subgraph(
-            self.network["subgraph_url"],
-            query=get_leader_query,
-            params={"address": address},
-        )
-        leader = leader_data["data"]["leader"]
-
-        return {
-            "id": leader["id"],
-            "address": leader["address"],
-            "amount_staked": int(leader["amountStaked"]),
-            "amount_allocated": int(leader["amountAllocated"]),
-            "amount_locked": int(leader["amountLocked"]),
-            "locked_until_timestamp": int(leader["lockedUntilTimestamp"]),
-            "amount_withdrawn": int(leader["amountWithdrawn"]),
-            "amount_slashed": int(leader["amountSlashed"]),
-            "reputation": int(leader["reputation"]),
-            "reward": int(leader["reward"]),
-            "amount_jobs_launched": int(leader["amountJobsLaunched"]),
-            "role": leader["role"],
-            "fee": int(leader["fee"]) if leader["fee"] else None,
-            "public_key": leader["publicKey"],
-            "webhook_url": leader["webhookUrl"],
-            "url": leader["url"],
-        }
-
-    def get_allocation(self, escrow_address: str) -> Optional[dict]:
+    def get_allocation(self, escrow_address: str) -> Optional[AllocationData]:
         """Gets the allocation info for the specified escrow.
 
         Args:
             escrow_address (str): Address of the escrow
 
         Returns:
-            Optional[dict]: Allocation info if escrow exists, otherwise None
+            Optional[AllocationData]: Allocation info if escrow exists, otherwise None
         """
 
         [
@@ -409,38 +337,13 @@ class StakingClient:
         if escrow_address == web3.constants.ADDRESS_ZERO:
             return None
 
-        return {
-            "escrow_address": escrow_address,
-            "staker": staker,
-            "tokens": tokens,
-            "created_at": created_at,
-            "closed_at": closed_at,
-        }
-
-    def get_rewards_info(self, slasher: str) -> List[dict]:
-        """Get rewards of the given slasher
-
-        Args:
-            slasher (str): Address of the slasher
-
-        Returns:
-            List[dict]: List of rewards info
-        """
-
-        reward_added_events_data = get_data_from_subgraph(
-            self.network["subgraph_url"],
-            query=get_reward_added_events_query,
-            params={"slasherAddress": slasher.lower()},
+        return AllocationData(
+            escrow_address=escrow_address,
+            staker=staker,
+            tokens=tokens,
+            created_at=created_at,
+            closed_at=closed_at,
         )
-        reward_added_events = reward_added_events_data["data"]["rewardAddedEvents"]
-
-        return [
-            {
-                "escrow_address": reward_added_events[i]["escrowAddress"],
-                "amount": reward_added_events[i]["amount"],
-            }
-            for i in range(len(reward_added_events))
-        ]
 
     def _is_valid_escrow(self, escrow_address: str) -> bool:
         """Checks if the escrow address is valid.
@@ -454,3 +357,258 @@ class StakingClient:
 
         # TODO: Use Escrow/Job Module once implemented
         return self.factory_contract.functions.hasEscrow(escrow_address).call()
+
+
+class LeaderFilter:
+    """
+    A class used to filter leaders.
+    """
+
+    def __init__(
+        self,
+        networks: List[ChainId],
+        role: Optional[str] = None,
+    ):
+        """
+        Initializes a LeaderFilter instance.
+
+        Args:
+            networks (List[ChainId]): Networks to request data
+            role (Optional[str]): Leader role
+        """
+
+        if not networks or any(
+            network.value not in set(chain_id.value for chain_id in ChainId)
+            for network in networks
+        ):
+            raise StakingClientError(f"Invalid ChainId")
+
+        self.networks = networks
+        self.role = role
+
+
+class LeaderData:
+    def __init__(
+        self,
+        chain_id: ChainId,
+        id: str,
+        address: str,
+        amount_staked: int,
+        amount_allocated: int,
+        amount_locked: int,
+        locked_until_timestamp: int,
+        amount_withdrawn: int,
+        amount_slashed: int,
+        reputation: int,
+        reward: int,
+        amount_jobs_launched: int,
+        role: Optional[str] = None,
+        fee: Optional[int] = None,
+        public_key: Optional[str] = None,
+        webhook_url: Optional[str] = None,
+        url: Optional[str] = None,
+    ):
+        """
+        Initializes an LeaderData instance.
+
+        Args:
+            chain_id (ChainId): Chain Identifier
+            id (str): Identifier
+            address (str): Address
+            amount_staked (int): Amount staked
+            amount_allocated (int): Amount allocated
+            amount_locked (int): Amount locked
+            locked_until_timestamp (int): Locked until timestamp
+            amount_withdrawn (int): Amount withdrawn
+            amount_slashed (int): Amount slashed
+            reputation (int): Reputation
+            reward (int): Reward
+            amount_jobs_launched (int): Amount of jobs launched
+            role (Optional[str]): Role
+            fee (Optional[int]): Fee
+            public_key (Optional[str]): Public key
+            webhook_url (Optional[str]): Webhook url
+            url (Optional[str]): Url
+        """
+
+        self.chain_id = chain_id
+        self.id = id
+        self.address = address
+        self.amount_staked = amount_staked
+        self.amount_allocated = amount_allocated
+        self.amount_locked = amount_locked
+        self.locked_until_timestamp = locked_until_timestamp
+        self.amount_withdrawn = amount_withdrawn
+        self.amount_slashed = amount_slashed
+        self.reputation = reputation
+        self.reward = reward
+        self.amount_jobs_launched = amount_jobs_launched
+        self.role = role
+        self.fee = fee
+        self.public_key = public_key
+        self.webhook_url = webhook_url
+        self.url = url
+
+
+class RewardData:
+    def __init__(
+        self,
+        escrow_address: str,
+        amount: int,
+    ):
+        """
+        Initializes an RewardData instance.
+
+        Args:
+            escrow_address (str): Escrow address
+            amount (int): Amount
+        """
+
+        self.escrow_address = escrow_address
+        self.amount = amount
+
+
+class StakingUtils:
+    """
+    A utility class that provides additional staking-related functionalities.
+    """
+
+    @staticmethod
+    def get_leaders(
+        filter: LeaderFilter = LeaderFilter(networks=[ChainId.POLYGON_MUMBAI]),
+    ) -> List[LeaderData]:
+        """Get leaders data of the protocol
+
+        Returns:
+            List[LeaderData]: List of leaders data
+        """
+        from human_protocol_sdk.gql.staking import get_leaders_query
+
+        leaders = []
+        for chain_id in filter.networks:
+            network = NETWORKS[chain_id]
+
+            leaders_data = get_data_from_subgraph(
+                network["subgraph_url"],
+                query=get_leaders_query(filter),
+                params={"role": filter.role},
+            )
+            leaders_raw = leaders_data["data"]["leaders"]
+
+            leaders.extend(
+                [
+                    LeaderData(
+                        chain_id=chain_id,
+                        id=leader.get("id", ""),
+                        address=leader.get("address", ""),
+                        amount_staked=int(leader.get("amountStaked", 0)),
+                        amount_allocated=int(leader.get("amountAllocated", 0)),
+                        amount_locked=int(leader.get("amountLocked", 0)),
+                        locked_until_timestamp=int(
+                            leader.get("lockedUntilTimestamp", 0)
+                        ),
+                        amount_withdrawn=int(leader.get("amountWithdrawn", 0)),
+                        amount_slashed=int(leader.get("amountSlashed", 0)),
+                        reputation=int(leader.get("reputation", 0)),
+                        reward=int(leader.get("reward", 0)),
+                        amount_jobs_launched=int(leader.get("amountJobsLaunched", 0)),
+                        role=leader.get("role", None),
+                        fee=int(leader.get("fee")) if leader.get("fee", None) else None,
+                        public_key=leader.get("publicKey", None),
+                        webhook_url=leader.get("webhookUrl", None),
+                        url=leader.get("url", None),
+                    )
+                    for leader in leaders_raw
+                ]
+            )
+
+        return leaders
+
+    @staticmethod
+    def get_leader(
+        chain_id: ChainId,
+        leader_address: str,
+    ) -> Optional[LeaderData]:
+        """Get the leader details.
+
+        Args:
+            chain_id (ChainId): Network in which the leader exists
+            leader_address (str): Address of the leader
+
+        Returns:
+            Optional[LeaderData]: Leader data if exists, otherwise None
+        """
+        from human_protocol_sdk.gql.staking import get_leader_query
+
+        if chain_id.value not in set(chain_id.value for chain_id in ChainId):
+            raise StakingClientError(f"Invalid ChainId")
+
+        if not Web3.is_address(leader_address):
+            raise StakingClientError(f"Invalid leader address: {leader_address}")
+
+        network = NETWORKS[chain_id]
+
+        leader_data = get_data_from_subgraph(
+            network["subgraph_url"],
+            query=get_leader_query,
+            params={"address": leader_address},
+        )
+        leader = leader_data["data"]["leader"]
+
+        if not leader:
+            return None
+
+        return LeaderData(
+            chain_id=chain_id,
+            id=leader.get("id", ""),
+            address=leader.get("address", ""),
+            amount_staked=int(leader.get("amountStaked", 0)),
+            amount_allocated=int(leader.get("amountAllocated", 0)),
+            amount_locked=int(leader.get("amountLocked", 0)),
+            locked_until_timestamp=int(leader.get("lockedUntilTimestamp", 0)),
+            amount_withdrawn=int(leader.get("amountWithdrawn", 0)),
+            amount_slashed=int(leader.get("amountSlashed", 0)),
+            reputation=int(leader.get("reputation", 0)),
+            reward=int(leader.get("reward", 0)),
+            amount_jobs_launched=int(leader.get("amountJobsLaunched", 0)),
+            role=leader.get("role", None),
+            fee=int(leader.get("fee")) if leader.get("fee", None) else None,
+            public_key=leader.get("publicKey", None),
+            webhook_url=leader.get("webhookUrl", None),
+            url=leader.get("url", None),
+        )
+
+    @staticmethod
+    def get_rewards_info(chain_id: ChainId, slasher: str) -> List[RewardData]:
+        """Get rewards of the given slasher
+
+        Args:
+            chain_id (ChainId): Network in which the slasher exists
+            slasher (str): Address of the slasher
+
+        Returns:
+            List[RewardData]: List of rewards info
+        """
+
+        if chain_id.value not in set(chain_id.value for chain_id in ChainId):
+            raise StakingClientError(f"Invalid ChainId")
+
+        if not Web3.is_address(slasher):
+            raise StakingClientError(f"Invalid slasher address: {slasher}")
+
+        network = NETWORKS[chain_id]
+
+        reward_added_events_data = get_data_from_subgraph(
+            network["subgraph_url"],
+            query=get_reward_added_events_query,
+            params={"slasherAddress": slasher.lower()},
+        )
+        reward_added_events = reward_added_events_data["data"]["rewardAddedEvents"]
+
+        return [
+            RewardData(
+                escrow_address=reward_added_event.get("escrowAddress", ""),
+                amount=int(reward_added_event.get("amount", 0)),
+            )
+            for reward_added_event in reward_added_events
+        ]

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_escrow.py
@@ -1864,7 +1864,7 @@ class EscrowTestCase(unittest.TestCase):
         date_from = datetime.fromtimestamp(1683811973)
         date_to = datetime.fromtimestamp(1683812007)
         escrow_filter = EscrowFilter(
-            networks=[ChainId.POLYGON_MUMBAI.value],
+            networks=[ChainId.POLYGON_MUMBAI],
             launcher=launcher,
             reputation_oracle=reputation_oracle,
             recording_oracle=recording_oracle,
@@ -1886,21 +1886,19 @@ class EscrowTestCase(unittest.TestCase):
         self.assertEqual("Invalid ChainId", str(cm.exception))
 
     def test_escrow_filter_invalid_chain_id(self):
-        with self.assertRaises(FilterError) as cm:
-            EscrowFilter(networks=[123])
-        self.assertEqual("Invalid ChainId", str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            EscrowFilter(networks=[ChainId(123)])
+        self.assertEqual("123 is not a valid ChainId", str(cm.exception))
 
     def test_escrow_filter_invalid_address_launcher(self):
         with self.assertRaises(FilterError) as cm:
-            EscrowFilter(
-                networks=[ChainId.POLYGON_MUMBAI.value], launcher="invalid_address"
-            )
+            EscrowFilter(networks=[ChainId.POLYGON_MUMBAI], launcher="invalid_address")
         self.assertEqual("Invalid address: invalid_address", str(cm.exception))
 
     def test_escrow_filter_invalid_address_reputation_oracle(self):
         with self.assertRaises(FilterError) as cm:
             EscrowFilter(
-                networks=[ChainId.POLYGON_MUMBAI.value],
+                networks=[ChainId.POLYGON_MUMBAI],
                 reputation_oracle="invalid_address",
             )
         self.assertEqual("Invalid address: invalid_address", str(cm.exception))
@@ -1908,7 +1906,7 @@ class EscrowTestCase(unittest.TestCase):
     def test_escrow_filter_invalid_address_recording_oracle(self):
         with self.assertRaises(FilterError) as cm:
             EscrowFilter(
-                networks=[ChainId.POLYGON_MUMBAI.value],
+                networks=[ChainId.POLYGON_MUMBAI],
                 recording_oracle="invalid_address",
             )
         self.assertEqual("Invalid address: invalid_address", str(cm.exception))
@@ -1916,7 +1914,7 @@ class EscrowTestCase(unittest.TestCase):
     def test_escrow_filter_invalid_dates(self):
         with self.assertRaises(FilterError) as cm:
             EscrowFilter(
-                networks=[ChainId.POLYGON_MUMBAI.value],
+                networks=[ChainId.POLYGON_MUMBAI],
                 date_from=datetime.fromtimestamp(1683812007),
                 date_to=datetime.fromtimestamp(1683811973),
             )
@@ -1981,7 +1979,7 @@ class EscrowTestCase(unittest.TestCase):
             mock_function.side_effect = side_effect
 
             filter = EscrowFilter(
-                networks=[ChainId.POLYGON_MUMBAI.value],
+                networks=[ChainId.POLYGON_MUMBAI],
                 launcher="0x1234567890123456789012345678901234567891",
                 job_requester_id="1",
                 status=Status.Pending,
@@ -2007,9 +2005,7 @@ class EscrowTestCase(unittest.TestCase):
             self.assertEqual(len(filtered), 1)
             self.assertEqual(filtered[0].address, mock_escrow_1["address"])
 
-            filter = EscrowFilter(
-                networks=[ChainId.POLYGON.value, ChainId.POLYGON_MUMBAI.value]
-            )
+            filter = EscrowFilter(networks=[ChainId.POLYGON, ChainId.POLYGON_MUMBAI])
 
             filtered = EscrowUtils.get_escrows(filter)
 
@@ -2028,8 +2024,8 @@ class EscrowTestCase(unittest.TestCase):
                 },
             )
             self.assertEqual(len(filtered), 2)
-            self.assertEqual(filtered[0].chainId, ChainId.POLYGON.value)
-            self.assertEqual(filtered[1].chainId, ChainId.POLYGON_MUMBAI.value)
+            self.assertEqual(filtered[0].chain_id, ChainId.POLYGON)
+            self.assertEqual(filtered[1].chain_id, ChainId.POLYGON_MUMBAI)
 
     def test_get_recording_oracle_address(self):
         mock_contract = MagicMock()
@@ -2318,7 +2314,7 @@ class EscrowTestCase(unittest.TestCase):
             }
 
             escrow = EscrowUtils.get_escrow(
-                ChainId.POLYGON_MUMBAI.value,
+                ChainId.POLYGON_MUMBAI,
                 "0x1234567890123456789012345678901234567890",
             )
 
@@ -2329,9 +2325,9 @@ class EscrowTestCase(unittest.TestCase):
                     "escrowAddress": "0x1234567890123456789012345678901234567890",
                 },
             )
-            self.assertEqual(escrow.chainId, ChainId.POLYGON_MUMBAI.value)
+            self.assertEqual(escrow.chain_id, ChainId.POLYGON_MUMBAI)
             self.assertEqual(escrow.address, mock_escrow["address"])
-            self.assertEqual(escrow.amountPaid, mock_escrow["amountPaid"])
+            self.assertEqual(escrow.amount_paid, int(mock_escrow["amountPaid"]))
 
     def test_get_escrow_empty_data(self):
         with patch("human_protocol_sdk.escrow.get_data_from_subgraph") as mock_function:
@@ -2342,7 +2338,7 @@ class EscrowTestCase(unittest.TestCase):
             }
 
             escrow = EscrowUtils.get_escrow(
-                ChainId.POLYGON_MUMBAI.value,
+                ChainId.POLYGON_MUMBAI,
                 "0x1234567890123456789012345678901234567890",
             )
             mock_function.assert_called_once_with(
@@ -2355,13 +2351,15 @@ class EscrowTestCase(unittest.TestCase):
             self.assertEqual(escrow, None)
 
     def test_get_escrow_invalid_chain_id(self):
-        with self.assertRaises(EscrowClientError) as cm:
-            EscrowUtils.get_escrow(123, "0x1234567890123456789012345678901234567890")
-        self.assertEqual("Invalid ChainId", str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            EscrowUtils.get_escrow(
+                ChainId(123), "0x1234567890123456789012345678901234567890"
+            )
+        self.assertEqual("123 is not a valid ChainId", str(cm.exception))
 
     def test_get_escrow_invalid_address_launcher(self):
         with self.assertRaises(EscrowClientError) as cm:
-            EscrowUtils.get_escrow(ChainId.LOCALHOST.value, "invalid_address")
+            EscrowUtils.get_escrow(ChainId.LOCALHOST, "invalid_address")
         self.assertEqual("Invalid escrow address: invalid_address", str(cm.exception))
 
 

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_statistics.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/test_statistics.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import datetime
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 from human_protocol_sdk.constants import NETWORKS, ChainId
 from human_protocol_sdk.gql.hmtoken import get_holders_query
@@ -11,56 +11,18 @@ from human_protocol_sdk.gql.statistics import (
 )
 from human_protocol_sdk.statistics import (
     StatisticsClient,
-    StatisticsClientError,
     StatisticsParam,
 )
-from web3 import Web3
-from web3.providers.rpc import HTTPProvider
 
 
 class StatisticsTestCase(unittest.TestCase):
     def setUp(self):
-        self.mock_provider = MagicMock(spec=HTTPProvider)
-        self.w3 = Web3(self.mock_provider)
-
-        self.mock_chain_id = ChainId.LOCALHOST.value
-        type(self.w3.eth).chain_id = PropertyMock(return_value=self.mock_chain_id)
-
-        self.statistics = StatisticsClient(self.w3)
-
-    def test_init_with_valid_inputs(self):
-        mock_provider = MagicMock(spec=HTTPProvider)
-        w3 = Web3(mock_provider)
-
-        mock_chain_id = ChainId.LOCALHOST.value
-        type(w3.eth).chain_id = PropertyMock(return_value=mock_chain_id)
-
-        statistics = StatisticsClient(w3)
-
-        self.assertEqual(statistics.w3, w3)
-        self.assertEqual(statistics.network, NETWORKS[ChainId(mock_chain_id)])
+        self.statistics = StatisticsClient(ChainId.LOCALHOST)
 
     def test_init_with_invalid_chain_id(self):
-        mock_provider = MagicMock(spec=HTTPProvider)
-        w3 = Web3(mock_provider)
-
-        mock_chain_id = 9999
-        type(w3.eth).chain_id = PropertyMock(return_value=mock_chain_id)
-
-        with self.assertRaises(StatisticsClientError) as cm:
-            StatisticsClient(w3)
-        self.assertEqual(f"Invalid ChainId: {mock_chain_id}", str(cm.exception))
-
-    def test_init_with_invalid_web3(self):
-        mock_provider = MagicMock(spec=HTTPProvider)
-        w3 = Web3(mock_provider)
-
-        mock_chain_id = None
-        type(w3.eth).chain_id = PropertyMock(return_value=mock_chain_id)
-
-        with self.assertRaises(StatisticsClientError) as cm:
-            StatisticsClient(w3)
-        self.assertEqual(f"Invalid Web3 Instance", str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            StatisticsClient(ChainId(123))
+        self.assertEqual(f"123 is not a valid ChainId", str(cm.exception))
 
     def test_get_escrow_statistics(self):
         param = StatisticsParam(


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
For our getter functions in Python SDK, we need more strict typing than dict.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Changed couple field types on `EscrowData` class.
- Used `get` function for the dict values returned from subgraph call.
- Moved `getLeader`, `getLeaders`, and `getReward` function to `StakingUtils` class as static methods.
- `StatisticsClient` does not accept `Web3` instance, but just `chain_id`, since it's not supposed to do any write operations.
- GitBook changed (https://app.gitbook.com/o/gVcp9m9Bobj6V368GNOW/s/FFmrUy0ymWxdSjtXZkJe/~/changes/76/)

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #662 

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
