### PR TITLE
[Reputation Oracle] Decrypt Intermediate/Final Results/Manifest

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/config/env.ts
+++ b/packages/apps/reputation-oracle/server/src/common/config/env.ts
@@ -30,6 +30,8 @@ export const ConfigNames = {
   SENDGRID_FROM_NAME: 'SENDGRID_FROM_NAME',
   REPUTATION_LEVEL_LOW: 'REPUTATION_LEVEL_LOW',
   REPUTATION_LEVEL_HIGH: 'REPUTATION_LEVEL_HIGH',
+  ENCRYPTION_PRIVATE_KEY: 'ENCRYPTION_PRIVATE_KEY',
+  ENCRYPTION_PASSPHRASE: 'ENCRYPTION_PASSPHRASE',
 };
 
 export const envValidator = Joi.object({
@@ -70,4 +72,7 @@ export const envValidator = Joi.object({
   // Reputation Level
   REPUTATION_LEVEL_LOW: Joi.number().default(300),
   REPUTATION_LEVEL_HIGH: Joi.number().default(700),
+  // Encryption
+  ENCRYPTION_PRIVATE_KEY: Joi.string().default(''),
+  ENCRYPTION_PASSPHRASE: Joi.string().default(''),
 });

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.spec.ts
@@ -1,7 +1,9 @@
-import { ChainId, StorageClient } from '@human-protocol/sdk';
-import { ConfigModule, registerAs } from '@nestjs/config';
+import { ChainId, Encryption, StorageClient } from '@human-protocol/sdk';
+import { ConfigModule, ConfigService, registerAs } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import {
+  MOCK_ENCRYPTION_PASSPHRASE,
+  MOCK_ENCRYPTION_PRIVATE_KEY,
   MOCK_FILE_URL,
   MOCK_MANIFEST,
   MOCK_S3_ACCESS_KEY,
@@ -21,6 +23,9 @@ jest.mock('@human-protocol/sdk', () => ({
   StorageClient: {
     downloadFileFromUrl: jest.fn(),
   },
+  Encryption: {
+    build: jest.fn(),
+  },
 }));
 
 jest.mock('minio', () => {
@@ -39,10 +44,21 @@ jest.mock('minio', () => {
 
 jest.mock('axios');
 
-describe('Web3Service', () => {
+describe('StorageService', () => {
   let storageService: StorageService;
 
   beforeAll(async () => {
+    const mockConfigService: Partial<ConfigService> = {
+      get: jest.fn((key: string) => {
+        switch (key) {
+          case 'ENCRYPTION_PRIVATE_KEY':
+            return MOCK_ENCRYPTION_PRIVATE_KEY;
+          case 'ENCRYPTION_PASSPHRASE':
+            return MOCK_ENCRYPTION_PASSPHRASE;
+        }
+      }),
+    };
+
     const moduleRef = await Test.createTestingModule({
       imports: [
         ConfigModule.forFeature(
@@ -56,7 +72,10 @@ describe('Web3Service', () => {
           })),
         ),
       ],
-      providers: [StorageService],
+      providers: [
+        StorageService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
     }).compile();
 
     storageService = moduleRef.get<StorageService>(StorageService);
@@ -164,9 +183,37 @@ describe('Web3Service', () => {
 
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockResolvedValueOnce(expectedJobFile);
+        .mockResolvedValueOnce(JSON.stringify(expectedJobFile));
       const solutionsFile = await storageService.download(MOCK_FILE_URL);
-      expect(solutionsFile).toBe(expectedJobFile);
+      expect(solutionsFile).toStrictEqual(expectedJobFile);
+    });
+
+    it('should download the encrypted file correctly', async () => {
+      const exchangeAddress = '0x1234567890123456789012345678901234567892';
+      const workerAddress = '0x1234567890123456789012345678901234567891';
+      const solution = 'test';
+
+      const expectedJobFile = {
+        exchangeAddress,
+        solutions: [
+          {
+            workerAddress,
+            solution,
+          },
+        ],
+      };
+
+      StorageClient.downloadFileFromUrl = jest
+        .fn()
+        .mockResolvedValueOnce('encrypted');
+      Encryption.build = jest.fn().mockResolvedValue({
+        decrypt: jest
+          .fn()
+          .mockResolvedValueOnce(JSON.stringify(expectedJobFile)),
+      });
+
+      const solutionsFile = await storageService.download(MOCK_FILE_URL);
+      expect(solutionsFile).toStrictEqual(expectedJobFile);
     });
 
     it('should return empty array when file cannot be downloaded', async () => {

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
@@ -1,7 +1,7 @@
-import { ChainId, StorageClient } from '@human-protocol/sdk';
+import { ChainId, Encryption, StorageClient } from '@human-protocol/sdk';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import * as Minio from 'minio';
-import { S3ConfigType, s3ConfigKey } from '../../common/config';
+import { ConfigNames, S3ConfigType, s3ConfigKey } from '../../common/config';
 import crypto from 'crypto';
 import { UploadedFile } from '../../common/interfaces/s3';
 import { FortuneFinalResult } from '../webhook/webhook.dto';
@@ -9,6 +9,7 @@ import { PassThrough } from 'stream';
 import axios from 'axios';
 import { Logger } from '@nestjs/common';
 import { hashStream } from '../../common/utils';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class StorageService {
@@ -17,6 +18,7 @@ export class StorageService {
   constructor(
     @Inject(s3ConfigKey)
     private s3Config: S3ConfigType,
+    public readonly configService: ConfigService,
   ) {
     this.minioClient = new Minio.Client({
       endPoint: this.s3Config.endPoint,
@@ -34,7 +36,20 @@ export class StorageService {
 
   public async download(url: string): Promise<any> {
     try {
-      return await StorageClient.downloadFileFromUrl(url);
+      const fileContent = await StorageClient.downloadFileFromUrl(url);
+      try {
+        return JSON.parse(fileContent);
+      } catch {
+        const encryption = await Encryption.build(
+          this.configService.get<string>(
+            ConfigNames.ENCRYPTION_PRIVATE_KEY,
+            '',
+          ),
+          this.configService.get<string>(ConfigNames.ENCRYPTION_PASSPHRASE, ''),
+        );
+
+        return JSON.parse(await encryption.decrypt(fileContent));
+      }
     } catch {
       return [];
     }

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -257,7 +257,7 @@ describe('WebhookService', () => {
       webhookRepository.findOne = jest.fn().mockReturnValue(webhookEntity);
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockReturnValueOnce(fortuneManifest);
+        .mockReturnValueOnce(JSON.stringify(fortuneManifest));
       jest.spyOn(webhookService, 'handleWebhookError').mockResolvedValue();
 
       jest.spyOn(webhookService, 'processFortune').mockImplementation(() => {
@@ -272,7 +272,7 @@ describe('WebhookService', () => {
       webhookRepository.findOne = jest.fn().mockReturnValue(webhookEntity);
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockReturnValueOnce(fortuneManifest);
+        .mockReturnValueOnce(JSON.stringify(fortuneManifest));
       jest
         .spyOn(webhookService, 'processFortune')
         .mockResolvedValue(results as any);
@@ -284,7 +284,7 @@ describe('WebhookService', () => {
       webhookRepository.findOne = jest.fn().mockReturnValue(cvatManifest);
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockReturnValueOnce(cvatManifest);
+        .mockReturnValueOnce(JSON.stringify(cvatManifest));
       jest
         .spyOn(webhookService, 'processCvat')
         .mockResolvedValue(results as any);
@@ -299,7 +299,7 @@ describe('WebhookService', () => {
 
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockReturnValueOnce(fortuneManifest);
+        .mockReturnValueOnce(JSON.stringify(fortuneManifest));
       jest
         .spyOn(webhookService, 'processFortune')
         .mockResolvedValue(results as any);
@@ -442,24 +442,26 @@ describe('WebhookService', () => {
     it('should successfully process and return correct result values', async () => {
       const escrowAddress = MOCK_ADDRESS;
       const chainId = ChainId.LOCALHOST;
-      StorageClient.downloadFileFromUrl = jest.fn().mockReturnValueOnce({
-        jobs: [
-          {
-            id: 1,
-            job_id: 1,
-            annotator_wallet_address: MOCK_ADDRESS,
-            annotation_quality: 0.96,
-          },
-        ],
-        results: [
-          {
-            id: 2,
-            job_id: 2,
-            annotator_wallet_address: MOCK_ADDRESS,
-            annotation_quality: 0.96,
-          },
-        ],
-      });
+      StorageClient.downloadFileFromUrl = jest.fn().mockReturnValueOnce(
+        JSON.stringify({
+          jobs: [
+            {
+              id: 1,
+              job_id: 1,
+              annotator_wallet_address: MOCK_ADDRESS,
+              annotation_quality: 0.96,
+            },
+          ],
+          results: [
+            {
+              id: 2,
+              job_id: 2,
+              annotator_wallet_address: MOCK_ADDRESS,
+              annotation_quality: 0.96,
+            },
+          ],
+        }),
+      );
 
       jest
         .spyOn(storageService, 'copyFileFromURLToBucket')
@@ -525,7 +527,7 @@ describe('WebhookService', () => {
       webhookRepository.findOne = jest.fn().mockReturnValue(webhookEntity);
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockReturnValueOnce(fortuneManifest);
+        .mockReturnValueOnce(JSON.stringify(fortuneManifest));
       jest.spyOn(webhookService, 'handleWebhookError').mockResolvedValue();
 
       (EscrowClient.build as any).mockImplementation(() => ({
@@ -552,8 +554,8 @@ describe('WebhookService', () => {
       ];
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockResolvedValueOnce(fortuneManifest)
-        .mockResolvedValue(finalResults);
+        .mockResolvedValueOnce(JSON.stringify(fortuneManifest))
+        .mockResolvedValue(JSON.stringify(finalResults));
 
       (EscrowClient.build as any).mockImplementation(() => ({
         getManifestUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
@@ -605,7 +607,7 @@ describe('WebhookService', () => {
       webhookRepository.findOne = jest.fn().mockReturnValue(webhookEntity);
       StorageClient.downloadFileFromUrl = jest
         .fn()
-        .mockResolvedValueOnce(cvatManifest);
+        .mockResolvedValueOnce(JSON.stringify(cvatManifest));
 
       (EscrowClient.build as any).mockImplementation(() => ({
         getManifestUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),

--- a/packages/apps/reputation-oracle/server/test/constants.ts
+++ b/packages/apps/reputation-oracle/server/test/constants.ts
@@ -198,3 +198,6 @@ export const MOCK_S3_ACCESS_KEY = 'access_key';
 export const MOCK_S3_SECRET_KEY = 'secret_key';
 export const MOCK_S3_BUCKET = 'solution';
 export const MOCK_S3_USE_SSL = false;
+
+export const MOCK_ENCRYPTION_PRIVATE_KEY = 'private_key';
+export const MOCK_ENCRYPTION_PASSPHRASE = 'passphrase';


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
All those intermediate results, final results, and manifests are encrypted, so we need to decrypt it before we access it.

## Summary of changes
- Add decryption after downloading content from storage.
- Updated test cases.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #1039
