### PR TITLE
[Governance] fix: remove estimateTimestampFromBlock function

### DIFF
--- a/packages/core/contracts/governance/MetaHumanGovernor.sol
+++ b/packages/core/contracts/governance/MetaHumanGovernor.sol
@@ -398,12 +398,8 @@ contract MetaHumanGovernor is
         //create snapshot of current spokes
         createSnapshot(proposalId);
 
-        uint256 voteStartTimestamp = estimateTimestampFromBlock(
-            proposalSnapshot(proposalId)
-        );
-        uint256 voteEndTimestamp = estimateTimestampFromBlock(
-            proposalDeadline(proposalId)
-        );
+        uint256 voteStartTimestamp = proposalSnapshot(proposalId);
+        uint256 voteEndTimestamp = proposalDeadline(proposalId);
 
         // Sends the proposal to all of the other spoke contracts
         if (spokeContractsSnapshots[proposalId].length > 0) {
@@ -466,31 +462,6 @@ contract MetaHumanGovernor is
             valueToSend,
             GAS_LIMIT
         );
-    }
-
-    /**
-     * @dev Estimates timestamp when given block number should be the current block.
-     *  @return blockToEstimate Block to estimate the timestamp for.
-     */
-    function estimateTimestampFromBlock(
-        uint256 blockToEstimate
-    ) internal view returns (uint256) {
-        uint256 currentTimestamp = block.timestamp;
-        uint256 currentBlock = block.number;
-        uint256 estimatedTimestamp = 0;
-        if (blockToEstimate > currentBlock) {
-            //future
-            uint256 blockDifference = blockToEstimate - currentBlock;
-            uint256 timeDifference = blockDifference * secondsPerBlock;
-            estimatedTimestamp = currentTimestamp + timeDifference;
-        } else {
-            //past
-            uint256 blockDifference = currentBlock - blockToEstimate;
-            uint256 timeDifference = blockDifference * secondsPerBlock;
-            estimatedTimestamp = currentTimestamp - timeDifference;
-        }
-
-        return estimatedTimestamp;
     }
 
     // The following functions are overrides required by Solidity.


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Per Certik comments, we need to remove `estimateTimestampFromBlock` since we switched proposal operation mode form block number to timestamps.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Removed `estimateTimestampFromBlock` function, and its usage.

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
