### PR TITLE
[Job Launcher server] Change the way of getting elements count

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -19,6 +19,7 @@ export enum ErrorJob {
   GroundThuthValidationFailed = 'Ground thuth validation failed',
   ManifestHashNotExist = 'Manifest hash does not exist',
   DataNotExist = 'Data does not exist',
+  ImageConsistency = 'Ground Truth images not found in dataset',
 }
 
 /**

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -123,6 +123,7 @@ import { CvatConfigService } from '../../common/config/cvat-config.service';
 import { PGPConfigService } from '../../common/config/pgp-config.service';
 import { S3ConfigService } from '../../common/config/s3-config.service';
 import { CvatCalculateJobBounty } from './job.interface';
+import { listObjectsInBucket } from '../../common/utils/storage';
 
 const rate = 1.5;
 jest.mock('@human-protocol/sdk', () => ({
@@ -1105,21 +1106,6 @@ describe('JobService', () => {
 
   describe('calculateJobBounty', () => {
     it('should calculate the job bounty correctly for image boxes from points type', async () => {
-      const storageDatasetMock: any = {
-        dataset: {
-          provider: StorageProviders.AWS,
-          region: AWSRegions.EU_CENTRAL_1,
-          bucketName: 'bucket',
-          path: 'folder/test',
-        },
-        points: {
-          provider: StorageProviders.AWS,
-          region: AWSRegions.EU_CENTRAL_1,
-          bucketName: 'bucket',
-          path: 'folder/test',
-        },
-      };
-
       jest
         .spyOn(storageService, 'download')
         .mockResolvedValueOnce(MOCK_CVAT_DATA)
@@ -1220,6 +1206,18 @@ describe('JobService', () => {
         .mockImplementation(() => ({
           getPublicKey: jest.fn().mockResolvedValue(MOCK_PGP_PUBLIC_KEY),
         }));
+
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
+
+      (listObjectsInBucket as any).mockResolvedValueOnce([
+        '1.jpg',
+        '2.jpg',
+        '3.jpg',
+        '4.jpg',
+        '5.jpg',
+      ]);
 
       await jobService.createJob(
         userId,
@@ -1435,7 +1433,7 @@ describe('JobService', () => {
       expect(paymentService.getUserBalance).toHaveBeenCalledWith(userId);
     });
 
-    it('should create a fortune job successfully on network selected from round robin logic', async () => {
+    it('should create a image label job successfully on network selected from round robin logic', async () => {
       const fundAmount = imageLabelBinaryJobDto.fundAmount;
       const fee = (MOCK_JOB_LAUNCHER_FEE / 100) * fundAmount;
 
@@ -1453,6 +1451,18 @@ describe('JobService', () => {
         .mockImplementation(() => ({
           getPublicKey: jest.fn().mockResolvedValue(MOCK_PGP_PUBLIC_KEY),
         }));
+
+      jest
+        .spyOn(storageService, 'download')
+        .mockResolvedValueOnce(MOCK_CVAT_GT);
+
+      (listObjectsInBucket as any).mockResolvedValueOnce([
+        '1.jpg',
+        '2.jpg',
+        '3.jpg',
+        '4.jpg',
+        '5.jpg',
+      ]);
 
       await jobService.createJob(userId, JobRequestType.IMAGE_POINTS, {
         ...imageLabelBinaryJobDto,

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -512,8 +512,16 @@ export class JobService {
       generateUrls: () => ({ dataUrl: new URL(''), gtUrl: new URL('') }),
     },
     [JobRequestType.IMAGE_BOXES]: {
-      getElementsCount: async (urls: GenerateUrls) =>
-        (await listObjectsInBucket(urls.dataUrl)).length,
+      getElementsCount: async (urls: GenerateUrls) => {
+        const gt = await this.storageService.download(
+          `${urls.gtUrl.protocol}//${urls.gtUrl.host}${urls.gtUrl.pathname}`,
+        );
+        const data = await listObjectsInBucket(urls.dataUrl);
+
+        await this.checkImageConsistency(gt.images, data);
+
+        return data.length - gt.images.length;
+      },
       generateUrls: (
         data: CvatDataDto,
         groundTruth: StorageDataDto,
@@ -527,8 +535,16 @@ export class JobService {
       },
     },
     [JobRequestType.IMAGE_POINTS]: {
-      getElementsCount: async (urls: GenerateUrls) =>
-        (await listObjectsInBucket(urls.dataUrl)).length,
+      getElementsCount: async (urls: GenerateUrls) => {
+        const gt = await this.storageService.download(
+          `${urls.gtUrl.protocol}//${urls.gtUrl.host}${urls.gtUrl.pathname}`,
+        );
+        const data = await listObjectsInBucket(urls.dataUrl);
+
+        await this.checkImageConsistency(gt.images, data);
+
+        return data.length - gt.images.length;
+      },
       generateUrls: (
         data: CvatDataDto,
         groundTruth: StorageDataDto,
@@ -645,6 +661,23 @@ export class JobService {
       },
     },
   };
+
+  private async checkImageConsistency(
+    gtImages: any[],
+    dataFiles: string[],
+  ): Promise<void> {
+    const gtFileNames = gtImages.map((image: any) => image.file_name);
+    const baseFileNames = dataFiles.map((fileName) =>
+      fileName.split('/').pop(),
+    );
+    const missingFileNames = gtFileNames.filter(
+      (fileName: any) => !baseFileNames.includes(fileName),
+    );
+
+    if (missingFileNames.length !== 0) {
+      throw new BadRequestException(ErrorJob.ImageConsistency);
+    }
+  }
 
   public async createJob(
     userId: number,


### PR DESCRIPTION
## Description

Change the way of getting elements count for `IMAGE_BOXES` and `IMAGE_POINTS` job types

## Summary of changes

- Get all elements from dataUrl
- Get elements from gtUrl ("images")
- Make sure that all filenames enlisted in gtUrl ("images") exist in dataset. If not, throw an error.
- Count all elements in dataset and subtract amount of elements in gt ("images")

## How test the changes

`yarn test`

## Related issues
#1937