### PR TITLE
Job Launcher - Fix crossed value

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -606,8 +606,8 @@ export class JobService {
         manifestOrigin,
       );
 
-      jobEntity.manifestHash = url;
-      jobEntity.manifestUrl = hash;
+      jobEntity.manifestUrl = url;
+      jobEntity.manifestHash = hash;
     }
 
     jobEntity.chainId = chainId;


### PR DESCRIPTION
## Description
The value of the hash was saved as url and the other way around
