### PR TITLE
[Job Launcher] escrow_created webhook

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -497,7 +497,6 @@ describe('CronJobService', () => {
     let fundEscrowMock: any;
     let cronJobEntityMock: Partial<CronJobEntity>;
     let jobEntityMock1: Partial<JobEntity>, jobEntityMock2: Partial<JobEntity>;
-    let createWebhookMock: any;
 
     beforeEach(() => {
       cronJobEntityMock = {
@@ -537,8 +536,6 @@ describe('CronJobService', () => {
       fundEscrowMock.mockResolvedValue(true);
 
       jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
-
-      createWebhookMock = jest.spyOn(webhookRepository, 'createUnique');
 
       const cvatManifestMock: DeepPartial<CvatManifestDto> = {
         data: {
@@ -584,7 +581,6 @@ describe('CronJobService', () => {
       await service.fundEscrowCronJob();
 
       expect(fundEscrowMock).toHaveBeenCalledTimes(2);
-      expect(createWebhookMock).toHaveBeenCalledTimes(2);
     });
 
     it('should increase retriesCount by 1, if the job fund fails', async () => {
@@ -595,8 +591,6 @@ describe('CronJobService', () => {
       expect(fundEscrowMock).toHaveBeenCalledTimes(2);
       expect(jobEntityMock1.retriesCount).toBe(2);
       expect(jobEntityMock2.retriesCount).toBe(1);
-
-      expect(createWebhookMock).toHaveBeenCalledTimes(1);
     });
 
     it('should mark job as failed if the job fund fails more than max retries count', async () => {
@@ -608,8 +602,6 @@ describe('CronJobService', () => {
       expect(fundEscrowMock).toHaveBeenCalledTimes(2);
       expect(jobEntityMock1.status).toBe(JobStatus.FAILED);
       expect(jobEntityMock2.status).toBe(JobStatus.SET_UP);
-
-      expect(createWebhookMock).toHaveBeenCalledTimes(1);
     });
 
     it('should complete the cron job entity on database to unlock', async () => {

--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -14,7 +14,7 @@ import {
   OracleType,
   WebhookStatus,
 } from '../../common/enums/webhook';
-import { CvatManifestDto, FortuneManifestDto } from '../job/job.dto';
+import { FortuneManifestDto } from '../job/job.dto';
 import { PaymentService } from '../payment/payment.service';
 import { ethers } from 'ethers';
 import { WebhookRepository } from '../webhook/webhook.repository';
@@ -154,22 +154,6 @@ export class CronJobService {
       for (const jobEntity of jobEntities) {
         try {
           await this.jobService.fundEscrow(jobEntity);
-
-          const manifest = await this.storageService.download(
-            jobEntity.manifestUrl,
-          );
-
-          if ((manifest as CvatManifestDto)?.annotation?.type) {
-            const webhookEntity = new WebhookEntity();
-            Object.assign(webhookEntity, {
-              escrowAddress: jobEntity.escrowAddress,
-              chainId: jobEntity.chainId,
-              eventType: EventType.ESCROW_CREATED,
-              oracleType: OracleType.CVAT,
-              hasSignature: false,
-            });
-            await this.webhookRepository.createUnique(webhookEntity);
-          }
         } catch (err) {
           this.logger.error(`Error funding escrow: ${err.message}`);
           await this.jobService.handleProcessJobFailure(jobEntity);

--- a/packages/apps/job-launcher/server/src/modules/job/job.module.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.module.ts
@@ -13,10 +13,12 @@ import { RoutingProtocolService } from './routing-protocol.service';
 import { EncryptionModule } from '../encryption/encryption.module';
 import { StorageModule } from '../storage/storage.module';
 import { AuthModule } from '../auth/auth.module';
+import { WebhookEntity } from '../webhook/webhook.entity';
+import { WebhookRepository } from '../webhook/webhook.repository';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([JobEntity]),
+    TypeOrmModule.forFeature([JobEntity, WebhookEntity]),
     ConfigModule,
     HttpModule,
     AuthModule,
@@ -26,7 +28,13 @@ import { AuthModule } from '../auth/auth.module';
     StorageModule,
   ],
   controllers: [JobController],
-  providers: [Logger, JobService, JobRepository, RoutingProtocolService],
+  providers: [
+    Logger,
+    JobService,
+    JobRepository,
+    RoutingProtocolService,
+    WebhookRepository,
+  ],
   exports: [JobService],
 })
 export class JobModule {}

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -114,6 +114,8 @@ import {
   OracleAddresses,
   RequestAction,
 } from './job.interface';
+import { WebhookEntity } from '../webhook/webhook.entity';
+import { WebhookRepository } from '../webhook/webhook.repository';
 
 @Injectable()
 export class JobService {
@@ -125,6 +127,7 @@ export class JobService {
     @Inject(Web3Service)
     private readonly web3Service: Web3Service,
     public readonly jobRepository: JobRepository,
+    public readonly webhookRepository: WebhookRepository,
     private readonly paymentService: PaymentService,
     private readonly paymentRepository: PaymentRepository,
     public readonly configService: ConfigService,
@@ -744,6 +747,16 @@ export class JobService {
 
     jobEntity.status = JobStatus.LAUNCHED;
     await this.jobRepository.updateOne(jobEntity);
+
+    const webhookEntity = new WebhookEntity();
+    Object.assign(webhookEntity, {
+      escrowAddress: jobEntity.escrowAddress,
+      chainId: jobEntity.chainId,
+      eventType: EventType.ESCROW_CREATED,
+      oracleType: OracleType.CVAT,
+      hasSignature: false,
+    });
+    await this.webhookRepository.createUnique(webhookEntity);
 
     return jobEntity;
   }


### PR DESCRIPTION
## Description

Send escrow_created webhook when the escrow is completed also in Fortune

## Summary of changes

Remove the restriction of the webhook only for CVAT 
Move the webhook from cron-job.service.ts to job.service.ts

## How test the changes

`yarn test`

## Related issues
#1741
