### PR TITLE
[Fortune Exchange Oracle] feat: Add assignment_id to query param

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.dto.ts
@@ -54,6 +54,11 @@ export class GetAssignmentsDto extends PageOptionsDto {
   @IsEnum(AssignmentStatus)
   @IsOptional()
   status: AssignmentStatus;
+
+  @ApiPropertyOptional({ name: 'assignment_id' })
+  @IsOptional()
+  @IsString()
+  assignmentId: string;
 }
 
 export class AssignmentDto {

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.interface.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.interface.ts
@@ -4,6 +4,7 @@ import { AssignmentEntity } from './assignment.entity';
 
 export interface AssignmentFilterData {
   chainId?: number;
+  assignmentId?: string;
   escrowAddress?: string;
   status?: AssignmentStatus;
   sortField?: AssignmentSortField;

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.repository.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.repository.ts
@@ -132,6 +132,11 @@ export class AssignmentRepository extends BaseRepository<AssignmentEntity> {
         chainId: data.chainId,
       });
     }
+    if (data.assignmentId !== undefined) {
+      queryBuilder.andWhere('assignment.id = :assignmentId', {
+        assignmentId: data.assignmentId,
+      });
+    }
     if (data.escrowAddress) {
       queryBuilder.andWhere('job.escrowAddress = :escrowAddress', {
         escrowAddress: data.escrowAddress,


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Adding `assignment_id` to query param list to `/assignments` endpoint.

## Summary of changes
- Added new query param, and updated the assignment repository to support this filtering param.

<!-- At a high level, what parts of the code did you change and why? -->

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #1974
