### PR TITLE
[CVAT-M2] Improve export of merged annotation results

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/utils/annotations.py
+++ b/packages/examples/cvat/exchange-oracle/src/utils/annotations.py
@@ -81,7 +81,7 @@ def convert_point_arrays_dataset_to_1_point_skeletons(
     """
 
     def _get_skeleton_label(original_label: str) -> str:
-        return original_label + "_sk"
+        return original_label
 
     new_label_cat = dm.LabelCategories.from_iterable(
         [_get_skeleton_label(label) for label in labels]


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

This PR allows to use the final exported annotations without additional actions from the user.

- Added removal of common filename prefix in the exported annotations (only the task data path is removed)
- Skeleton is renamed into the point name (so that the skeleton and the point have the same label) in the IMAGE_POINTS task
- Fixed export of GT annotations in the final annotations of the IMAGE_POINTS task. GT annotations were missing or could have incorrect label or position

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
