### PR TITLE
Changed mineNBlocks function to use more efficient way to mine blocks

### DIFF
--- a/packages/core/test/GovernanceUtils.ts
+++ b/packages/core/test/GovernanceUtils.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { Signer } from 'ethers';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
 import {
   MetaHumanGovernor,
   VHMToken,
@@ -16,13 +17,7 @@ import {
 let owner: Signer;
 
 export const mineNBlocks = async (n: number) => {
-  await Promise.all(
-    Array(n)
-      .fill(0)
-      .map(async () => {
-        await ethers.provider.send('evm_mine', []);
-      })
-  );
+  await mine(n);
 };
 
 export async function createMockUserWithVotingPower(


### PR DESCRIPTION
## Description

This change speeds up hardhat tests execution in `packages/core` by around 100x times.

On my local machine, it went from `712.65s` to `7.32s`

## Summary of changes

Used a more efficient way to mine blocks.

## How test the changes

`yarn run test`