### PR TITLE
[Job Launcher] Get operator address

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/web3/web3.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/web3/web3.controller.ts
@@ -31,4 +31,19 @@ export class Web3Controller {
   getValidChains(): ChainId[] {
     return this.web3Service.getValidChains();
   }
+
+  @ApiOperation({
+    summary: 'Get the address of the Job Launcher',
+    description: 'Endpoint to get the address of the Job Launcher.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Job Launcher address',
+    type: String,
+  })
+  @Public()
+  @Get('/operator-address')
+  getOperatorAddress(): string {
+    return this.web3Service.getOperatorAddress();
+  }
 }

--- a/packages/apps/job-launcher/server/src/modules/web3/web3.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/web3/web3.service.spec.ts
@@ -5,19 +5,18 @@ import { MAINNET_CHAIN_IDS, TESTNET_CHAIN_IDS } from '../../common/constants';
 import { ErrorWeb3 } from '../../common/constants/errors';
 import { Web3Env } from '../../common/enums/web3';
 import { Web3Service } from './web3.service';
+import { MOCK_ADDRESS, MOCK_PRIVATE_KEY } from './../../../test/constants';
 
 describe('Web3Service', () => {
   let mockConfigService: Partial<ConfigService>;
   let web3Service: Web3Service;
-  const privateKey =
-    '5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 
   beforeAll(async () => {
     mockConfigService = {
       get: jest.fn((key: string, defaultValue?: any) => {
         switch (key) {
           case 'WEB3_PRIVATE_KEY':
-            return privateKey;
+            return MOCK_PRIVATE_KEY;
           case 'WEB3_ENV':
             return 'testnet';
           default:
@@ -67,6 +66,13 @@ describe('Web3Service', () => {
       mockConfigService.get = jest.fn().mockReturnValue(Web3Env.TESTNET);
       const validChainIds = web3Service.getValidChains();
       expect(validChainIds).toBe(TESTNET_CHAIN_IDS);
+    });
+  });
+
+  describe('getOperatorAddress', () => {
+    it('should get the operator address', () => {
+      const operatorAddress = web3Service.getOperatorAddress();
+      expect(operatorAddress).toBe(MOCK_ADDRESS);
     });
   });
 });

--- a/packages/apps/job-launcher/server/src/modules/web3/web3.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/web3/web3.service.ts
@@ -69,4 +69,8 @@ export class Web3Service {
 
     return 1n;
   }
+
+  public getOperatorAddress(): string {
+    return Object.values(this.signers)[0].address;
+  }
 }


### PR DESCRIPTION
## Description

Create an endpoint to retrieve the job launcher address

## Summary of changes

Create a new endpoint inside web3 controller
Create a new method to return the address in web3 service

## How test the changes

`yarn test`

## Related issues
#1484 
