### PR TITLE
[Job Launcher] Improved JwtAuthGuard

### DIFF
--- a/packages/apps/job-launcher/server/src/common/exceptions/auth.filter.ts
+++ b/packages/apps/job-launcher/server/src/common/exceptions/auth.filter.ts
@@ -19,6 +19,7 @@ export class AuthExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
 
     let status = HttpStatus.FORBIDDEN;
+
     if (exception.message === ErrorUser.NotFound) {
       status = HttpStatus.NO_CONTENT;
     }

--- a/packages/apps/job-launcher/server/src/common/guards/apikey.auth.ts
+++ b/packages/apps/job-launcher/server/src/common/guards/apikey.auth.ts
@@ -31,6 +31,7 @@ export class ApiKeyGuard implements CanActivate {
               Number(apiKeyId),
               apiKey,
             );
+
           if (userWithApiKey) {
             request.user = userWithApiKey;
             return true;
@@ -42,7 +43,6 @@ export class ApiKeyGuard implements CanActivate {
         throw new UnauthorizedException('Invalid API Key format');
       }
     }
-
     return false;
   }
 }


### PR DESCRIPTION
## Description
Fix returned status code when auth token has expired: 403 -> 401.


## Summary of changes
- [x] Update auth interceptor and returned correct code.

## How test the changes
1. `POST /auth/signin`
2. Wait for the authorization token to expire.
3. Send any auth request

## Related issues
[Job Launcher] Fix returned status code when auth token has expired: 403 -> 401
[#1715](https://github.com/humanprotocol/human-protocol/issues/1715)
