### PR TITLE
[CVAT-M2] Fix GT preparation for boxes from points and skeletons from boxes

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py
@@ -88,6 +88,10 @@ class InvalidCoordinates(DatasetValidationError):
     pass
 
 
+class InvisibleSkeletonError(DatasetValidationError):
+    pass
+
+
 T = TypeVar("T")
 
 
@@ -113,7 +117,7 @@ class _ExcludedAnnotationsInfo:
     messages: List[_ExcludedAnnotationInfo] = field(default_factory=list)
 
     excluded_count: int = 0
-    "The number of excluded annotations. Can be different from len(error_messages)"
+    "The number of excluded annotations. Can be different from len(messages)"
 
     total_count: int = 0
 
@@ -1334,6 +1338,13 @@ class SkeletonsFromBoxesTaskBuilder:
             if skeleton.id in visited_ids:
                 raise DatasetValidationError(f"repeated annotation id {skeleton.id}")
 
+            if all(
+                v == dm.Points.Visibility.absent for p in skeleton.elements for v in p.visibility
+            ):
+                # Handle fully absent skeletons
+                # It's not the same as with all occluded points
+                raise InvisibleSkeletonError("no visible points")
+
             for element in skeleton.elements:
                 # This is what Datumaro is expected to parse
                 assert len(element.points) == 2 and len(element.visibility) == 1
@@ -1360,15 +1371,6 @@ class SkeletonsFromBoxesTaskBuilder:
             for skeleton in sample_skeletons:
                 try:
                     _validate_skeleton(skeleton, sample_bbox=sample_bbox)
