### PR TITLE
[CVAT][Exchange oracle] Fix `/register` endpoint

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/cvat/api_calls.py
+++ b/packages/examples/cvat/exchange-oracle/src/cvat/api_calls.py
@@ -551,7 +551,9 @@ def get_user_id(user_email: str) -> int:
                 org=Config.cvat_config.cvat_org_slug,
             )
 
-            (page, _) = api_client.memberships_api.list(user=invitation.user.username)
+            (page, _) = api_client.memberships_api.list(
+                user=invitation.user.username, org=Config.cvat_config.cvat_org_slug
+            )
             membership = page.results[0]
             api_client.memberships_api.destroy(membership.id)
         except exceptions.ApiException as e:

--- a/packages/examples/cvat/exchange-oracle/src/services/cvat.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/cvat.py
@@ -300,6 +300,10 @@ def get_user_by_id(session: Session, wallet_address: str) -> Optional[User]:
     return session.query(User).where(User.wallet_address == wallet_address).first()
 
 
+def get_user_by_email(session: Session, email: str) -> Optional[User]:
+    return session.query(User).where(User.cvat_email == email).first()
+
+
 # Assignments
 
 


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
During account binding exchange oracle was throwing an error due to the incomplete api call to CVAT

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

- Now all CVAT work is done within an organization
- Now admin rights are not required for the CVAT user
- Now annotators will be members of the CVAT organization
- Added cleanup of the user with the previous email on user email change in the `/register` endpoint
- Added `cvat_org_slug` to `memberships_api.list()` api call to avoid empty response

## Related issues

To close #1153 

<!-- Does this close any open issues? -->

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
