### PR TITLE
[CVAT-M2] Move project annotations request closer to downloading

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/handlers/completed_escrows.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/completed_escrows.py
@@ -91,7 +91,6 @@ class _CompletedEscrowsHandler:
                 # Request dataset preparation beforehand
                 for job in jobs:
                     cvat_api.request_job_annotations(job.cvat_id, format_name=annotation_format)
-                cvat_api.request_project_annotations(project.cvat_id, format_name=annotation_format)
 
                 # Collect raw annotations from CVAT, validate and convert them
                 # into a recording oracle suitable format
@@ -111,6 +110,9 @@ class _CompletedEscrowsHandler:
                         file=job_annotations_file,
                     )
 
+                # Request project annotations right before downloading
+                # to avoid occasional data removals
+                cvat_api.request_project_annotations(project.cvat_id, format_name=annotation_format)
                 project_annotations_file = cvat_api.get_project_annotations(
                     project.cvat_id, format_name=annotation_format
                 )


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

This PR tries to address occasional project export failures in CVAT by moving the export request right before the downloading.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
