### PR TITLE
fix: faucet server build failing

### DIFF
--- a/packages/apps/faucet-server/package.json
+++ b/packages/apps/faucet-server/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@human-protocol/core": "*",
     "@skaleproject/pow-ethers": "^0.2.4",
-    "@types/express": "^4.17.14",
     "axios": "^1.3.4",
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
@@ -23,5 +22,9 @@
     "express-rate-limit": "^7.1.3",
     "node-cache": "^5.1.2",
     "web3": "^1.10.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4718,6 +4718,13 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
   integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
 
+"@types/cors@^2.8.17":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/crypto-js@^4.1.2":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.1.tgz#480edd76991a63050cb88db1a8840758c55a7135"


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Adding `@types/cors` dev dependency to the faucet server. The build is failing because of missing type definition.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #1341
