### PR TITLE
[Reputation Oracle] Rework kyc module

### DIFF
--- a/packages/apps/reputation-oracle/server/src/app.module.ts
+++ b/packages/apps/reputation-oracle/server/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
@@ -18,6 +18,7 @@ import { KycModule } from './modules/kyc/kyc.module';
 import { CronJobModule } from './modules/cron-job/cron-job.module';
 import { PayoutModule } from './modules/payout/payout.module';
 import { EnvConfigModule } from './common/config/config.module';
+import { DatabaseExceptionFilter } from './common/exceptions/database.filter';
 
 @Module({
   providers: [
@@ -28,6 +29,10 @@ import { EnvConfigModule } from './common/config/config.module';
     {
       provide: APP_INTERCEPTOR,
       useClass: SnakeCaseInterceptor,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: DatabaseExceptionFilter,
     },
   ],
   imports: [

--- a/packages/apps/reputation-oracle/server/src/common/exceptions/database.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/exceptions/database.filter.ts
@@ -1,0 +1,31 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  Logger,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { DatabaseError } from '../../database/database.error';
+
+@Catch(DatabaseError)
+export class DatabaseExceptionFilter implements ExceptionFilter {
+  private logger = new Logger(DatabaseExceptionFilter.name);
+
+  catch(exception: DatabaseError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status = HttpStatus.UNPROCESSABLE_ENTITY;
+    const message = exception.message;
+    this.logger.error(`Database error: ${message}`, exception.stack);
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      message: message,
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/common/exceptions/kyc.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/exceptions/kyc.filter.ts
@@ -1,0 +1,36 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  Logger,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { KycError } from '../../modules/kyc/kyc.error';
+import { ErrorKyc } from '../constants/errors';
+
+@Catch(KycError)
+export class KycExceptionFilter implements ExceptionFilter {
+  private logger = new Logger(KycExceptionFilter.name);
+
+  catch(exception: KycError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    let status = HttpStatus.BAD_REQUEST;
+
+    if (exception.message === ErrorKyc.InvalidSynapsAPIResponse) {
+      status = HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+    const message = exception.message;
+    this.logger.error(`KYC error: ${message}`, exception.stack);
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      message: message,
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
@@ -13,6 +13,7 @@ import {
   Post,
   Query,
   Req,
+  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../common/guards';
@@ -23,8 +24,10 @@ import {
   KycUpdateWebhookQueryDto,
 } from './kyc.dto';
 import { KycService } from './kyc.service';
+import { KycExceptionFilter } from '../../common/exceptions/kyc.filter';
 
 @ApiTags('Kyc')
+@UseFilters(KycExceptionFilter)
 @Controller('/kyc')
 export class KycController {
   constructor(private readonly kycService: KycService) {}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.error.ts
@@ -1,0 +1,5 @@
+export class KycError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.repository.ts
@@ -1,66 +1,25 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import {
-  FindOptionsWhere,
-  FindManyOptions,
-  FindOneOptions,
-  Repository,
-} from 'typeorm';
-
+import { Injectable, Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { BaseRepository } from '../../database/base.repository';
 import { KycEntity } from './kyc.entity';
-import { ErrorKyc } from '../../common/constants/errors';
-import { KycCreateDto, KycUpdateDto } from './kyc.dto';
 
 @Injectable()
-export class KycRepository {
+export class KycRepository extends BaseRepository<KycEntity> {
   private readonly logger = new Logger(KycRepository.name);
 
-  constructor(
-    @InjectRepository(KycEntity)
-    private readonly kycEntityRepository: Repository<KycEntity>,
-  ) {}
-
-  public async updateOne(
-    where: FindOptionsWhere<KycEntity>,
-    dto: Partial<KycUpdateDto>,
-  ): Promise<KycEntity> {
-    const kycEntity = await this.kycEntityRepository.findOneBy(where);
-
-    if (!kycEntity) {
-      this.logger.log(ErrorKyc.NotFound, KycRepository.name);
-      throw new NotFoundException(ErrorKyc.NotFound);
-    }
-
-    Object.assign(kycEntity, dto);
-    return kycEntity.save();
+  constructor(private dataSource: DataSource) {
+    super(KycEntity, dataSource);
   }
 
-  public async findOne(
-    where: FindOptionsWhere<KycEntity>,
-    options?: FindOneOptions<KycEntity>,
+  public async findOneBySessionId(
+    sessionId: string,
   ): Promise<KycEntity | null> {
-    const userEntity = await this.kycEntityRepository.findOne({
-      where,
-      ...options,
+    const userEntity = await this.findOne({
+      where: {
+        sessionId: sessionId,
+      },
     });
 
     return userEntity;
-  }
-
-  public find(
-    where: FindOptionsWhere<KycEntity>,
-    options?: FindManyOptions<KycEntity>,
-  ): Promise<KycEntity[]> {
-    return this.kycEntityRepository.find({
-      where,
-      order: {
-        createdAt: 'DESC',
-      },
-      ...options,
-    });
-  }
-
-  public async create(dto: KycCreateDto): Promise<KycEntity> {
-    return this.kycEntityRepository.create(dto).save();
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.spec.ts
@@ -193,7 +193,9 @@ describe('Kyc Service', () => {
         });
       });
 
-      jest.spyOn(kycRepository, 'create').mockResolvedValue({} as KycEntity);
+      jest
+        .spyOn(kycRepository, 'createUnique')
+        .mockResolvedValue({} as KycEntity);
 
       const result = await kycService.initSession(mockUserEntity as any);
 
@@ -208,7 +210,7 @@ describe('Kyc Service', () => {
           headers: { 'Api-Key': synapsConfigService.apiKey },
         },
       );
-      expect(kycRepository.create).toHaveBeenCalledWith({
+      expect(kycRepository.createUnique).toHaveBeenCalledWith({
         sessionId: '123',
         status: KycStatus.NONE,
         userId: 1,
@@ -266,10 +268,9 @@ describe('Kyc Service', () => {
         mockKycUpdate,
       );
 
-      expect(kycRepository.updateOne).toHaveBeenCalledWith(
-        { sessionId: '123' },
-        { status: KycStatus.APPROVED },
-      );
+      expect(kycRepository.updateOne).toHaveBeenCalledWith({
+        status: KycStatus.APPROVED,
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Rework kyc.repository to use base repository.
Stop throwing http exceptions on a service level.

## Summary of changes

- Create a new error to be thrown in Kyc service.
- Replace all http exceptions with the new error.
- Rework DB to use baseRepository.

## How test the changes

`yarn test`

## Related issues
#1894