### PR TITLE
Reputation Oracle - Fix cron jobs

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index } from 'typeorm';
+import { BeforeInsert, Column, Entity, Index } from 'typeorm';
 
 import { NS } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
@@ -19,4 +19,12 @@ export class CronJobEntity extends BaseEntity implements ICronJob {
 
   @Column({ type: 'timestamptz', nullable: true })
   public completedAt?: Date | null;
+
+  @BeforeInsert()
+  public beforeInsert(): void {
+    const date = new Date();
+    this.startedAt = date;
+    this.createdAt = date;
+    this.updatedAt = date;
+  }
 }


### PR DESCRIPTION
## Description
StartedAt from CronJobEntity cannot be null and needs to be initialized before inserting it.

