### PR TITLE
[JobLauncher Server] Added ApiKey decorator on getResult endpoint

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -82,6 +82,7 @@ export class JobController {
     );
   }
 
+  @ApiKey()
   @Get('/result')
   public async getResult(
     @Request() req: RequestWithUser,


### PR DESCRIPTION
## Description

This pull request introduces an important update to the Job Launcher module for our Discord app server. The main focus of this change is to integrate an apiKey decorator for the getResult API endpoint. 

## Summary of changes

Implemented an apiKey decorator in the getResult API endpoint.

## How test the changes

- Launch a Job: Use the updated Job Launcher to initiate a new job.
- Attempt Unauthorized Access: Try to access the getResult endpoint without the API key to verify that access is denied.
- Authorized Access Testing: Access the getResult endpoint with the correct API key and validate that the job results are correctly retrieved.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
