### PR TITLE
[Job Launcher] Fix unique index in Webhook table

### DIFF
--- a/packages/apps/job-launcher/server/src/database/migrations/1711705135695-updateWebhookIndex.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1711705135695-updateWebhookIndex.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateWebhookIndex1711705135695 implements MigrationInterface {
+  name = 'UpdateWebhookIndex1711705135695';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DROP INDEX "hmt"."IDX_7449312cababf4bb89c681e986"
+        `);
+    await queryRunner.query(`
+            CREATE UNIQUE INDEX "IDX_012a8481fc9980fcc49f3f0dc2" ON "hmt"."webhook" ("chain_id", "escrow_address", "event_type")
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DROP INDEX "hmt"."IDX_012a8481fc9980fcc49f3f0dc2"
+        `);
+    await queryRunner.query(`
+            CREATE UNIQUE INDEX "IDX_7449312cababf4bb89c681e986" ON "hmt"."webhook" ("chain_id", "escrow_address")
+        `);
+  }
+}

--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -218,9 +218,7 @@ export class CronJobService {
               chainId: jobEntity.chainId,
               eventType: EventType.ESCROW_CANCELED,
               oracleType,
-              hasSignature:
-                (manifest as FortuneManifestDto).requestType ===
-                JobRequestType.FORTUNE,
+              hasSignature: true,
             });
             await this.webhookRepository.createUnique(webhookEntity);
           }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -815,7 +815,7 @@ export class JobService {
       chainId: jobEntity.chainId,
       eventType: EventType.ESCROW_CREATED,
       oracleType: oracleType,
-      hasSignature: oracleType === OracleType.FORTUNE,
+      hasSignature: oracleType !== OracleType.HCAPTCHA ? true : false,
     });
     await this.webhookRepository.createUnique(webhookEntity);
 

--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.entity.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.entity.ts
@@ -10,7 +10,7 @@ import {
 import { ChainId } from '@human-protocol/sdk';
 
 @Entity({ schema: NS, name: 'webhook' })
-@Index(['chainId', 'escrowAddress'], { unique: true })
+@Index(['chainId', 'escrowAddress', 'eventType'], { unique: true })
 export class WebhookEntity extends BaseEntity {
   @Column({ type: 'int' })
   public chainId: ChainId;

--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.ts
@@ -89,7 +89,7 @@ export class WebhookService {
     );
 
     // Check if the request was successful.
-    if (status !== HttpStatus.CREATED) {
+    if (status !== HttpStatus.CREATED && status !== HttpStatus.OK) {
       this.logger.log(ErrorWebhook.NotSent, WebhookService.name);
       throw new NotFoundException(ErrorWebhook.NotSent);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Fixes unique index in webhook schema.
Minor updates.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
1. Added `eventType` to unique index in Webhook schema to avoid getting DB duplication errors upon escrow cancellation.
2. Enabled webhook signature for CVAT oracles
3. Check not only for 201 status but for 200 too when webhook is being sent

## Related issues
To close #1785 

<!-- Does this close any open issues? -->
