### PR TITLE
[Job Launcher] Quick launch

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -17,7 +17,7 @@ export enum ErrorJob {
   TaskDataNotFound = 'Task data not found',
   HCaptchaInvalidJobType = 'hCaptcha invalid job type',
   GroundThuthValidationFailed = 'Ground thuth validation failed',
-  ManifestHashNotExist = 'Manifest does hash not exist',
+  ManifestHashNotExist = 'Manifest hash does not exist',
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -17,6 +17,7 @@ export enum ErrorJob {
   TaskDataNotFound = 'Task data not found',
   HCaptchaInvalidJobType = 'hCaptcha invalid job type',
   GroundThuthValidationFailed = 'Ground thuth validation failed',
+  ManifestHashNotExist = 'Manifest hash not exist',
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -17,7 +17,7 @@ export enum ErrorJob {
   TaskDataNotFound = 'Task data not found',
   HCaptchaInvalidJobType = 'hCaptcha invalid job type',
   GroundThuthValidationFailed = 'Ground thuth validation failed',
-  ManifestHashNotExist = 'Manifest hash not exist',
+  ManifestHashNotExist = 'Manifest does hash not exist',
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/common/utils/index.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/index.ts
@@ -43,6 +43,7 @@ export const parseUrl = (
   region: string;
   useSSL: boolean;
   filename?: string;
+  extension?: string;
   port?: number;
 } => {
   const patterns = [
@@ -70,7 +71,7 @@ export const parseUrl = (
   ];
 
   for (const { regex, endPoint, port } of patterns) {
-    const match = url.match(regex);
+    let match = url.match(regex);
 
     if (match) {
       const [, param1, param2, path] = match;
@@ -79,21 +80,31 @@ export const parseUrl = (
         parts[0] || (patterns[2].regex === regex ? param2 : param1);
       const filename = parts.length > 1 ? parts[parts.length - 1] : undefined;
 
-      let region = '';
-      if (regex === patterns[2].regex) {
-        region = param1;
-      } else if (regex === patterns[3].regex) {
-        region = param2;
-      }
-
-      return {
+      const data = {
         useSSL: url.startsWith('https:'),
         endPoint: endPoint.replace('$1', param1),
-        region,
+        region: '',
         port: port && param2 ? Number(param2) || undefined : undefined,
         bucket,
-        filename,
+        filename: '',
+        extension: '',
       };
+
+      if (regex === patterns[2].regex) {
+        data.region = param1;
+      } else if (regex === patterns[3].regex) {
+        data.region = param2;
+      }
+
+      if (filename) {
+        match = filename.match(/([^\/]+)\.([^.\/]+)$/);
+        if (match && match.length > 1) {
+          data.filename = match[1];
+          data.extension = match[2];
+        }
+      }
+
+      return data;
     }
   }
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -50,7 +50,7 @@ export class JobController {
   })
   @ApiBody({ type: JobQuickLaunchDto })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description:
       'ID of the created job with pre-definde manifest url via quick launch.',
     type: Number,
@@ -82,7 +82,7 @@ export class JobController {
   })
   @ApiBody({ type: JobFortuneDto })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description: 'ID of the created fortune job.',
     type: Number,
   })
@@ -113,7 +113,7 @@ export class JobController {
   })
   @ApiBody({ type: JobCvatDto })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description: 'ID of the created CVAT job.',
     type: Number,
   })
@@ -143,7 +143,7 @@ export class JobController {
   })
   @ApiBody({ type: JobCaptchaDto })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description: 'ID of the created hCaptcha job.',
     type: Number,
   })

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -30,6 +30,7 @@ import {
   JobIdDto,
   FortuneFinalResultDto,
   JobCaptchaDto,
+  JobQuickLaunchDto,
 } from './job.dto';
 import { JobService } from './job.service';
 import { JobRequestType, JobStatusFilter } from '../../common/enums/job';
