### PR TITLE
[Job Launcher] Fix get details

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1197,8 +1197,8 @@ export class JobService {
     } else {
       manifest = manifest as CvatManifestDto;
       specificManifestDetails = {
-        requestType: manifest.annotation.type,
-        submissionsRequired: manifest.annotation.job_size,
+        requestType: manifest.annotation?.type,
+        submissionsRequired: manifest.annotation?.job_size,
       };
     }
 


### PR DESCRIPTION
## Description
Fixed the getDetails method to be able to return job data correctly.

## Summary of changes
Added handlers for nested properties.

## How test the changes
Creates a new job using the `/job/quick-launch` endpoint with a request type other than IMAGE_POINTS or IMAGE_BOXES and invalid manifest, and call `/job/details/:jobId`, it will return data without 500 error.

## Related issues
[Job Launcher] Fix the getDetails method to be able to return job data correctly
[#1714](https://github.com/humanprotocol/human-protocol/issues/1714)