### PR TITLE
[Reputation Oracle] Rework reputation module

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/exceptions/reputation.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/exceptions/reputation.filter.ts
@@ -1,0 +1,32 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  Logger,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { ReputationError } from '../../modules/reputation/reputation.error';
+
+@Catch(ReputationError)
+export class ReputationExceptionFilter implements ExceptionFilter {
+  private logger = new Logger(ReputationExceptionFilter.name);
+
+  catch(exception: ReputationError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status = HttpStatus.BAD_REQUEST;
+
+    const message = exception.message;
+    this.logger.error(`Reputation error: ${message}`, exception.stack);
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      message: message,
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -178,7 +178,7 @@ export class CronJobService {
                 await escrowClient.getJobLauncherAddress(escrowAddress),
               )
             ).webhookUrl,
-            // Temporarily disable sending webhook to Recoring Oracle
+            // Temporarily disable sending webhook to Recording Oracle
             // (
             //   await OperatorUtils.getLeader(
             //     chainId,

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseFilters } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -14,9 +14,11 @@ import {
   ReputationGetParamsDto,
   ReputationGetQueryDto,
 } from './reputation.dto';
+import { ReputationExceptionFilter } from '../../common/exceptions/reputation.filter';
 
 @Public()
 @ApiTags('Reputation')
+@UseFilters(ReputationExceptionFilter)
 @Controller('reputation')
 export class ReputationController {
   constructor(private readonly reputationService: ReputationService) {}

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.ts
@@ -1,0 +1,5 @@
+export class ReputationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
@@ -305,14 +305,16 @@ describe('ReputationService', () => {
 
     it('should create a new reputation entity if not found', async () => {
       jest
-        .spyOn(reputationRepository, 'findOne')
+        .spyOn(reputationRepository, 'findOneByAddress')
         .mockResolvedValueOnce(undefined as any);
-      jest.spyOn(reputationRepository, 'create');
+      jest.spyOn(reputationRepository, 'createUnique');
 
       await reputationService.increaseReputation(chainId, address, type);
 
-      expect(reputationRepository.findOne).toHaveBeenCalledWith({ address });
-      expect(reputationRepository.create).toHaveBeenCalledWith({
+      expect(reputationRepository.findOneByAddress).toHaveBeenCalledWith(
+        address,
+      );
+      expect(reputationRepository.createUnique).toHaveBeenCalledWith({
         chainId,
         address,
         reputationPoints: 1,
@@ -328,12 +330,14 @@ describe('ReputationService', () => {
       };
 
       jest
-        .spyOn(reputationRepository, 'findOne')
+        .spyOn(reputationRepository, 'findOneByAddress')
         .mockResolvedValueOnce(reputationEntity as ReputationEntity);
 
       await reputationService.increaseReputation(chainId, address, type);
 
-      expect(reputationRepository.findOne).toHaveBeenCalledWith({ address });
+      expect(reputationRepository.findOneByAddress).toHaveBeenCalledWith(
+        address,
+      );
       expect(reputationEntity.reputationPoints).toBe(2);
       expect(reputationEntity.save).toHaveBeenCalled();
     });
@@ -346,14 +350,16 @@ describe('ReputationService', () => {
 
     it('should create a new reputation entity if not found', async () => {
       jest
-        .spyOn(reputationRepository, 'findOne')
+        .spyOn(reputationRepository, 'findOneByAddress')
         .mockResolvedValueOnce(undefined as any);
-      jest.spyOn(reputationRepository, 'create');
+      jest.spyOn(reputationRepository, 'createUnique');
 
       await reputationService.decreaseReputation(chainId, address, type);
 
-      expect(reputationRepository.findOne).toHaveBeenCalledWith({ address });
-      expect(reputationRepository.create).toHaveBeenCalledWith({
+      expect(reputationRepository.findOneByAddress).toHaveBeenCalledWith(
+        address,
+      );
+      expect(reputationRepository.createUnique).toHaveBeenCalledWith({
         chainId,
         address,
         reputationPoints: 0,
@@ -369,12 +375,14 @@ describe('ReputationService', () => {
       };
 
       jest
-        .spyOn(reputationRepository, 'findOne')
+        .spyOn(reputationRepository, 'findOneByAddress')
         .mockResolvedValueOnce(reputationEntity as ReputationEntity);
 
       await reputationService.decreaseReputation(chainId, address, type);
 
-      expect(reputationRepository.findOne).toHaveBeenCalledWith({ address });
+      expect(reputationRepository.findOneByAddress).toHaveBeenCalledWith(
+        address,
+      );
       expect(reputationEntity.reputationPoints).toBe(0);
       expect(reputationEntity.save).toHaveBeenCalled();
     });
@@ -411,7 +419,7 @@ describe('ReputationService', () => {
       };
 
       jest
-        .spyOn(reputationRepository, 'findOne')
+        .spyOn(reputationRepository, 'findOneByAddressAndChainId')
         .mockResolvedValueOnce(reputationEntity as ReputationEntity);
 
       const result = await reputationService.getReputation(chainId, address);
@@ -422,10 +430,9 @@ describe('ReputationService', () => {
         reputation: ReputationLevel.LOW,
       };
 
-      expect(reputationRepository.findOne).toHaveBeenCalledWith({
-        chainId,
-        address,
-      });
+      expect(
+        reputationRepository.findOneByAddressAndChainId,
+      ).toHaveBeenCalledWith(address, chainId);
       expect(result).toEqual(resultReputation);
     });
   });
@@ -442,7 +449,7 @@ describe('ReputationService', () => {
       };
 
       jest
-        .spyOn(reputationRepository, 'find')
+        .spyOn(reputationRepository, 'findByChainId')
         .mockResolvedValueOnce([reputationEntity as ReputationEntity]);
 
       const result = await reputationService.getAllReputations();
@@ -453,7 +460,7 @@ describe('ReputationService', () => {
         reputation: ReputationLevel.LOW,
       };
 
-      expect(reputationRepository.find).toHaveBeenCalled();
+      expect(reputationRepository.findByChainId).toHaveBeenCalled();
       expect(result).toEqual([resultReputation]);
     });
   });


### PR DESCRIPTION
## Description

Rework reputation.repository to use base repository.
Stop throwing http exceptions on a service level.

## Summary of changes

- Create a new error to be thrown in reputation service.
- Replace all http exceptions with the new error.
- Rework DB to use baseRepository.

## How test the changes

`yarn test`

## Related issues
#1895
