### PR TITLE
Job Luancher - fix allowed status to cancel job

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/index.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/index.ts
@@ -33,6 +33,7 @@ export const CVAT_JOB_TYPES = [
 export const CANCEL_JOB_STATUSES = [
   JobStatus.PENDING,
   JobStatus.PAID,
+  JobStatus.FAILED,
   JobStatus.LAUNCHED,
 ];
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -652,6 +652,22 @@ describe('JobService', () => {
         jobService.requestToCancelJob(userId, jobId),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('should throw an error if status is invalid', async () => {
+      const mockJobEntity: Partial<JobEntity> = {
+        id: jobId,
+        userId,
+        status: JobStatus.COMPLETED,
+        chainId: ChainId.LOCALHOST,
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      jobRepository.findOne = jest.fn().mockResolvedValue(mockJobEntity);
+
+      await expect(
+        jobService.requestToCancelJob(userId, jobId),
+      ).rejects.toThrow(new ConflictException(ErrorJob.InvalidStatusCancellation));
+    });
   });
 
   describe('cancelCronJob', () => {


### PR DESCRIPTION
## Description
Failed jobs should also be allowed to cancel.

## Summary of changes
Add failed jobs to the list of statuses that can be cancelled
Add a test for status

## How test the changes
`yarn test`

## Operational checklist

- [x] All new functionality is covered by tests
- [x] Any related documentation has been changed or added
