### PR TITLE
Fix serverUrl in getAssignments

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.controller.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.controller.spec.ts
@@ -65,7 +65,7 @@ describe('assignmentController', () => {
         query,
         userAddress,
         reputationNetwork,
-        MOCK_EXCHANGE_ORACLE,
+        expect.any(String),
       );
     });
 

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.controller.ts
@@ -39,7 +39,6 @@ export class AssignmentController {
     description: 'Details of the assignment to be created.',
     type: CreateAssignmentDto,
   })
-  @ApiBearerAuth()
   @ApiResponse({
     status: 200,
     description: 'Assignment created successfully.',
@@ -64,7 +63,6 @@ export class AssignmentController {
     summary: 'Get Assignments',
     description: 'Endpoint to retrieve a list of assignments.',
   })
-  @ApiBearerAuth()
   @ApiResponse({
     status: 200,
     description: 'List of assignments retrieved successfully.',
@@ -82,14 +80,14 @@ export class AssignmentController {
   getAssignments(
     @Request() req: RequestWithUser,
     @Query() query: GetAssignmentsDto,
-  ): Promise<PageDto<AssignmentDto>> {
-    const serverUrl = (req.headers as any).referer.slice(
-      0,
-      (req.headers as any).referer.indexOf(
-        '/',
-        (req.headers as any).referer.indexOf('//') + 2,
-      ) + 1,
-    );
+  ): any {
+    let protocol = 'http';
+
+    if ((req as any).secure) {
+      protocol = 'https';
+    }
+
+    const serverUrl = `${protocol}://${(req.headers as any).host}`;
     return this.assignmentService.getAssignmentList(
       query,
       req.user.address,


### PR DESCRIPTION
## Description

Requests from other services don't contain the referer property and the server throws an error.

## Summary of changes

Use host property to avoid the error

## How test the changes
 `yarn test`

