### PR TITLE
[Reputation Oracle] Rework CVAT payouts

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/dto/result.ts
+++ b/packages/apps/reputation-oracle/server/src/common/dto/result.ts
@@ -33,10 +33,8 @@ export class ImageLabelBinaryJobResults {
   worker_performance: WorkerPerformanceResult[];
 }
 export class CvatAnnotationMetaJobs {
-  id: number;
   job_id: number;
-  annotator_wallet_address: string;
-  annotation_quality: number;
+  final_result_id: number;
 }
 
 export class CvatAnnotationMetaResults {

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
@@ -21,6 +21,7 @@ import { PayoutService } from './payout.service';
 import { createMock } from '@golevelup/ts-jest';
 import { CvatManifestDto } from '../../common/dto/manifest';
 import { ErrorResults } from '../../common/constants/errors';
+import { CvatAnnotationMeta } from 'src/common/dto/result';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -253,19 +254,23 @@ describe('PayoutService', () => {
       const escrowAddress = MOCK_ADDRESS;
       const chainId = ChainId.LOCALHOST;
 
-      const results = {
+      const results: CvatAnnotationMeta = {
         jobs: [
           {
-            id: 1,
             job_id: 1,
-            annotator_wallet_address: MOCK_ADDRESS,
-            annotation_quality: 0.96,
+            final_result_id: 3,
           },
         ],
         results: [
           {
             id: 2,
-            job_id: 2,
+            job_id: 1,
+            annotator_wallet_address: MOCK_ADDRESS,
+            annotation_quality: 0.6,
+          },
+          {
+            id: 3,
+            job_id: 1,
             annotator_wallet_address: MOCK_ADDRESS,
             annotation_quality: 0.96,
           },
@@ -289,6 +294,8 @@ describe('PayoutService', () => {
         url: expect.any(String),
         hash: expect.any(String),
       });
+      expect(result.recipients.length).toEqual(1);
+      expect(result.amounts.length).toEqual(1);
     });
   });
 });

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
@@ -220,8 +220,8 @@ export class PayoutService {
         (result) => result.id === job.final_result_id,
       );
       if (
-        finalResult &&
-        finalResult.annotation_quality >= manifest.validation.min_quality
+        finalResult
+        // && finalResult.annotation_quality >= manifest.validation.min_quality
       ) {
         const existingValue =
           accMap.get(finalResult.annotator_wallet_address) || 0n;

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
@@ -215,10 +215,20 @@ export class PayoutService {
     }
 
     const bountyValue = ethers.parseUnits(manifest.job_bounty, 18);
-    const accumulatedBounties = annotations.results.reduce((accMap, curr) => {
-      if (curr.annotation_quality >= manifest.validation.min_quality) {
-        const existingValue = accMap.get(curr.annotator_wallet_address) || 0n;
-        accMap.set(curr.annotator_wallet_address, existingValue + bountyValue);
+    const accumulatedBounties = annotations.jobs.reduce((accMap, job) => {
+      const finalResult = annotations.results.find(
+        (result) => result.id === job.final_result_id,
+      );
+      if (
+        finalResult &&
+        finalResult.annotation_quality >= manifest.validation.min_quality
+      ) {
+        const existingValue =
+          accMap.get(finalResult.annotator_wallet_address) || 0n;
+        accMap.set(
+          finalResult.annotator_wallet_address,
+          existingValue + bountyValue,
+        );
       }
       return accMap;
     }, new Map<string, typeof bountyValue>());


### PR DESCRIPTION
## Description

Rework CVAT payouts calculation to avoid situations where 1 task can be paid twice.

## Summary of changes

- Modify objects to match:

`{
  "jobs": [
    {
      "job_id": int,
      "final_result_id": int,
    }, ...
  ],
  "results": [
    {
      "id": int,
      "job_id": int,
      "annotator_wallet_address": Address,
      "annotation_quality": number,
    }, ...
  ]
}`

- Replace the iteration over `results` with a loop over `jobs`

## How test the changes

`yarn test`

## Related issues
#1901 