-                except InvalidCoordinates as error:
-                    excluded_gt_info.add_message(
-                        "Sample '{}': GT skeleton #{} ({}) skipped - {}".format(
-                            gt_sample.id, skeleton.id, label_cat[skeleton.label].name, error
-                        ),
-                        sample_id=gt_sample.id,
-                        sample_subset=gt_sample.subset,
-                    )
-                    continue
                 except DatasetValidationError as error:
                     excluded_gt_info.add_message(
                         "Sample '{}': GT skeleton #{} ({}) skipped - {}".format(
@@ -1563,26 +1565,30 @@ class SkeletonsFromBoxesTaskBuilder:
         return bbox_iou(a, b) > 0
 
     def _prepare_gt(self):
-        def _filter_ambiguous_boxes(
+        def _find_unambiguous_matches(
             input_boxes: List[dm.Bbox],
             gt_skeletons: List[dm.Skeleton],
-        ) -> List[dm.Bbox]:
-            filtered_boxes: List[dm.Bbox] = []
-            for input_bbox in input_boxes:
-                matched_skeletons: List[dm.Skeleton] = []
-                for gt_skeleton in gt_skeletons:
-                    if input_bbox.label != gt_skeleton.label:
-                        continue
+        ) -> List[Tuple[dm.Bbox, dm.Skeleton]]:
+            matches = [
+                [
+                    (input_bbox.label == gt_skeleton.label)
+                    and (self._match_boxes(input_bbox.get_bbox(), gt_skeleton.get_bbox()))
+                    for gt_skeleton in gt_skeletons
+                ]
+                for input_bbox in input_boxes
+            ]
 
-                    if not self._match_boxes(input_bbox.get_bbox(), gt_skeleton.get_bbox()):
-                        continue
-
-                    matched_skeletons.append(gt_skeleton)
+            ambiguous_boxes: list[int] = set()
+            ambiguous_skeletons: list[int] = set()
+            for bbox_idx, input_bbox in enumerate(input_boxes):
+                matched_skeletons: List[dm.Skeleton] = [
+                    gt_skeletons[j] for j in range(len(gt_skeletons)) if matches[bbox_idx][j]
+                ]
 
                 if len(matched_skeletons) > 1:
                     # Handle ambiguous matches
                     excluded_boxes_info.add_message(
-                        "Sample '{}': bbox #{} ({}) skipped - "
+                        "Sample '{}': bbox #{} ({}) and overlapping skeletons skipped - "
                         "too many matching skeletons ({}) found".format(
                             boxes_sample.id,
                             input_bbox.id,
@@ -1592,96 +1598,99 @@ class SkeletonsFromBoxesTaskBuilder:
                         sample_id=boxes_sample.id,
                         sample_subset=boxes_sample.subset,
                     )
-                    # Don't need to count as excluded, because it's not an error in annotations
+                    # not an error, should not be counted as excluded for an error
+                    ambiguous_boxes.add(input_bbox.id)
+                    ambiguous_skeletons.update(s.id for s in matched_skeletons)
                     continue
-                elif len(matched_skeletons) == 1:
-                    filtered_boxes.append(input_bbox)
 
-            return filtered_boxes
+            for skeleton_idx, gt_skeleton in enumerate(gt_skeletons):
+                matched_boxes: List[dm.Bbox] = [
+                    input_boxes[i] for i in range(len(input_boxes)) if matches[i][skeleton_idx]
+                ]
+
+                if len(matched_boxes) > 1:
+                    # Handle ambiguous matches
+                    excluded_gt_info.add_message(
+                        "Sample '{}': GT skeleton #{} ({}) and overlapping boxes skipped - "
+                        "too many matching boxes ({}) found".format(
+                            gt_sample.id,
+                            gt_skeleton.id,
+                            gt_label_cat[gt_skeleton.label].name,
+                            self._format_list([f"#{a.id}" for a in matched_boxes]),
+                        ),
+                        sample_id=gt_sample.id,
+                        sample_subset=gt_sample.subset,
+                    )
+                    # not an error, should not be counted as excluded for an error
+                    ambiguous_skeletons.add(gt_skeleton.id)
+                    ambiguous_boxes.update(b.id for b in matched_boxes)
+                    continue
+                elif not matched_boxes:
+                    # Handle unmatched skeletons
+                    excluded_gt_info.add_message(
+                        "Sample '{}': GT skeleton #{} ({}) skipped - "
+                        "no matching boxes found".format(
+                            gt_sample.id,
+                            gt_skeleton.id,
+                            gt_label_cat[gt_skeleton.label].name,
+                        ),
+                        sample_id=gt_sample.id,
+                        sample_subset=gt_sample.subset,
+                    )
+                    excluded_gt_info.excluded_count += 1  # an error
+                    continue
+
+            unambiguous_matches: List[Tuple[dm.Bbox, dm.Skeleton]] = []
+            for bbox_idx, input_bbox in enumerate(input_boxes):
+                if input_bbox.id in ambiguous_boxes:
+                    continue
+
+                matched_skeleton = None
+                for gt_idx, gt_skeleton in enumerate(gt_skeletons):
+                    if gt_skeleton.id in ambiguous_skeletons:
+                        continue
+
+                    if matches[bbox_idx][gt_idx]:
+                        matched_skeleton = gt_skeleton
+                        break
+
+                if matched_skeleton:
+                    unambiguous_matches.append((input_bbox, matched_skeleton))
+
+            return unambiguous_matches
 
         def _find_good_gt_skeletons(
             input_boxes: List[dm.Bbox], gt_skeletons: List[dm.Skeleton]
         ) -> List[dm.Bbox]:
-            # Exclude from further matching all the boxes matching more than 1 GT bbox
-            input_boxes = _filter_ambiguous_boxes(input_boxes, gt_skeletons)
+            matches = _find_unambiguous_matches(input_boxes, gt_skeletons)
 
-            # Find unambiguous gt skeleton - input bbox pairs
             matched_skeletons = []
-            visited_boxes = set()
-            for gt_skeleton in gt_skeletons:
-                gt_skeleton_id = gt_skeleton.id
-
+            for input_bbox, gt_skeleton in matches:
                 if all(
                     v != dm.Points.Visibility.visible
                     for p in gt_skeleton.elements
                     for v in p.visibility
                 ):
-                    # Handle fully hidden skeletons
+                    # Handle skeletons without visible points
                     excluded_gt_info.add_message(
                         "Sample '{}': GT skeleton #{} ({}) skipped - "
                         "no visible points".format(
-                            gt_sample.id, gt_skeleton_id, gt_label_cat[gt_skeleton.label].name
+                            gt_sample.id, gt_skeleton.id, gt_label_cat[gt_skeleton.label].name
                         ),
                         sample_id=gt_sample.id,
                         sample_subset=gt_sample.subset,
                     )
-                    excluded_gt_info.excluded_count += 1
+                    # not an error, should not be counted as excluded for an error
+                    # we skip it as we can't reliably annotate and validate occluded now.
+                    # TODO: figure out how to handle this, specifically is how to validate
                     continue
-
-                matched_boxes: List[dm.Bbox] = []
-                for input_bbox in input_boxes:
-                    box_id = input_bbox.id
-                    if box_id in visited_boxes:
-                        continue
-
-                    if input_bbox.label != gt_skeleton.label:
-                        continue
-
-                    if not self._match_boxes(input_bbox.get_bbox(), gt_skeleton.get_bbox()):
-                        continue
-
-                    matched_boxes.append(input_bbox)
-                    visited_boxes.add(box_id)
-
-                if len(matched_boxes) > 1:
-                    # Handle ambiguous matches
-                    excluded_gt_info.add_message(
-                        "Sample '{}': GT skeleton #{} ({}) skipped - "
-                        "too many matching boxes ({}) found".format(
-                            gt_sample.id,
-                            gt_skeleton_id,
-                            gt_label_cat[gt_skeleton.label].name,
-                            len(matched_boxes),
-                        ),
-                        sample_id=gt_sample.id,
-                        sample_subset=gt_sample.subset,
-                    )
-                    # Don't need to count as excluded, because it's not an error in annotations
-                    continue
-                elif len(matched_boxes) == 0:
-                    # Handle unmatched boxes
-                    excluded_gt_info.add_message(
-                        "Sample '{}': GT skeleton #{} ({}) skipped - "
-                        "no matching boxes found".format(
-                            gt_sample.id,
-                            gt_skeleton_id,
-                            gt_label_cat[gt_skeleton.label].name,
-                        ),
-                        sample_id=gt_sample.id,
-                        sample_subset=gt_sample.subset,
-                    )
-                    excluded_gt_info.excluded_count += 1
-                    continue
-
-                # TODO: maybe check if the top match is good enough
-                # (high thresholds may lead to matching issues for small objects)
 
                 gt_count_per_class[gt_skeleton.label] = (
                     gt_count_per_class.get(gt_skeleton.label, 0) + 1
                 )
 
                 matched_skeletons.append(gt_skeleton)
-                skeleton_bbox_mapping[gt_skeleton_id] = matched_boxes[0].id
+                skeleton_bbox_mapping[gt_skeleton.id] = input_bbox.id
 
             return matched_skeletons
 
@@ -1762,6 +1771,17 @@ class SkeletonsFromBoxesTaskBuilder:
                     excluded_gt_info.total_count,
                 )
             )
+
+        self.logger.info(
+            "GT counts per class to be used for validation: {}".format(
+                self._format_list(
+                    [
+                        f"{gt_label_cat[label_id].name}: {count}"
+                        for label_id, count in gt_count_per_class.items()
+                    ]
+                )
+            )
+        )
 
         labels_with_few_gt = [
             gt_label_cat[label_id]

--- a/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py
@@ -351,7 +351,7 @@ class BoxesFromPointsTaskBuilder:
 
         if excluded_gt_info.excluded_count:
             self.logger.warning(
-                "Some GT boxes were excluded due to the errors found: {}".format(
+                "Some GT boxes were excluded due to the errors found: \n{}".format(
                     self._format_list(
                         [e.message for e in excluded_gt_info.messages], separator="\n"
                     )
@@ -509,7 +509,7 @@ class BoxesFromPointsTaskBuilder:
 
         if excluded_points_info.excluded_count:
             self.logger.warning(
-                "Some points were excluded due to the errors found: {}".format(
+                "Some points were excluded due to the errors found: \n{}".format(
                     self._format_list(
                         [e.message for e in excluded_points_info.messages], separator="\n"
                     )
@@ -542,27 +542,34 @@ class BoxesFromPointsTaskBuilder:
         return is_point_in_bbox(px, py, bbox)
 
     def _prepare_gt(self):
-        def _filter_ambiguous_skeletons(
+        def _find_unambiguous_matches(
             input_skeletons: List[dm.Skeleton],
             gt_boxes: List[dm.Bbox],
-        ) -> List[dm.Skeleton]:
-            filtered_skeletons: List[dm.Skeleton] = []
-            for input_skeleton in input_skeletons:
-                matched_boxes: List[dm.Bbox] = []
-                for gt_bbox in gt_boxes:
-                    if input_skeleton.label != gt_bbox.label:
-                        continue
+        ) -> List[Tuple[dm.Skeleton, dm.Bbox]]:
+            matches = [
+                [
+                    (input_skeleton.label == gt_bbox.label)
+                    and (
+                        self._is_point_in_bbox(
+                            *input_skeleton.elements[0].points[0:2], bbox=gt_bbox
+                        )
+                    )
+                    for gt_bbox in gt_boxes
+                ]
+                for input_skeleton in input_skeletons
+            ]
 
-                    input_point = input_skeleton.elements[0]
-                    if not self._is_point_in_bbox(*input_point.points[0:2], bbox=gt_bbox):
-                        continue
-
-                    matched_boxes.append(gt_bbox)
+            ambiguous_boxes: list[int] = set()
+            ambiguous_skeletons: list[int] = set()
+            for skeleton_idx, input_skeleton in enumerate(input_skeletons):
+                matched_boxes: List[dm.Bbox] = [
+                    gt_boxes[j] for j in range(len(gt_boxes)) if matches[skeleton_idx][j]
+                ]
 
                 if len(matched_boxes) > 1:
                     # Handle ambiguous matches
                     excluded_points_info.add_message(
-                        "Sample '{}': point #{} ({}) skipped - "
+                        "Sample '{}': point #{} ({}) and overlapping boxes skipped - "
                         "too many matching boxes ({}) found".format(
                             points_sample.id,
                             input_skeleton.id,
@@ -572,75 +579,79 @@ class BoxesFromPointsTaskBuilder:
                         sample_id=points_sample.id,
                         sample_subset=points_sample.subset,
                     )
-                    # Don't need to count as excluded, because it's not an error in annotations
+                    # not an error, should not be counted as excluded for an error
+                    ambiguous_skeletons.add(input_skeleton.id)
+                    ambiguous_boxes.update(a.id for a in matched_boxes)
                     continue
-                elif len(matched_boxes) == 1:
-                    filtered_skeletons.append(input_skeleton)
 
-            return filtered_skeletons
-
-        def _find_good_gt_boxes(
-            input_skeletons: List[dm.Skeleton],
-            gt_boxes: List[dm.Bbox],
-        ) -> List[dm.Bbox]:
-            # Exclude from further matching all the skeletons matching more than 1 GT bbox
-            input_skeletons = _filter_ambiguous_skeletons(input_skeletons, gt_boxes)
-
-            matched_boxes = []
-            visited_skeletons = set()
-            for gt_bbox in gt_boxes:
-                gt_bbox_id = gt_bbox.id
-
-                matched_skeletons: List[dm.Skeleton] = []
-                for input_skeleton in input_skeletons:
-                    skeleton_id = input_skeleton.id
-                    if skeleton_id in visited_skeletons:
-                        continue
-
-                    if input_skeleton.label != gt_bbox.label:
-                        continue
-
-                    input_point = input_skeleton.elements[0]
-                    if not self._is_point_in_bbox(*input_point.points[0:2], bbox=gt_bbox):
-                        continue
-
-                    matched_skeletons.append(input_skeleton)
-                    visited_skeletons.add(skeleton_id)
+            for gt_idx, gt_bbox in enumerate(gt_boxes):
+                matched_skeletons: List[dm.Skeleton] = [
+                    input_skeletons[i] for i in range(len(input_skeletons)) if matches[i][gt_idx]
+                ]
 
                 if len(matched_skeletons) > 1:
                     # Handle ambiguous matches
                     excluded_gt_info.add_message(
-                        "Sample '{}': GT bbox #{} ({}) skipped - "
+                        "Sample '{}': GT bbox #{} ({}) and overlapping points skipped - "
                         "too many matching points ({}) found".format(
                             gt_sample.id,
-                            gt_bbox_id,
+                            gt_bbox.id,
                             gt_label_cat[gt_bbox.label].name,
                             self._format_list([f"#{a.id}" for a in matched_skeletons]),
                         ),
                         sample_id=gt_sample.id,
                         sample_subset=gt_sample.subset,
                     )
-                    # Don't need to count as excluded, because it's not an error in annotations
+                    # not an error, should not be counted as excluded for an error
+                    ambiguous_boxes.add(gt_bbox.id)
+                    ambiguous_skeletons.update(a.id for a in matched_skeletons)
                     continue
-                elif len(matched_skeletons) == 0:
-                    # Handle unmatched boxes
+                elif not matched_skeletons:
+                    # Handle unmatched skeletons
                     excluded_gt_info.add_message(
                         "Sample '{}': GT bbox #{} ({}) skipped - "
                         "no matching points found".format(
                             gt_sample.id,
-                            gt_bbox_id,
+                            gt_bbox.id,
                             gt_label_cat[gt_bbox.label].name,
                         ),
                         sample_id=gt_sample.id,
                         sample_subset=gt_sample.subset,
                     )
-                    excluded_gt_info.excluded_count += 1
+                    excluded_gt_info.excluded_count += 1  # an error
                     continue
 
+            unambiguous_matches: List[Tuple[dm.Bbox, dm.Skeleton]] = []
+            for skeleton_idx, input_skeleton in enumerate(input_skeletons):
+                if input_skeleton.id in ambiguous_skeletons:
+                    continue
+
+                matched_bbox = None
+                for gt_idx, gt_bbox in enumerate(gt_boxes):
+                    if gt_bbox.id in ambiguous_boxes:
+                        continue
+
+                    if matches[skeleton_idx][gt_idx]:
+                        matched_bbox = gt_bbox
+                        break
+
+                if matched_bbox:
+                    unambiguous_matches.append((input_skeleton, matched_bbox))
+
+            return unambiguous_matches
+
+        def _find_good_gt_boxes(
+            input_skeletons: List[dm.Skeleton],
+            gt_boxes: List[dm.Bbox],
+        ) -> List[dm.Bbox]:
+            matches = _find_unambiguous_matches(input_skeletons, gt_boxes)
+
+            matched_boxes = []
+            for input_skeleton, gt_bbox in matches:
                 gt_count_per_class[gt_bbox.label] = gt_count_per_class.get(gt_bbox.label, 0) + 1
 
                 matched_boxes.append(gt_bbox)
-                bbox_point_mapping[gt_bbox_id] = matched_skeletons[0].id
+                bbox_point_mapping[gt_bbox.id] = input_skeleton.id
 
             return matched_boxes
 
@@ -690,7 +701,7 @@ class BoxesFromPointsTaskBuilder:
 
         if excluded_points_info.messages:
             self.logger.warning(
-                "Some points were excluded from GT due to the problems found: {}".format(
+                "Some points were excluded from GT due to the problems found: \n{}".format(
                     self._format_list(
                         [e.message for e in excluded_points_info.messages], separator="\n"
                     )
@@ -699,7 +710,7 @@ class BoxesFromPointsTaskBuilder:
 
         if excluded_gt_info.messages:
             self.logger.warning(
-                "Some GT annotations were excluded due to the problems found: {}".format(
+                "Some GT annotations were excluded due to the problems found: \n{}".format(
                     self._format_list(
                         [e.message for e in excluded_gt_info.messages], separator="\n"
                     )
@@ -716,6 +727,17 @@ class BoxesFromPointsTaskBuilder:
                     excluded_gt_info.total_count,
                 )
             )
+
+        self.logger.info(
+            "GT counts per class to be used for validation: {}".format(
+                self._format_list(
+                    [
+                        f"{gt_label_cat[label_id].name}: {count}"
+                        for label_id, count in gt_count_per_class.items()
+                    ]
+                )
+            )
+        )
 
         gt_labels_without_anns = [
             gt_label_cat[label_id]


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

Before the PR, during GT selection, ambiguous input annotations were excluded, but their matching GT annotations stood in place, and this could lead to incorrect GT-input matches after the exclusion (these matches should have been ambiguous without the first exclusion). In the end, this could result in incorrect GT, that could not be annotated correctly.

This PR changes the approach so that the all initially ambiguous annotations (both GT and input) are excluded simultaneously.

- Fixed GT preparation in the case of multiple overlapping annotations in GT and input points/boxes
- Improved logging
- Fully invisible skeletons with all the points **absent** will be excluded as errors now. Fully invisible, but with at least 1 occluded point will be kept, but excluded from GT till we figure out how to validate them correctly. They won't be considered errors

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
