### PR TITLE
[Reputation Oracle] Remove unused field from webhook entity

### DIFF
--- a/packages/apps/reputation-oracle/server/src/database/migrations/1712220998800-removeOracleAddress.ts
+++ b/packages/apps/reputation-oracle/server/src/database/migrations/1712220998800-removeOracleAddress.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveOracleAddress1712220998800 implements MigrationInterface {
+  name = 'RemoveOracleAddress1712220998800';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."webhook_incoming" DROP COLUMN "oracle_address"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."webhook_incoming" ADD "oracle_address" character varying`,
+    );
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -178,12 +178,13 @@ export class CronJobService {
                 await escrowClient.getJobLauncherAddress(escrowAddress),
               )
             ).webhookUrl,
-            (
-              await OperatorUtils.getLeader(
-                chainId,
-                await escrowClient.getRecordingOracleAddress(escrowAddress),
-              )
-            ).webhookUrl,
+            // Temporarily disable sending webhook to Recoring Oracle
+            // (
+            //   await OperatorUtils.getLeader(
+            //     chainId,
+            //     await escrowClient.getRecordingOracleAddress(escrowAddress),
+            //   )
+            // ).webhookUrl,
           ];
           const webhookBody: WebhookDto = {
             chainId,

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.entity.ts
@@ -11,9 +11,6 @@ export class WebhookIncomingEntity extends BaseEntity {
   @Column({ type: 'int' })
   public chainId: ChainId;
 
-  @Column({ type: 'varchar', nullable: true })
-  public oracleAddress: string;
-
   @Column({ type: 'varchar' })
   public escrowAddress: string;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Removes an unused field from `WebhookIncomingEntity` 

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
Removed `oracleAddress` field from `WebhookIncomingEntity`
Temporarily disabled notification to Recording Oracle

