### PR TITLE
[CVAT-M2] Return only tasks with active assignments in Exchange Oracle

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/services/cvat.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/cvat.py
@@ -172,13 +172,8 @@ def get_projects_by_assignee(
             Project.jobs.any(
                 Job.assignments.any(
                     (Assignment.user_wallet_address == wallet_address)
-                    & Assignment.status.in_(
-                        [
-                            AssignmentStatuses.created,
-                            AssignmentStatuses.completed,
-                            AssignmentStatuses.canceled,
-                        ]
-                    )
+                    & (Assignment.status == AssignmentStatuses.created)
+                    & (utcnow() < Assignment.expires_at)
                 )
             )
         )

--- a/packages/examples/cvat/exchange-oracle/src/services/exchange.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/exchange.py
@@ -87,6 +87,7 @@ def get_tasks_by_assignee(
                 cvat_projects=[p.cvat_id for p in cvat_projects],
             )
             if assignment.status == AssignmentStatuses.created
+            if not assignment.is_finished
         }
 
         for project in cvat_projects:

--- a/packages/examples/cvat/exchange-oracle/tests/integration/services/test_cvat.py
+++ b/packages/examples/cvat/exchange-oracle/tests/integration/services/test_cvat.py
@@ -391,7 +391,7 @@ class ServiceIntegrationTest(unittest.TestCase):
             session=self.session,
             wallet_address=wallet_address_1,
             cvat_job_id=cvat_id_1,
-            expires_at=datetime.now(),
+            expires_at=datetime.now() + timedelta(days=1),
         )
 
         wallet_address_2 = "0x86e83d346041E8806e352681f3F14549C0d2BC61"
@@ -418,8 +418,9 @@ class ServiceIntegrationTest(unittest.TestCase):
 
         projects = cvat_service.get_projects_by_assignee(self.session, wallet_address_2)
 
-        self.assertEqual(len(projects), 1)
-        self.assertEqual(projects[0].cvat_id, cvat_id_2)
+        self.assertEqual(
+            len(projects), 0
+        )  # expired should not be shown, https://github.com/humanprotocol/human-protocol/pull/1879
 
     def test_update_project_status(self):
         cvat_id = 1


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

- Return only tasks with active assignments in `/tasks?wallet_address=XXX` of Exchange Oracle

This helps to avoid situations where older inactive assignments bloat all the top projects in the response. This problem exists before the #1649 is merged, where it's avoided by pagination and filters.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
