### PR TITLE
[Job Launcher] Display partially paid escrows

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/StatusToggleButtons.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/StatusToggleButtons.tsx
@@ -8,6 +8,7 @@ import { JobStatus } from '../../types';
 const RANGE_BUTTONS = [
   { label: 'Launched', value: JobStatus.LAUNCHED },
   { label: 'Pending', value: JobStatus.PENDING },
+  { label: 'Partial', value: JobStatus.PARTIAL },
   { label: 'Completed', value: JobStatus.COMPLETED },
   { label: 'Canceled', value: JobStatus.CANCELED },
   { label: 'Failed', value: JobStatus.FAILED },

--- a/packages/apps/job-launcher/client/src/layouts/AuthLayout.tsx
+++ b/packages/apps/job-launcher/client/src/layouts/AuthLayout.tsx
@@ -61,6 +61,9 @@ export default function AuthLayout() {
                   <Link to="/jobs/pending">Pending</Link>
                 </ListItem>
                 <ListItem>
+                  <Link to="/jobs/partial">Partial</Link>
+                </ListItem>
+                <ListItem>
                   <Link to="/jobs/completed">Completed</Link>
                 </ListItem>
                 <ListItem>

--- a/packages/apps/job-launcher/client/src/pages/Job/JobList/index.tsx
+++ b/packages/apps/job-launcher/client/src/pages/Job/JobList/index.tsx
@@ -8,6 +8,7 @@ import { JobStatus } from '../../../types';
 
 const JOB_NAV_ITEMS = [
   { status: JobStatus.LAUNCHED, label: 'launched' },
+  { status: JobStatus.PARTIAL, label: 'partial' },
   { status: JobStatus.COMPLETED, label: 'completed' },
   { status: JobStatus.PENDING, label: 'pending' },
   { status: JobStatus.CANCELED, label: 'canceled' },

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -235,6 +235,7 @@ export type JobRequest = {
 export enum JobStatus {
   LAUNCHED = 'LAUNCHED',
   PENDING = 'PENDING',
+  PARTIAL = 'PARTIAL',
   CANCELED = 'CANCELED',
   FAILED = 'FAILED',
   COMPLETED = 'COMPLETED',

--- a/packages/apps/job-launcher/server/src/common/enums/job.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/job.ts
@@ -4,6 +4,7 @@ export enum JobStatus {
   CREATED = 'CREATED',
   SET_UP = 'SET_UP',
   LAUNCHED = 'LAUNCHED',
+  PARTIAL = 'PARTIAL',
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
   TO_CANCEL = 'TO_CANCEL',
@@ -13,6 +14,7 @@ export enum JobStatus {
 export enum JobStatusFilter {
   PENDING = 'PENDING',
   LAUNCHED = 'LAUNCHED',
+  PARTIAL = 'PARTIAL',
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
   CANCELED = 'CANCELED',

--- a/packages/apps/job-launcher/server/src/common/utils/status.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/status.ts
@@ -5,16 +5,13 @@ export function filterToEscrowStatus(
   filterStatus: JobStatusFilter,
 ): EscrowStatus[] {
   switch (filterStatus) {
+    case JobStatusFilter.PARTIAL:
+      return [EscrowStatus.Partial];
     case JobStatusFilter.COMPLETED:
       return [EscrowStatus.Complete];
     case JobStatusFilter.CANCELED:
       return [EscrowStatus.Cancelled];
     default:
-      return [
-        EscrowStatus.Launched,
-        EscrowStatus.Pending,
-        EscrowStatus.Partial,
-        EscrowStatus.Paid,
-      ];
+      return [EscrowStatus.Launched, EscrowStatus.Pending, EscrowStatus.Paid];
   }
 }

--- a/packages/apps/job-launcher/server/src/database/migrations/1712826368303-addPartialStatus.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1712826368303-addPartialStatus.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPartialStatus1712826368303 implements MigrationInterface {
+  name = 'AddPartialStatus1712826368303';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."jobs_status_enum"
+            RENAME TO "jobs_status_enum_old"
+        `);
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."jobs_status_enum" AS ENUM(
+                'PENDING',
+                'PAID',
+                'CREATED',
+                'SET_UP',
+                'LAUNCHED',
+                'PARTIAL',
+                'COMPLETED',
+                'FAILED',
+                'TO_CANCEL',
+                'CANCELED'
+            )
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ALTER COLUMN "status" TYPE "hmt"."jobs_status_enum" USING "status"::"text"::"hmt"."jobs_status_enum"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."jobs_status_enum_old"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."jobs_status_enum_old" AS ENUM(
+                'PENDING',
+                'PAID',
+                'CREATED',
+                'SET_UP',
+                'LAUNCHED',
+                'COMPLETED',
+                'FAILED',
+                'TO_CANCEL',
+                'CANCELED'
+            )
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ALTER COLUMN "status" TYPE "hmt"."jobs_status_enum_old" USING "status"::"text"::"hmt"."jobs_status_enum_old"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."jobs_status_enum"
+        `);
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."jobs_status_enum_old"
+            RENAME TO "jobs_status_enum"
+        `);
+  }
+}

--- a/packages/sdk/typescript/subgraph/src/mapping/Escrow.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/Escrow.ts
@@ -233,7 +233,7 @@ export function handleBulkTransfer(event: BulkTransfer): void {
   // Update escrow entity
   const escrowEntity = Escrow.load(dataSource.address().toHex());
   if (escrowEntity) {
-    escrowEntity.status = event.params._isPartial ? 'Partially Paid' : 'Paid';
+    escrowEntity.status = event.params._isPartial ? 'Partial' : 'Paid';
 
     // Read data on-chain
     const escrowContract = EscrowContract.bind(event.address);

--- a/packages/sdk/typescript/subgraph/tests/escrow/escrow.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/escrow/escrow.test.ts
@@ -611,12 +611,7 @@ describe('Escrow', () => {
     );
 
     // Escrow
-    assert.fieldEquals(
-      'Escrow',
-      escrowAddress.toHex(),
-      'status',
-      'Partially Paid'
-    );
+    assert.fieldEquals('Escrow', escrowAddress.toHex(), 'status', 'Partial');
 
     // Bulk 2
     const bulk2 = createBulkTransferEvent(


### PR DESCRIPTION
## Description

Display escrows with Partially paid status because now in case payouts were triggered but escrow balance is not 0, escrow won't be visible in any of the existing tabs

## Summary of changes

Job Launcher Server:
 - Add Partial status to database
 - Add new Partial status to filter and query subgraph
 - Update Launched status in DB in case of Partial on chain

Job Launcher Client:
 - Add new Partial tab in sidebar and dashboard

Subgraph:
 - Update partial escrow status from `Partially Paid` to `Partial`

## How test the changes

`yarn test`

## Related issues
#1842
