### PR TITLE
[Reputation Oracle] Fixed create incoming webhook method

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -106,7 +106,7 @@ describe('WebhookService', () => {
 
       await webhookService.createIncomingWebhook(validDto);
 
-      expect(webhookRepository.create).toHaveBeenCalled();
+      expect(webhookRepository.createUnique).toHaveBeenCalled();
       expect(webhookEntity.status).toBe(WebhookStatus.PENDING);
       expect(webhookEntity.retriesCount).toBe(0);
       expect(webhookEntity.waitUntil).toBeInstanceOf(Date);
@@ -131,7 +131,9 @@ describe('WebhookService', () => {
         eventType: EventType.TASK_COMPLETED,
       };
 
-      jest.spyOn(webhookRepository as any, 'create').mockResolvedValue(null);
+      jest
+        .spyOn(webhookRepository as any, 'createUnique')
+        .mockResolvedValue(null);
 
       await expect(
         webhookService.createIncomingWebhook(validDto),

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -41,13 +41,14 @@ export class WebhookService {
         throw new BadRequestException(ErrorWebhook.InvalidEventType);
       }
 
-      const webhookEntity = await this.webhookRepository.create({
-        chainId: dto.chainId,
-        escrowAddress: dto.escrowAddress,
-        status: WebhookStatus.PENDING,
-        waitUntil: new Date(),
-        retriesCount: 0,
-      });
+      let webhookEntity = new WebhookIncomingEntity();
+      webhookEntity.chainId = dto.chainId;
+      webhookEntity.escrowAddress = dto.escrowAddress;
+      webhookEntity.status = WebhookStatus.PENDING;
+      webhookEntity.waitUntil = new Date();
+      webhookEntity.retriesCount = 0;
+
+      webhookEntity = await this.webhookRepository.createUnique(webhookEntity);
 
       if (!webhookEntity) {
         this.logger.log(ErrorWebhook.NotCreated, WebhookService.name);


### PR DESCRIPTION
## Description
The webhook was not created after the call. Method `this.webhookRepository.create(...)` did not work as expected.

## Summary of changes
`this.webhookRepository.create(...)` has been changed to `this.webhookRepository.createUnique(...)`

## Related issues
[Reputation Oracle] Fix create incoming webgook method
[#1799](https://github.com/humanprotocol/human-protocol/issues/1799)
