### PR TITLE
[Job Launcher] Temporarily disable signature for a CVAT webhook

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -427,9 +427,13 @@ export class JobService {
       this.configService.get(ConfigNames.WEB3_PRIVATE_KEY)!,
     );
     const { data } = await firstValueFrom(
-      await this.httpService.post(webhookUrl, webhookData, {
-        headers: { [HEADER_SIGNATURE_KEY]: signedBody },
-      }),
+      await this.httpService.post(
+        webhookUrl,
+        webhookData,
+        webhookData instanceof FortuneWebhookDto
+          ? { headers: { [HEADER_SIGNATURE_KEY]: signedBody } }
+          : undefined
+      ),
     );
 
     if (!data) {

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -430,9 +430,9 @@ export class JobService {
       await this.httpService.post(
         webhookUrl,
         webhookData,
-        webhookData instanceof FortuneWebhookDto
-          ? { headers: { [HEADER_SIGNATURE_KEY]: signedBody } }
-          : undefined
+        webhookData instanceof CVATWebhookDto
+          ? undefined
+          : { headers: { [HEADER_SIGNATURE_KEY]: signedBody } }
       ),
     );
 
@@ -645,15 +645,16 @@ export class JobService {
       }
       if (jobEntity.escrowAddress && jobEntity.status === JobStatus.LAUNCHED) {
         if ((manifest as CvatManifestDto)?.annotation?.type) {
+          const cvatWebhookData: CVATWebhookDto = {
+            escrow_address: jobEntity.escrowAddress,
+            chain_id: jobEntity.chainId,
+            event_type: EventType.ESCROW_CREATED,
+          };
           await this.sendWebhook(
             this.configService.get<string>(
               ConfigNames.CVAT_EXCHANGE_ORACLE_WEBHOOK_URL,
             )!,
-            {
-              escrow_address: jobEntity.escrowAddress,
-              chain_id: jobEntity.chainId,
-              event_type: EventType.ESCROW_CREATED,
-            },
+            cvatWebhookData,
           );
         }
       }


### PR DESCRIPTION
## Description

Temporarily disabled signature for a CVAT webhook. 
Reason: Job Launcher is sending webhooks right after escrow was created. CVAT Exchange Oracle during signature check is trying to fetch escrow data from the subgraph and throwing an error because subrgraph takes some time to sync with the node.
Also, because Job Launcher doesn't currently support webhook retries.

## Summary of changes

Temporarily disabled signature for a CVAT webhook. 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
