### PR TITLE
[Job Launcher] Fixed incorrect if statement in `escrowFailedWebhook` method

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1225,8 +1225,8 @@ export class JobService {
 
   public async escrowFailedWebhook(dto: WebhookDataDto): Promise<void> {
     if (
-      dto.eventType !==
-      (EventType.ESCROW_FAILED || EventType.TASK_CREATION_FAILED)
+      dto.eventType !== EventType.ESCROW_FAILED &&
+      dto.eventType !== EventType.TASK_CREATION_FAILED
     ) {
       this.logger.log(ErrorJob.InvalidEventType, JobService.name);
       throw new BadRequestException(ErrorJob.InvalidEventType);


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Fixing a bug when Job Launcher throws an error in case of a `task_creation_failed` event type.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
Changed incorrect if statement in `escrowFailedWebhook` method

## Related issues
To close #1794 
