### PR TITLE
Added new regex to parse url util

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -86,6 +86,7 @@ export enum ErrorCurrency {
  * Represents error messages related to bucket.
  */
 export enum ErrorBucket {
+  NotExist = 'Bucket does not exist',
   NotPublic = 'Bucket is not public',
   UnableSaveFile = 'Unable to save file',
 }

--- a/packages/apps/job-launcher/server/src/common/utils/index.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/index.ts
@@ -50,6 +50,14 @@ export const parseUrl = (url: string): {
       endPoint: 'storage.googleapis.com',
     },
     {
+      regex: /^https:\/\/s3\.[a-z0-9-]+\.amazonaws\.com\/[a-zA-Z0-9\.-]+$/,
+      endPoint: 's3.amazonaws.com',
+    },
+    {
+      regex: /^https:\/\/[a-zA-Z0-9\.-]+\.s3\.[a-z0-9-]+\.amazonaws\.com\/$/,
+      endPoint: 's3.amazonaws.com',
+    },
+    {
       regex: /^https?:\/\/([^/:]+)(?::(\d+))?(\/.*)?/,
       endPoint: '$1',
       port: '$2',

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -240,6 +240,11 @@ export class JobService {
     fundAmount: number,
   ): Promise<string> {
     const storageData = parseUrl(endpointUrl);
+
+    if (!storageData.bucket) {
+      throw new BadRequestException(ErrorBucket.NotExist);
+    }
+
     const storageClient = new StorageClient({
       endPoint: storageData.endPoint,
       port: storageData.port,


### PR DESCRIPTION
## Description
Added new regular expressions to the URL parser. The URL parser must be able to work with the link type provided by AWS.

## Summary of changes
- Added new regex.
- Added error handling

## How test the changes
Send `POST http://127.0.0.1:5001/job/cvat`
with `dataUrl` param `https://cvat-test-dataset.s3.eu-west-1.amazonaws.com` or `https://s3.eu-west-1.amazonaws.com/cvat-test-dataset`

## Related issues
[[Job Launcher] Add AWS regex to url parser#1176](https://github.com/humanprotocol/human-protocol/issues/1176)