### PR TITLE
[Job Launcher] Updated `getCvatElementsCount` method

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
@@ -1,5 +1,5 @@
 import { JobRequestType } from '../../common/enums/job';
-import { CreateJob, CvatDataDto, Label } from './job.dto';
+import { CreateJob, CvatDataDto, Label, StorageDataDto } from './job.dto';
 
 export interface RequestAction {
   calculateFundAmount: (dto: CreateJob, rate: number) => Promise<number>;
@@ -10,12 +10,16 @@ export interface RequestAction {
   ) => Promise<any>;
 }
 
-export interface DatasetAction {
+export interface ManifestAction {
   getElementsCount: (
     requestType: JobRequestType,
     data: CvatDataDto,
     gtUrl?: string,
   ) => Promise<number>;
+  generateUrls: (
+    data: CvatDataDto,
+    groundTruth: StorageDataDto,
+  ) => GenerateUrls;
 }
 
 export interface EscrowAction {
@@ -34,9 +38,17 @@ export interface OracleAddresses {
 
 export interface CvatCalculateJobBounty {
   requestType: JobRequestType;
-  elementsCount: number;
   fundAmount: number;
+  data: CvatDataDto;
+  gtUrl: string;
   nodesTotal?: number;
+}
+
+export interface GenerateUrls {
+  dataUrl: string;
+  gtUrl: string;
+  pointsUrl?: string;
+  boxesUrl?: string;
 }
 
 export interface CvatImageData {

--- a/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.interface.ts
@@ -14,6 +14,7 @@ export interface DatasetAction {
   getElementsCount: (
     requestType: JobRequestType,
     data: CvatDataDto,
+    gtUrl?: string,
   ) => Promise<number>;
 }
 
@@ -31,9 +32,37 @@ export interface OracleAddresses {
   reputationOracle: string;
 }
 
-export class CvatCalculateJobBounty {
+export interface CvatCalculateJobBounty {
   requestType: JobRequestType;
   elementsCount: number;
   fundAmount: number;
   nodesTotal?: number;
+}
+
+export interface CvatImageData {
+  id: number;
+  width: number;
+  height: number;
+  file_name: string;
+  license: number;
+  flickr_url: string;
+  coco_url: string;
+  date_captured: number;
+}
+
+export interface CvatAnnotationData {
+  id: number;
+  image_id: number;
+  category_id: number;
+  segmentation: number[];
+  area: number;
+  bbox: [number, number, number, number];
+  iscrowd: number;
+  attributes: {
+    scale: number;
+    x: number;
+    y: number;
+  };
+  keypoints: [number, number, number];
+  num_keypoints: number;
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -80,6 +80,8 @@ import {
   MOCK_CVAT_LABELS_WITH_NODES,
   MOCK_CVAT_DATA_POINTS,
   MOCK_CVAT_DATA_BOXES,
+  MOCK_CVAT_DATA,
+  MOCK_CVAT_GT,
 } from '../../../test/constants';
 import { PaymentService } from '../payment/payment.service';
 import { Web3Service } from '../web3/web3.service';
@@ -526,6 +528,43 @@ describe('JobService', () => {
     });
   });
 
+  describe('getCvatElementsCount', () => {
+    let storageDatasetMock: StorageDataDto;
+
+    beforeAll(async () => {
+      storageDatasetMock = {
+        provider: StorageProviders.AWS,
+        region: AWSRegions.AP_EAST_1,
+        bucketName: 'bucket',
+        path: 'folder/test',
+      };
+    });
+
+    it('should throw ConflictException if storageData is not provided', async () => {
+      await expect(
+        jobService.getCvatElementsCount(
+          JobRequestType.IMAGE_BOXES_FROM_POINTS,
+          null as any,
+          'some-gt-url',
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should calculate the number of CVAT elements correctly', async () => {
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_DATA)
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
+
+      const result = await jobService.getCvatElementsCount(
+        JobRequestType.IMAGE_BOXES_FROM_POINTS,
+        storageDatasetMock,
+        'some-gt-url',
+      );
+      expect(result).toBe(2);
+    });
+  });
+
   describe('createCvatManifest', () => {
     it('should create a valid CVAT manifest for image boxes job type', async () => {
       const jobBounty = '50';
@@ -574,12 +613,12 @@ describe('JobService', () => {
     });
 
     it('should create a valid CVAT manifest for image boxes from points job type', async () => {
-      const jobBounty = '25.0';
+      const jobBounty = '50.0';
 
-      const data = {
-        annotations: ['string', 'string', 'string', 'string'],
-      };
-      jest.spyOn(storageService, 'download').mockResolvedValueOnce(data);
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_DATA)
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
 
       const dto: JobCvatDto = {
         data: MOCK_CVAT_DATA_POINTS,
@@ -625,10 +664,10 @@ describe('JobService', () => {
     it('should create a valid CVAT manifest for image skeletons from boxes job type', async () => {
       const jobBounty = '4.0';
 
-      const data = {
-        annotations: ['string', 'string', 'string', 'string'],
-      };
-      jest.spyOn(storageService, 'download').mockResolvedValueOnce(data);
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_DATA)
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
 
       const dto: JobCvatDto = {
         data: MOCK_CVAT_DATA_BOXES,
@@ -1205,7 +1244,7 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-      const storageDataMock: any = {
+      const storageDatasetMock: any = {
         dataset: {
           provider: StorageProviders.GCS,
           region: AWSRegions.EU_CENTRAL_1,
@@ -1214,14 +1253,21 @@ describe('JobService', () => {
         },
       };
 
+      const storageGtMock: any = {
+        provider: StorageProviders.GCS,
+        region: AWSRegions.EU_CENTRAL_1,
+        bucketName: 'bucket',
+        path: 'folder/test',
+      };
+
       const imageLabelBinaryJobDto: JobCvatDto = {
         chainId: MOCK_CHAIN_ID,
-        data: storageDataMock,
+        data: storageDatasetMock,
         labels: MOCK_CVAT_LABELS,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         minQuality: 0.95,
         fundAmount: 10,
-        groundTruth: storageDataMock,
+        groundTruth: storageGtMock,
         userGuide: MOCK_FILE_URL,
         type: JobRequestType.IMAGE_POINTS,
       };
@@ -1245,7 +1291,7 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-      const storageDataMock: any = {
+      const storageDatasetMock: any = {
         dataset: {
           provider: StorageProviders.AWS,
           region: 'test-region',
@@ -1254,14 +1300,21 @@ describe('JobService', () => {
         },
       };
 
+      const storageGtMock: any = {
+        provider: StorageProviders.AWS,
+        region: 'test-region',
+        bucketName: 'bucket',
+        path: 'folder/test',
+      };
+
       const imageLabelBinaryJobDto: JobCvatDto = {
         chainId: MOCK_CHAIN_ID,
-        data: storageDataMock,
+        data: storageDatasetMock,
         labels: MOCK_CVAT_LABELS,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         minQuality: 0.95,
         fundAmount: 10,
-        groundTruth: storageDataMock,
+        groundTruth: storageGtMock,
         userGuide: MOCK_FILE_URL,
         type: JobRequestType.IMAGE_POINTS,
       };
@@ -1285,7 +1338,7 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-      const storageDataMock: any = {
+      const storageDatasetMock: any = {
         dataset: {
           provider: StorageProviders.AWS,
           bucketName: 'bucket',
@@ -1293,14 +1346,20 @@ describe('JobService', () => {
         },
       };
 
+      const storageGtMock: any = {
+        provider: StorageProviders.AWS,
+        bucketName: 'bucket',
+        path: 'folder/test',
+      };
+
       const imageLabelBinaryJobDto: JobCvatDto = {
         chainId: MOCK_CHAIN_ID,
-        data: storageDataMock,
+        data: storageDatasetMock,
         labels: MOCK_CVAT_LABELS,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         minQuality: 0.95,
         fundAmount: 10,
-        groundTruth: storageDataMock,
+        groundTruth: storageGtMock,
         userGuide: MOCK_FILE_URL,
         type: JobRequestType.IMAGE_POINTS,
       };
@@ -1324,7 +1383,7 @@ describe('JobService', () => {
       const userBalance = 25;
       getUserBalanceMock.mockResolvedValue(userBalance);
 
-      const storageDataMock: any = {
+      const storageDatasetMock: any = {
         dataset: {
           provider: StorageProviders.AWS,
           region: AWSRegions.EU_CENTRAL_1,
@@ -1332,14 +1391,20 @@ describe('JobService', () => {
         },
       };
 
+      const storageGtMock: any = {
+        provider: StorageProviders.AWS,
+        region: AWSRegions.EU_CENTRAL_1,
+        path: 'folder/test',
+      };
+
       const imageLabelBinaryJobDto: JobCvatDto = {
         chainId: MOCK_CHAIN_ID,
-        data: storageDataMock,
+        data: storageDatasetMock,
         labels: MOCK_CVAT_LABELS,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
         minQuality: 0.95,
         fundAmount: 10,
-        groundTruth: storageDataMock,
+        groundTruth: storageGtMock,
         userGuide: MOCK_FILE_URL,
         type: JobRequestType.IMAGE_POINTS,
       };

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -1129,26 +1129,70 @@ describe('JobService', () => {
 
   describe('calculateJobBounty', () => {
     it('should calculate the job bounty correctly for image boxes from points type', async () => {
+      const storageDatasetMock: any = {
+        dataset: {
+          provider: StorageProviders.AWS,
+          region: AWSRegions.EU_CENTRAL_1,
+          bucketName: 'bucket',
+          path: 'folder/test',
+        },
+        points: {
+          provider: StorageProviders.AWS,
+          region: AWSRegions.EU_CENTRAL_1,
+          bucketName: 'bucket',
+          path: 'folder/test',
+        },
+      };
+
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_DATA)
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
+
       const data = {
         requestType: JobRequestType.IMAGE_BOXES_FROM_POINTS,
-        elementsCount: 28883,
         fundAmount: 22.918128652290278,
+        data: storageDatasetMock,
+        gtUrl: MOCK_FILE_URL,
       };
-      const result = await jobService['calculateJobBounty'](data);
 
-      expect(result).toEqual('0.000793481586133375');
+      const result = await jobService['calculateJobBounty'](data); //  elementsCount = 2
+
+      expect(result).toEqual('11.459064326145139');
     });
 
     it('should calculate the job bounty correctly for image skeletons from boxed type', async () => {
+      const storageDatasetMock: any = {
+        dataset: {
+          provider: StorageProviders.AWS,
+          region: AWSRegions.EU_CENTRAL_1,
+          bucketName: 'bucket',
+          path: 'folder/test',
+        },
+        boxes: {
+          provider: StorageProviders.AWS,
+          region: AWSRegions.EU_CENTRAL_1,
+          bucketName: 'bucket',
+          path: 'folder/test',
+        },
+      };
+
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_DATA)
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
+
       const data = {
         requestType: JobRequestType.IMAGE_SKELETONS_FROM_BOXES,
-        elementsCount: 50,
         fundAmount: 22.918128652290278,
+        data: storageDatasetMock,
+        gtUrl: MOCK_FILE_URL,
         nodesTotal: 4,
       };
-      const result = await jobService['calculateJobBounty'](data);
 
-      expect(result).toEqual('0.636614684785841055');
+      const result = await jobService['calculateJobBounty'](data); //  elementsCount = 2
+
+      expect(result).toEqual('5.7295321630725695');
     });
   });
 

--- a/packages/apps/job-launcher/server/test/constants.ts
+++ b/packages/apps/job-launcher/server/test/constants.ts
@@ -155,3 +155,59 @@ export const MOCK_CVAT_LABELS_WITH_NODES: Label[] = [
 
 export const MOCK_BUCKET_FILE =
   'https://bucket.s3.eu-central-1.amazonaws.com/folder/test';
+
+export const MOCK_CVAT_DATA = {
+  images: [
+    {
+      id: 1,
+      file_name: '1.jpg',
+    },
+    {
+      id: 2,
+      file_name: '2.jpg',
+    },
+    {
+      id: 3,
+      file_name: '3.jpg',
+    },
+    {
+      id: 4,
+      file_name: '4.jpg',
+    },
+    {
+      id: 5,
+      file_name: '5.jpg',
+    },
+  ],
+  annotations: [
+    {
+      image_id: 1,
+    },
+    {
+      image_id: 2,
+    },
+    {
+      image_id: 3,
+    },
+    {
+      image_id: 4,
+    },
+    {
+      image_id: 5,
+    },
+  ],
+};
+
+export const MOCK_CVAT_GT = {
+  images: [
+    {
+      file_name: '1.jpg',
+    },
+    {
+      file_name: '2.jpg',
+    },
+    {
+      file_name: '3.jpg',
+    },
+  ],
+};


### PR DESCRIPTION
## Description
Changed the get elements count logic for `IMAGE_BOXES_FROM_POINTS` and `IMAGE_SKELETONS_FROM_BOXES`.

## Summary of changes
- Improved `getCvatElementsCount` method.
- Implemented `generateUrls` method
- Refactored `calculateJobBounty` method
- Implemented unit tests.

## How test the changes
`yarn test`

## Related issues
[Job Launcher] Implement new logic for calculate job bounty
[#1807](https://github.com/humanprotocol/human-protocol/issues/1807)
