### PR TITLE
Fix readme job launcher server

### DIFF
--- a/packages/apps/job-launcher/server/README.md
+++ b/packages/apps/job-launcher/server/README.md
@@ -39,10 +39,10 @@ First of all, postgres needs to be installed, please see here <a href="https://w
 
 Then run the following commands in the postgres console to create the database and issue permissions:
 ```bash
-$ CREATE DATABASE "reputation-oracle";
+$ CREATE DATABASE "job-launcher";
 $ CREATE USER operator WITH ENCRYPTED PASSWORD 'qwerty';
-$ GRANT ALL PRIVILEGES ON DATABASE "reputation-oracle" TO "operator";
-$ \c "reputation-oracle" postgres
+$ GRANT ALL PRIVILEGES ON DATABASE "job-launcher" TO "operator";
+$ \c "job-launcher" postgres
 $ GRANT CREATE ON SCHEMA public TO operator;
 ```
 Now we're ready to run the migrations:


### PR DESCRIPTION
## Description

This pull request addresses an issue with outdated information in the project's README file. The previous version of the README provided instructions for setting up a PostgreSQL database with the name "reputation-oracle", which is no longer relevant to the current state of the project. The instructions have been updated to reflect the correct database name, "job-launcher", ensuring that new developers or contributors can set up their development environment accurately and efficiently.

## Summary of changes

Updated the PostgreSQL setup instructions in the README file to change the database name from "reputation-oracle" to "job-launcher".
Updated the user permissions instructions to ensure consistency with the new database name.

## How test the changes

Follow the updated instructions in the README to set up the PostgreSQL database.
Ensure that you are able to create the "job-launcher" database and assign the necessary permissions to the "operator" user without any issues.
Confirm that you are able to connect to the "job-launcher" database using the provided credentials.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

N/A


## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
