### PR TITLE
[CVAT-M2] Fix gt paths in points and bbox annotation tasks

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/core/tasks/simple.py
+++ b/packages/examples/cvat/exchange-oracle/src/core/tasks/simple.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import datumaro as dm
+
+# These details are relevant for IMAGE_POINTS and IMAGE_BOXES tasks
+
+
+class TaskMetaLayout:
+    GT_FILENAME = "gt.json"
+
+
+class TaskMetaSerializer:
+    GT_DATASET_FORMAT = "coco_instances"
+
+    def serialize_gt_annotations(self, gt_dataset: dm.Dataset) -> bytes:
+        with TemporaryDirectory() as temp_dir:
+            gt_dataset_dir = os.path.join(temp_dir, "gt_dataset")
+            gt_dataset.export(gt_dataset_dir, self.GT_DATASET_FORMAT)
+            return (Path(gt_dataset_dir) / "annotations" / "instances_default.json").read_bytes()
+
+    def parse_gt_annotations(self, gt_dataset_data: bytes) -> dm.Dataset:
+        with TemporaryDirectory() as temp_dir:
+            annotations_filename = os.path.join(temp_dir, "annotations.json")
+            with open(annotations_filename, "wb") as f:
+                f.write(gt_dataset_data)
+
+            dataset = dm.Dataset.import_from(annotations_filename, format=self.GT_DATASET_FORMAT)
+            dataset.init_cache()
+            return dataset

--- a/packages/examples/cvat/exchange-oracle/src/crons/process_recording_oracle_webhooks.py
+++ b/packages/examples/cvat/exchange-oracle/src/crons/process_recording_oracle_webhooks.py
@@ -99,7 +99,6 @@ def handle_recording_oracle_event(webhook: Webhook, *, db_session: Session, logg
                             new_status, webhook.escrow_address, project.cvat_id
                         )
                     )
-
                     cvat_db_service.update_project_status(db_session, project.id, new_status)
 
         case RecordingOracleEventTypes.task_rejected:
@@ -140,9 +139,13 @@ def handle_recording_oracle_event(webhook: Webhook, *, db_session: Session, logg
                             db_session, task_id, TaskStatuses.annotation
                         )
 
-                    cvat_db_service.update_project_status(
-                        db_session, project.id, ProjectStatuses.annotation
+                    new_status = ProjectStatuses.annotation
+                    logger.info(
+                        "Changing project status to {} (escrow_address={}, project={})".format(
+                            new_status, webhook.escrow_address, project.cvat_id
+                        )
                     )
+                    cvat_db_service.update_project_status(db_session, project.id, new_status)
 
         case _:
             assert False, f"Unknown recording oracle event {webhook.event_type}"

--- a/packages/examples/cvat/exchange-oracle/tests/utils/dataset_helpers.py
+++ b/packages/examples/cvat/exchange-oracle/tests/utils/dataset_helpers.py
@@ -1,0 +1,46 @@
+import json
+
+
+def build_gt_dataset(filenames: list[str]) -> str:
+    data = {
+        "licenses": [{"name": "", "id": 0, "url": ""}],
+        "info": {
+            "contributor": "",
+            "date_created": "",
+            "description": "",
+            "url": "",
+            "version": "",
+            "year": "",
+        },
+        "categories": [{"id": 1, "name": "cat", "supercategory": ""}],
+        "images": [],
+        "annotations": [],
+    }
+
+    for filename in filenames:
+        image_id = len(data["images"]) + 1
+        data["images"].append(
+            {
+                "id": image_id,
+                "width": 640,
+                "height": 480,
+                "file_name": filename,
+                "license": 0,
+                "flickr_url": "",
+                "coco_url": "",
+                "date_captured": 0,
+            }
+        )
+        data["annotations"].append(
+            {
+                "id": len("annotations") + 1,
+                "image_id": image_id,
+                "category_id": 1,
+                "segmentation": [],
+                "area": 4,
+                "bbox": [2, 4, 2, 2],
+                "iscrowd": 0,
+            }
+        )
+
+    return json.dumps(data)

--- a/packages/examples/cvat/recording-oracle/src/core/config.py
+++ b/packages/examples/cvat/recording-oracle/src/core/config.py
@@ -134,7 +134,7 @@ class FeaturesConfig:
 
 class ValidationConfig:
     default_point_validity_relative_radius = float(
-        os.environ.get("DEFAULT_POINT_VALIDITY_RELATIVE_RADIUS", 0.8)
+        os.environ.get("DEFAULT_POINT_VALIDITY_RELATIVE_RADIUS", 0.9)
     )
 
     default_oks_sigma = float(

--- a/packages/examples/cvat/recording-oracle/src/core/tasks/simple.py
+++ b/packages/examples/cvat/recording-oracle/src/core/tasks/simple.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import datumaro as dm
+
+# These details are relevant for IMAGE_POINTS and IMAGE_BOXES tasks
+
+
+class TaskMetaLayout:
+    GT_FILENAME = "gt.json"
+
+
+class TaskMetaSerializer:
+    GT_DATASET_FORMAT = "coco_instances"
+
+    def serialize_gt_annotations(self, gt_dataset: dm.Dataset) -> bytes:
+        with TemporaryDirectory() as temp_dir:
+            gt_dataset_dir = os.path.join(temp_dir, "gt_dataset")
+            gt_dataset.export(gt_dataset_dir, self.GT_DATASET_FORMAT)
+            return (Path(gt_dataset_dir) / "annotations" / "instances_default.json").read_bytes()
+
+    def parse_gt_annotations(self, gt_dataset_data: bytes) -> dm.Dataset:
+        with TemporaryDirectory() as temp_dir:
+            annotations_filename = os.path.join(temp_dir, "annotations.json")
+            with open(annotations_filename, "wb") as f:
+                f.write(gt_dataset_data)
+
+            dataset = dm.Dataset.import_from(annotations_filename, format=self.GT_DATASET_FORMAT)
+            dataset.init_cache()
+            return dataset


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

Prior this PR, Exchange Oracle would create tasks using the full image paths in the input bucket. Recording oracle would validate using the original GT. If the input data has some prefix and the original GT contains paths relative to the input data path (e.g. just the file names), the validation fails, as GT images matching the current validated job file names (which are full) can't be found in the GT dataset.

This PR fixes this by saving an updated GT during task creation in the private Exchange Oracle bucket.

- Added saving of the updated GT during task creation for IMAGE_POINTS and IMAGE_BOXES task types
- Added logging on project return to the annotation state after the validation was rejected
- Increased the default point validity radius to 0.9 (from 0.8). This value seems to be better suited for typical scenarios

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
