### PR TITLE
[Monorepo] [CD] Python SDK - use setuptools==68.2.2

### DIFF
--- a/.github/workflows/cd-node-sdk.yaml
+++ b/.github/workflows/cd-node-sdk.yaml
@@ -3,6 +3,11 @@ name: Node.js SDK NPM publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version to use'
+        required: true
 
 jobs:
   node-sdk-publish:
@@ -17,10 +22,18 @@ jobs:
         working-directory: ./packages/core
       - name: Change Node.js SDK version
         uses: jossef/action-set-json-field@v2
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           file: ./packages/sdk/typescript/human-protocol-sdk/package.json
           field: version
           value: ${{ github.event.release.tag_name }}
+      - name: Change Node.js SDK version
+        uses: jossef/action-set-json-field@v2
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          file: ./packages/sdk/typescript/human-protocol-sdk/package.json
+          field: version
+          value: ${{ github.event.inputs.release_version }}
       - run: yarn build
         name: Build SDK package
         working-directory: ./packages/sdk/typescript/human-protocol-sdk

--- a/.github/workflows/cd-python-sdk.yaml
+++ b/.github/workflows/cd-python-sdk.yaml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./packages/sdk/python/human-protocol-sdk
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install setuptools==68.2.2 wheel twine
       - name: Set the relase version
         uses: "DamianReeves/write-file-action@master"
         with:

--- a/.github/workflows/cd-python-sdk.yaml
+++ b/.github/workflows/cd-python-sdk.yaml
@@ -3,6 +3,11 @@ name: Python SDK publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version to use'
+        required: true
 
 jobs:
   publish-python-sdk:
@@ -24,13 +29,22 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools==68.2.2 wheel twine
-      - name: Set the relase version
+      - name: Set the release version
         uses: "DamianReeves/write-file-action@master"
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           path: ./packages/sdk/python/human-protocol-sdk/human_protocol_sdk/__init__.py
           write-mode: overwrite
           contents: |
             __version__ = "${{ github.event.release.tag_name }}"
+      - name: Set the release version
+        uses: "DamianReeves/write-file-action@master"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          path: ./packages/sdk/python/human-protocol-sdk/human_protocol_sdk/__init__.py
+          write-mode: overwrite
+          contents: |
+            __version__ = "${{ github.event.inputs.release_version }}"
       - name: Build and publish
         working-directory: ./packages/sdk/python/human-protocol-sdk
         env:


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Use `setuptools == 68.2.2`, since v69 has breaking changes.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
