### PR TITLE
[Reputation Oracle] Remove getBalance check and check number of solutions received

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -22,6 +22,7 @@ export enum ErrorResults {
   IntermediateResultsURLNotSet = 'Intermediate results URL is not set',
   NoIntermediateResultsFound = 'No intermediate results found',
   NoResultsHaveBeenVerified = 'No results have been verified',
+  NotAllRequiredSolutionsHaveBeenSent = 'Not all required solutions have been sent',
 }
 
 /**


### PR DESCRIPTION
## Description

Remove getBalance after bulkpayout because the escrow balance is not updated instantaneously

Check number of solutions in Reputation Oracle before uploading final results

## Summary of changes

Remove getBalance check

Check if the number of valid solutions match with the number of solutions requested

## Related issues
Closes #1151 

## Operational checklist

- [x] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
