### PR TITLE
[Reputation Oracle] Fix `user.controller.ts`

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -8,7 +8,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 
 import { ErrorAuth, ErrorUser } from '../../common/constants/errors';
-import { UserStatus } from '../../common/enums/user';
+import { OperatorStatus, UserStatus } from '../../common/enums/user';
 import { UserCreateDto, Web3UserCreateDto } from '../user/user.dto';
 import { UserEntity } from '../user/user.entity';
 import { UserService } from '../user/user.service';
@@ -387,7 +387,7 @@ export class AuthService {
       data.address,
     );
 
-    await kvstore.set(data.address, 'ACTIVE');
+    await kvstore.set(data.address, OperatorStatus.ACTIVE);
 
     return this.auth(userEntity);
   }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -14,8 +14,8 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
-import { Public } from '../../common/decorators';
 import {
+  DisableOperatorDto,
   RegisterAddressRequestDto,
   RegisterAddressResponseDto,
 } from './user.dto';
@@ -25,11 +25,10 @@ import { UserService } from './user.service';
 
 @ApiTags('User')
 @Controller('/user')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 export class UserController {
   constructor(private readonly userService: UserService) {}
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @Public()
   @Post('/register-address')
   @HttpCode(200)
   @ApiOperation({
@@ -72,7 +71,7 @@ export class UserController {
     summary: 'Disable an operator',
     description: 'Endpoint to disable an operator.',
   })
-  @ApiBody({ type: String })
+  @ApiBody({ type: DisableOperatorDto })
   @ApiResponse({
     status: 204,
     description: 'Operator disabled succesfully',
@@ -82,9 +81,9 @@ export class UserController {
     description: 'Not Found. Could not find the requested content.',
   })
   public disableOperator(
-    @Body() signature: string,
+    @Body() data: DisableOperatorDto,
     @Request() req: RequestWithUser,
   ): Promise<void> {
-    return this.userService.disableOperator(req.user, signature);
+    return this.userService.disableOperator(req.user, data.signature);
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
@@ -66,3 +66,9 @@ export class RegisterAddressResponseDto {
   @IsString()
   public signedAddress: string;
 }
+
+export class DisableOperatorDto {
+  @ApiProperty()
+  @IsString()
+  public signature: string;
+}

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -253,7 +253,7 @@ describe('UserService', () => {
       );
       expect(kvstoreClientMock.set).toHaveBeenCalledWith(
         MOCK_ADDRESS,
-        'ACTIVE',
+        OperatorStatus.INACTIVE,
       );
     });
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -157,8 +157,10 @@ export class UserService {
     const currentWeb3Env = this.web3ConfigService.env;
     if (currentWeb3Env === Web3Env.MAINNET) {
       signer = this.web3Service.getSigner(ChainId.POLYGON);
-    } else {
+    } else if (currentWeb3Env === Web3Env.TESTNET) {
       signer = this.web3Service.getSigner(ChainId.POLYGON_AMOY);
+    } else {
+      signer = this.web3Service.getSigner(ChainId.LOCALHOST);
     }
 
     const kvstore = await KVStoreClient.build(signer);
@@ -169,6 +171,6 @@ export class UserService {
       throw new BadRequestException(ErrorOperator.OperatorNotActive);
     }
 
-    await kvstore.set(user.evmAddress, 'ACTIVE');
+    await kvstore.set(user.evmAddress, OperatorStatus.INACTIVE);
   }
 }


### PR DESCRIPTION
## Description
Register address has the public decorator but jwtAuth is required
Disable operator marked as public in swagger but jwtAuth is also required
Check also the string body

## Summary of changes

Improve decorators usage in `user.controller.ts`
Create a new dto for `disableOperator` endpoint
Fix the status sent to blockchain in `disableOperator`

## How test the changes

`yarn test`

## Related issues
#1882 