@@ -42,6 +43,38 @@ import { ChainId } from '@human-protocol/sdk';
 @Controller('/job')
 export class JobController {
   constructor(private readonly jobService: JobService) {}
+
+  @ApiOperation({
+    summary: 'Create a job via quick launch',
+    description: 'Endpoint to create a new job using pre-definde manifest url.',
+  })
+  @ApiBody({ type: JobQuickLaunchDto })
+  @ApiResponse({
+    status: 200,
+    description:
+      'ID of the created job with pre-definde manifest url via quick launch.',
+    type: Number,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad Request. Invalid input parameters.',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized. Missing or invalid credentials.',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Conflict. Conflict with the current state of the server.',
+  })
+  @Post('/quick-launch')
+  @ApiKey()
+  public async quickLaunch(
+    @Request() req: RequestWithUser,
+    @Body() data: JobQuickLaunchDto,
+  ): Promise<number> {
+    return this.jobService.createJob(req.user.id, data.requestType, data);
+  }
 
   @ApiOperation({
     summary: 'Create a fortune job',

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -80,6 +80,31 @@ export class JobDto {
   public chainId?: ChainId;
 }
 
+export class JobQuickLaunchDto extends JobDto {
+  @ApiProperty({
+    description: 'Request type',
+    name: 'request_type',
+    enum: JobRequestType,
+  })
+  @IsEnum(JobRequestType)
+  public requestType: JobRequestType;
+
+  @ApiProperty({ name: 'manifest_url' })
+  @IsString()
+  @IsNotEmpty()
+  public manifestUrl: string;
+
+  @ApiProperty({ name: 'manifest_hash' })
+  @IsString()
+  @IsOptional()
+  public manifestHash: string;
+
+  @ApiProperty({ name: 'fund_amount' })
+  @IsNumber()
+  @IsPositive()
+  public fundAmount: number;
+}
+
 export class JobFortuneDto extends JobDto {
   @ApiProperty({ name: 'requester_title' })
   @IsString()
@@ -747,4 +772,8 @@ class TaskData {
   datapoint_text?: DatapointText;
 }
 
-export type CreateJob = JobFortuneDto | JobCvatDto | JobCaptchaDto;
+export type CreateJob =
+  | JobQuickLaunchDto
+  | JobFortuneDto
+  | JobCvatDto
+  | JobCaptchaDto;

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -90,7 +90,7 @@ export class JobQuickLaunchDto extends JobDto {
   public requestType: JobRequestType;
 
   @ApiProperty({ name: 'manifest_url' })
-  @IsString()
+  @IsUrl()
   @IsNotEmpty()
   public manifestUrl: string;
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
@@ -8,4 +8,12 @@ export interface RequestAction {
     requestType: JobRequestType,
     fundAmount: number,
   ) => Promise<any>;
+  getTrustedHandlers: () => string[];
+  getOracleAddresses: () => OracleAddresses;
+}
+
+export interface OracleAddresses {
+  exchangeOracle: string;
+  recordingOracle: string;
+  reputationOracle: string;
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
@@ -8,7 +8,13 @@ export interface RequestAction {
     requestType: JobRequestType,
     fundAmount: number,
   ) => Promise<any>;
+}
+
+export interface EscrowAction {
   getTrustedHandlers: () => string[];
+}
+
+export interface OracleAction {
   getOracleAddresses: () => OracleAddresses;
 }
 


### PR DESCRIPTION
## Description
Implemented a generic method to JL that can **create/fund/setup** an escrow using the provided manifest. The result of the call will be the escrow address.

## Summary of changes
- [x] Implemented new endpoint `/job/quick-launch`.
- [x] Updated service method `createJob`.
- [x] Added manifest hash
- [x] Added trusted handlers
- [x] Unit tests.
- [x] Improved parseUrl separate filename and extension.

## How test the changes
**POST** `/job/quick-launch`
```
{
  "chain_id": 80001,
  "request_type": "FORTUNE",
  "manifest_url": <URL>,
  "fund_amount": 1
}
```
`yarn test`

## Related issues
[[Job Launcher] Integrate quick-launch feature #1660](https://github.com/humanprotocol/human-protocol/issues/1660)