### PR TITLE
[Reputation Oracle] feat: secure cron job [#1663]

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/config/env.ts
+++ b/packages/apps/reputation-oracle/server/src/common/config/env.ts
@@ -38,6 +38,7 @@ export const ConfigNames = {
   PGP_ENCRYPT: 'PGP_ENCRYPT',
   SYNAPS_API_KEY: 'SYNAPS_API_KEY',
   SYNAPS_WEBHOOK_SECRET: 'SYNAPS_WEBHOOK_SECRET',
+  CRON_SECRET: 'CRON_SECRET',
 };
 
 export const envValidator = Joi.object({
@@ -88,4 +89,6 @@ export const envValidator = Joi.object({
   // Synaps Kyc
   SYNAPS_API_KEY: Joi.string().required(),
   SYNAPS_WEBHOOK_SECRET: Joi.string().required(),
+  // Cron Secret
+  CRON_SECRET: Joi.string().required(),
 });

--- a/packages/apps/reputation-oracle/server/src/common/guards/cron.auth.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/cron.auth.ts
@@ -1,0 +1,26 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ConfigNames } from '../config';
+
+@Injectable()
+export class CronAuthGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    if (
+      request.headers['authorization'] ===
+      `Bearer ${this.configService.get(ConfigNames.CRON_SECRET)}`
+    ) {
+      return true;
+    }
+
+    throw new UnauthorizedException('Unauthorized');
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron.job.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron.job.controller.ts
@@ -1,7 +1,13 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Public } from '../../common/decorators';
 import { CronJobService } from './cron-job.service';
+import { CronAuthGuard } from '../../common/guards/cron.auth';
 
 @Public()
 @ApiTags('Cron')
@@ -19,6 +25,8 @@ export class CronJobController {
     status: 200,
     description: 'Pending cron jobs processed successfully',
   })
+  @ApiBearerAuth()
+  @UseGuards(CronAuthGuard)
   public async processPendingCronJob(): Promise<void> {
     await this.cronJobService.processPendingWebhooks();
     return;
@@ -35,6 +43,8 @@ export class CronJobController {
     status: 200,
     description: 'Paid cron jobs processed successfully',
   })
+  @ApiBearerAuth()
+  @UseGuards(CronAuthGuard)
   public async processPaidCronJob(): Promise<void> {
     await this.cronJobService.processPaidWebhooks();
     return;

--- a/packages/apps/reputation-oracle/server/vercel.json
+++ b/packages/apps/reputation-oracle/server/vercel.json
@@ -19,11 +19,11 @@
   ],
   "crons": [
     {
-      "path": "/webhook/cron/pending",
+      "path": "/cron/webhook/pending",
       "schedule": "*/1 * * * *"
     },
     {
-      "path": "/webhook/cron/paid",
+      "path": "/cron/webhook/paid",
       "schedule": "*/1 * * * *"
     }
   ],


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
We need to secure cron jobs triggered by Vercel by adding `CRON_SECRET` env variable.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Added new `CronAuthGuard` to cron job endpoints.
- Fixed `vercel.json` to trigger correct endpoint for cron jobs.

## How test the changes

<!-- If there are any special testing requirements, add them here -->
- Tested triggering cron endpoints on local environment with bearer auth header. This auth header will be set by Vercel automatically on production.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #1663