### PR TITLE
[CVAT-M2] Remove task size multiplier for skeletons

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/core/tasks/skeletons_from_boxes.py
+++ b/packages/examples/cvat/exchange-oracle/src/core/tasks/skeletons_from_boxes.py
@@ -8,7 +8,7 @@ import datumaro as dm
 from attrs import frozen
 from datumaro.util import dump_json, parse_json
 
-DEFAULT_ASSIGNMENT_SIZE_MULTIPLIER = 2 * 3  # tile grid size
+DEFAULT_ASSIGNMENT_SIZE_MULTIPLIER = 1
 
 SkeletonBboxMapping = Dict[int, int]
 


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

Prior this PR, skeleton annotation tasks used a task size multiplier of 6, supposed for more efficient annotation process. It seems, however, that this multiplier is too big, as the annotators become tired of annotating 72 images per assignment and lose interest and focus. This PR changes the multiplier "back" to 1, so that the default manifest job size is used. 

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
