### PR TITLE
Fix oracles webhook

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.spec.ts
@@ -163,7 +163,7 @@ describe('WebhookService', () => {
         .mockResolvedValue(MOCK_EXCHANGE_ORACLE_WEBHOOK_URL);
       jest.spyOn(httpService as any, 'post').mockImplementation(() => {
         return of({
-          status: HttpStatus.OK,
+          status: HttpStatus.CREATED,
         });
       });
       expect(await (webhookService as any).sendWebhook(webhookEntity)).toBe(
@@ -189,7 +189,7 @@ describe('WebhookService', () => {
         .mockResolvedValue(MOCK_EXCHANGE_ORACLE_WEBHOOK_URL);
       jest.spyOn(httpService as any, 'post').mockImplementation(() => {
         return of({
-          status: HttpStatus.OK,
+          status: HttpStatus.CREATED,
         });
       });
       expect(await (webhookService as any).sendWebhook(webhookEntity)).toBe(
@@ -215,7 +215,7 @@ describe('WebhookService', () => {
         .mockResolvedValue(MOCK_EXCHANGE_ORACLE_WEBHOOK_URL);
       jest.spyOn(httpService as any, 'post').mockImplementation(() => {
         return of({
-          status: HttpStatus.OK,
+          status: HttpStatus.CREATED,
         });
       });
       expect(await (webhookService as any).sendWebhook(webhookEntity)).toBe(

--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.spec.ts
@@ -138,7 +138,7 @@ describe('WebhookService', () => {
         .mockResolvedValue(MOCK_EXCHANGE_ORACLE_WEBHOOK_URL);
       jest.spyOn(httpService as any, 'post').mockImplementation(() => {
         return of({
-          status: HttpStatus.OK,
+          status: HttpStatus.CREATED,
         });
       });
       expect(await (webhookService as any).sendWebhook(webhookEntity)).toBe(

--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.ts
@@ -89,7 +89,7 @@ export class WebhookService {
     );
 
     // Check if the request was successful.
-    if (status !== HttpStatus.OK) {
+    if (status !== HttpStatus.CREATED) {
       this.logger.log(ErrorWebhook.NotSent, WebhookService.name);
       throw new NotFoundException(ErrorWebhook.NotSent);
     }

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -181,7 +181,7 @@ describe('WebhookService', () => {
     it('should successfully send a webhook', async () => {
       jest.spyOn(httpService as any, 'post').mockImplementation(() => {
         return of({
-          status: HttpStatus.OK,
+          status: HttpStatus.CREATED,
         });
       });
       expect(

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -95,7 +95,7 @@ export class WebhookService {
       }),
     );
 
-    if (status !== HttpStatus.OK) {
+    if (status !== HttpStatus.CREATED) {
       this.logger.log(ErrorWebhook.NotSent, WebhookService.name);
       throw new NotFoundException(ErrorWebhook.NotSent);
     }


### PR DESCRIPTION
## Description

Oracles webhooks callings are waiting for a 200 response, but the endpoint returns a 201

## Summary of changes

Switch the expected status code from 200 to 201

## How test the changes

yarn test
