### PR TITLE
[Job Launcher] Show job results in job details

### DIFF
--- a/packages/apps/job-launcher/client/src/hooks/useJobDetails.ts
+++ b/packages/apps/job-launcher/client/src/hooks/useJobDetails.ts
@@ -1,9 +1,15 @@
 import useSWR from 'swr';
 import * as jobService from '../services/job';
+import { JobDetailsResults } from '../types';
 
 export const useJobDetails = (jobId: number) => {
   return useSWR(`human-protocol-job-${jobId}`, async () => {
     const job = await jobService.getJobDetails(jobId);
-    return job;
+    const jobData: JobDetailsResults = job;
+    try {
+      const results = await jobService.getJobResult(jobId);
+      jobData.results = results;
+    } catch {}
+    return jobData;
   });
 };

--- a/packages/apps/job-launcher/client/src/pages/Job/JobDetail/index.tsx
+++ b/packages/apps/job-launcher/client/src/pages/Job/JobDetail/index.tsx
@@ -1,10 +1,12 @@
 import { LoadingButton } from '@mui/lab';
-import { Box, Card, Grid, Stack, Typography } from '@mui/material';
+import { Box, Card, Grid, IconButton, Stack, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { CardTextRow } from '../../../components/CardTextRow';
 import { CopyAddressButton } from '../../../components/CopyAddressButton';
+import { CopyLinkIcon } from '../../../components/Icons/CopyLinkIcon';
+import { Table } from '../../../components/Table';
 import { useJobDetails } from '../../../hooks/useJobDetails';
 import { useSnackbar } from '../../../providers/SnackProvider';
 import * as jobService from '../../../services/job';
@@ -202,50 +204,57 @@ export default function JobDetail() {
           </Grid>
         </Grid>
       </Box>
-      {/*
-      TODO: Add this back in when we have a way to fetch the job solution
-      <Box sx={{ mt: 10 }}>
-        <Typography variant="h4" fontWeight={600}>
-          Job solutions
-        </Typography>
-        <Box sx={{ mt: 7 }}>
-          <Table
-            columns={[
-              {
-                id: 'workerAddress',
-                label: 'Worker Address',
-                render: ({ workerAddress }) => (
-                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    {workerAddress}
-                    <IconButton color="primary" sx={{ ml: 3 }}>
-                      <CopyLinkIcon />
-                    </IconButton>
-                  </Box>
-                ),
-              },
-              { id: 'fortune', label: 'Fortune' },
-            ]}
-            data={[
-              {
-                workerAddress: '0x670bCc966ddc4fE7136c8793617a2C4D22849827',
-                fortune: '1',
-              },
-              {
-                workerAddress: '0x670bCc966ddc4fE7136c8793617a2C4D22849827',
-                fortune: '1',
-              },
-              {
-                workerAddress: '0x670bCc966ddc4fE7136c8793617a2C4D22849827',
-                fortune: '1',
-              },
-              {
-                workerAddress: '0x670bCc966ddc4fE7136c8793617a2C4D22849827',
-                fortune: '1',
-              },
-            ]}
-          />
+      {data.results && (
+        <Box sx={{ mt: 10 }}>
+          <Typography variant="h4" fontWeight={600}>
+            Job solutions
+          </Typography>
+          <Box sx={{ mt: 7 }}>
+            {data.manifest.requestType === 'FORTUNE' && (
+              <Table
+                columns={[
+                  {
+                    id: 'workerAddress',
+                    label: 'Worker Address',
+                    render: ({ workerAddress }) => (
+                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        {workerAddress}
+                        <IconButton color="primary" sx={{ ml: 3 }}>
+                          <CopyLinkIcon />
+                        </IconButton>
+                      </Box>
+                    ),
+                  },
+                  { id: 'solution', label: 'Fortune' },
+                  {
+                    id: 'error',
+                    label: 'Status',
+                    render: ({ error }) => (error ? 'Refused' : 'Accepted'),
+                  },
+                  { id: 'error', label: 'Refused reason' },
+                ]}
+                data={data.results}
+              />
+            )}
+            {data.manifest.requestType !== 'FORTUNE' && (
+              <Box
+                sx={{
+                  borderRadius: '16px',
+                  background: '#fff',
+                  boxShadow:
+                    '0px 1px 5px 0px rgba(233, 235, 250, 0.20), 0px 2px 2px 0px rgba(233, 235, 250, 0.50), 0px 3px 1px -2px #E9EBFA',
+                  p: '14px 42px 18px',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <CardTextRow label="URL" value={data.results as string} />
+              </Box>
+            )}
+          </Box>
         </Box>
-      </Box> */}
+      )}
     </Box>
   );
 }

--- a/packages/apps/job-launcher/client/src/services/job.ts
+++ b/packages/apps/job-launcher/client/src/services/job.ts
@@ -7,6 +7,7 @@ import {
   CvatRequest,
   JobStatus,
   JobDetailsResponse,
+  FortuneFinalResult,
 } from '../types';
 import api from '../utils/api';
 
@@ -61,7 +62,9 @@ export const getJobList = async ({
 };
 
 export const getJobResult = async (jobId: number) => {
-  const { data } = await api.get(`/job/result`, { params: { jobId } });
+  const { data } = await api.get<FortuneFinalResult[] | string>(`/job/result`, {
+    params: { jobId },
+  });
   return data;
 };
 

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -135,3 +135,13 @@ export type JobDetailsResponse = {
     slashed: number;
   };
 };
+
+export type JobDetailsResults = JobDetailsResponse & {
+  results?: FortuneFinalResult[] | string;
+};
+
+export type FortuneFinalResult = {
+  exchangeAddress: string;
+  workerAddress: string;
+  solution: string;
+};


### PR DESCRIPTION
## Description

Show job results when exist

## Summary of changes

Make a request to the getResults endpoint to get solutions. In the Fortune case, display a table with the value and status. Otherwise, display the results URL.

## Related issues
#1219 

## Operational checklist

- [ ] All new functionality is covered by tests
- [ ] Any related documentation has been changed or added
