### PR TITLE
[Job Launcher] Refactored calculate job bounty method

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
@@ -15,11 +15,6 @@ export interface ManifestAction {
     requestType: JobRequestType,
     data: CvatDataDto,
   ) => Promise<number>;
-  calculateJobBounty: (
-    elementsCount: number,
-    fundAmount: number,
-    nodesTotal?: number,
-  ) => Promise<string>;
 }
 
 export interface EscrowAction {
@@ -34,4 +29,11 @@ export interface OracleAddresses {
   exchangeOracle: string;
   recordingOracle: string;
   reputationOracle: string;
+}
+
+export class CvatCalculateJobBounty {
+  requestType: JobRequestType;
+  elementsCount: number;
+  fundAmount: number;
+  nodesTotal?: number;
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -530,7 +530,7 @@ describe('JobService', () => {
     it('should create a valid CVAT manifest for image boxes job type', async () => {
       const jobBounty = '50';
       jest
-        .spyOn(jobService, 'calculateCvatJobBounty')
+        .spyOn(jobService, 'calculateJobBounty')
         .mockResolvedValueOnce(jobBounty);
 
       const dto: JobCvatDto = {
@@ -1088,15 +1088,28 @@ describe('JobService', () => {
     });
   });
 
-  describe('calculateCvatJobBounty', () => {
-    it('should calculate the job bounty correctly', async () => {
-      const tokenFundAmount = 0.013997056833333334;
-      const result = await jobService['calculateCvatJobBounty'](
-        6,
-        tokenFundAmount,
-      );
+  describe('calculateJobBounty', () => {
+    it('should calculate the job bounty correctly for image boxes from points type', async () => {
+      const data = {
+        requestType: JobRequestType.IMAGE_BOXES_FROM_POINTS,
+        elementsCount: 28883,
+        fundAmount: 22.918128652290278,
+      };
+      const result = await jobService['calculateJobBounty'](data);
 
-      expect(result).toEqual('0.002332842805555555');
+      expect(result).toEqual('0.000793481586133375');
+    });
+
+    it('should calculate the job bounty correctly for image skeletons from boxed type', async () => {
+      const data = {
+        requestType: JobRequestType.IMAGE_SKELETONS_FROM_BOXES,
+        elementsCount: 50,
+        fundAmount: 22.918128652290278,
+        nodesTotal: 4,
+      };
+      const result = await jobService['calculateJobBounty'](data);
+
+      expect(result).toEqual('0.636614684785841055');
     });
   });
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -118,6 +118,7 @@ import {
   OracleAction,
   OracleAddresses,
   RequestAction,
+  CvatCalculateJobBounty,
 } from './job.interface';
 import { WebhookEntity } from '../webhook/webhook.entity';
 import { WebhookRepository } from '../webhook/webhook.repository';
@@ -150,15 +151,15 @@ export class JobService {
     requestType: JobRequestType,
     tokenFundAmount: number,
   ): Promise<CvatManifestDto> {
-    const { getElementsCount, calculateJobBounty } =
-      this.createManifestActions[requestType];
+    const { getElementsCount } = this.createManifestActions[requestType];
 
     const elementsCount = await getElementsCount(requestType, dto.data);
-    const jobBounty = await calculateJobBounty(
+    const jobBounty = await this.calculateJobBounty({
+      requestType,
       elementsCount,
-      tokenFundAmount,
-      dto.labels[0]?.nodes?.length,
-    );
+      fundAmount: tokenFundAmount,
+      nodesTotal: dto.labels[0]?.nodes?.length,
+    });
 
     return {
       data: {
@@ -508,70 +509,33 @@ export class JobService {
   private createManifestActions: Record<JobRequestType, ManifestAction> = {
     [JobRequestType.HCAPTCHA]: {
       getElementsCount: async () => 0,
-      calculateJobBounty: async () => ethers.formatEther(0),
     },
     [JobRequestType.FORTUNE]: {
       getElementsCount: async () => 0,
-      calculateJobBounty: async () => ethers.formatEther(0),
     },
     [JobRequestType.IMAGE_BOXES]: {
       getElementsCount: async (
         requestType: JobRequestType,
         data: CvatDataDto,
       ) => (await listObjectsInBucket(data.dataset, requestType)).length,
-      calculateJobBounty: async (
-        elementsCount: number,
-        fundAmount: number,
-      ): Promise<string> =>
-        this.calculateCvatJobBounty(elementsCount, fundAmount),
     },
     [JobRequestType.IMAGE_POINTS]: {
       getElementsCount: async (
         requestType: JobRequestType,
         data: CvatDataDto,
       ) => (await listObjectsInBucket(data.dataset, requestType)).length,
-      calculateJobBounty: async (
-        elementsCount: number,
-        fundAmount: number,
-      ): Promise<string> =>
-        this.calculateCvatJobBounty(elementsCount, fundAmount),
     },
     [JobRequestType.IMAGE_BOXES_FROM_POINTS]: {
       getElementsCount: async (
         requestType: JobRequestType,
         data: CvatDataDto,
       ) => this.getCvatElementsCount(requestType, data.points!),
-      calculateJobBounty: async (
-        elementsCount: number,
-        fundAmount: number,
-      ): Promise<string> =>
-        this.calculateCvatJobBounty(elementsCount, fundAmount),
     },
     [JobRequestType.IMAGE_SKELETONS_FROM_BOXES]: {
       getElementsCount: async (
         requestType: JobRequestType,
         data: CvatDataDto,
       ) => this.getCvatElementsCount(requestType, data.boxes!),
-      calculateJobBounty: async (
-        elementsCount: number,
-        fundAmount: number,
-        nodesTotal: number,
-      ): Promise<string> => {
-        const cvatDefaultJobSize = Number(this.cvatConfigService.jobSize);
-
-        const jobSizeMultiplier = Number(
-          this.cvatConfigService.skeletonsJobSizeMultiplier,
-        );
-        const jobSize = jobSizeMultiplier * cvatDefaultJobSize;
-
-        // For each skeleton node CVAT creates a separate project thus increasing amount of jobs
-        const totalJobs =
-          Math.ceil(div(elementsCount, jobSize)) * (nodesTotal || 1);
-
-        return ethers.formatEther(
-          ethers.parseUnits(fundAmount.toString(), 'ether') / BigInt(totalJobs),
-        );
-      },
     },
   };
 
@@ -761,17 +725,36 @@ export class JobService {
     ).annotations?.length;
   }
 
-  public async calculateCvatJobBounty(
-    elementsCount: number,
-    fundAmount: number,
+  public async calculateJobBounty(
+    data: CvatCalculateJobBounty,
   ): Promise<string> {
-    const jobSize = Number(this.cvatConfigService.jobSize);
+    const { requestType, elementsCount, fundAmount, nodesTotal } = data;
+    const cvatDefaultJobSize = Number(this.cvatConfigService.jobSize);
 
-    const totalJobs = Math.ceil(div(elementsCount, jobSize));
+    let jobSize = cvatDefaultJobSize;
 
-    return ethers.formatEther(
-      ethers.parseUnits(fundAmount.toString(), 'ether') / BigInt(totalJobs),
-    );
+    if (requestType === JobRequestType.IMAGE_SKELETONS_FROM_BOXES) {
+      const jobSizeMultiplier = Number(
+        this.cvatConfigService.skeletonsJobSizeMultiplier,
+      );
+      jobSize *= jobSizeMultiplier;
+    }
+
+    let totalJobs: number;
+
+    // For each skeleton node CVAT creates a separate project thus increasing amount of jobs
+    if (
+      requestType === JobRequestType.IMAGE_SKELETONS_FROM_BOXES &&
+      nodesTotal
+    ) {
+      totalJobs = Math.ceil(elementsCount / jobSize) * nodesTotal;
+    } else {
+      totalJobs = Math.ceil(elementsCount / jobSize);
+    }
+
+    const jobBounty =
+      ethers.parseUnits(fundAmount.toString(), 'ether') / BigInt(totalJobs);
+    return ethers.formatEther(jobBounty);
   }
 
   public async createEscrow(jobEntity: JobEntity): Promise<JobEntity> {


### PR DESCRIPTION
## Description
Refactored calculate job bounty method.

## Summary of changes
- Added `CvatCalculateJobBounty` interface.
- Updated `calculateJobBounty` method.
- Removed `calculateJobBounty` from `createManifestActions`.
- Renamed `createManifestActions` -> `createDatasetActions`.
- Renamed `ManifestAction` -> `DatasetAction`.
- Added new test cases.

## How test the changes
`yarn test`

## Related issues
[Job Launcher] Refactor calculate job bounty method
[#1805](https://github.com/humanprotocol/human-protocol/issues/1805)
