### PR TITLE
[Job Launcher] Cvat url pathname 

### DIFF
--- a/packages/apps/job-launcher/server/src/common/utils/storage.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/storage.ts
@@ -66,7 +66,7 @@ export async function listObjectsInBucket(url: URL): Promise<string[]> {
                   nextContinuationToken,
                 )}`
               : ''
-          }${url.pathname ? `&prefix=${url.pathname}` : ''}`,
+          }${url.pathname ? `&prefix=${url.pathname.replace(/^\//, '')}` : ''}`,
         );
 
         if (response.status === HttpStatus.OK && response.data) {


### PR DESCRIPTION
## Description

Cvat bounties were failing because the url of the bucket was wrong

## Summary of changes

Replace the first / if the pathname of the bucket start with /

## How test the changes

`yarn test`

