### PR TITLE
[Governance] Fix Missing Access Control 

### DIFF
--- a/packages/core/contracts/governance/DAOSpokeContract.sol
+++ b/packages/core/contracts/governance/DAOSpokeContract.sol
@@ -302,7 +302,9 @@ contract DAOSpokeContract is IWormholeReceiver, Magistrate {
         }
     }
 
-    function sendVoteResultToHub(uint256 proposalId) public payable {
+    function sendVoteResultToHub(
+        uint256 proposalId
+    ) public payable onlyMagistrate {
         require(
             proposals[proposalId].voteFinished,
             'DAOSpokeContract: vote is not finished'

--- a/packages/core/test/DAOSpokeContract.ts
+++ b/packages/core/test/DAOSpokeContract.ts
@@ -589,6 +589,29 @@ describe('DAOSpokeContract', function () {
       );
     });
 
+    it('should revert when the caller is not the magistrate', async () => {
+      const proposalId = await createProposalOnSpoke(
+        daoSpoke,
+        wormholeMockForDaoSpoke,
+        1,
+        await governor.getAddress()
+      );
+
+      await finishProposal(
+        daoSpoke,
+        wormholeMockForDaoSpoke,
+        proposalId,
+        await governor.getAddress()
+      );
+
+      const proposal = await daoSpoke.proposals(proposalId);
+      expect(proposal.voteFinished).to.be.true;
+
+      await expect(
+        daoSpoke.connect(user1).sendVoteResultToHub(proposalId)
+      ).to.be.revertedWith('Magistrate: caller is not the magistrate');
+    });
+
     it('should send vote result to hub', async () => {
       const proposalId = await createProposalOnSpoke(
         daoSpoke,


### PR DESCRIPTION
## Description

-  There is a missing Access Control to `sendVoteResultToHub` on `DAOSpokeContract.sol `

## Summary of changes

- Modify the function `sendVoteResultToHub` for more security. 

Closes #1994

