### PR TITLE
[Job Launcher] Fixed login/logout

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Auth/ValidateEmailForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Auth/ValidateEmailForm.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, CircularProgress, Grid, Typography } from '@mui/material';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as authService from '../../services/auth';
 import { useAppDispatch, useAppSelector } from '../../state';
 import { signOut } from '../../state/auth/reducer';
@@ -9,6 +10,7 @@ export default function VerifyEmailForm() {
   const [emailSent, setEmailSent] = useState(false);
   const { user, refreshToken } = useAppSelector((state) => state.auth);
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
   const handleResend = async () => {
     setIsLoading(true);
@@ -33,6 +35,7 @@ export default function VerifyEmailForm() {
     }
     dispatch(signOut());
     setIsLoading(false);
+    navigate('/');
   };
 
   if (isLoading) {

--- a/packages/apps/job-launcher/server/src/common/constants/index.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/index.ts
@@ -66,5 +66,6 @@ export const HCAPTCHA_ORACLE_STAKE = 0.05;
 export const HCAPTCHA_NOT_PRESENTED_LABEL = 'Not presented';
 
 export const RESEND_EMAIL_VERIFICATION_PATH = '/auth/resend-email-verification';
+export const LOGOUT_PATH = '/auth/logout';
 
 export const E2E_TEST_ENV = 'test-e2e';

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.service.ts
@@ -160,7 +160,7 @@ export class AuthService {
     newRefreshTokenEntity.type = TokenType.REFRESH;
     const date = new Date();
     newRefreshTokenEntity.expiresAt = new Date(
-      date.getTime() + this.authConfigService.refreshTokenExpiresIn,
+      date.getTime() + this.authConfigService.refreshTokenExpiresIn * 1000,
     );
 
     await this.tokenRepository.createUnique(newRefreshTokenEntity);

--- a/packages/apps/job-launcher/server/src/modules/auth/strategy/jwt.http.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/strategy/jwt.http.ts
@@ -3,16 +3,22 @@ import { PassportStrategy } from '@nestjs/passport';
 import { HttpStatus, Injectable, Req } from '@nestjs/common';
 
 import { UserEntity } from '../../user/user.entity';
-import { RESEND_EMAIL_VERIFICATION_PATH } from '../../../common/constants';
+import {
+  LOGOUT_PATH,
+  RESEND_EMAIL_VERIFICATION_PATH,
+} from '../../../common/constants';
 import { UserStatus } from '../../../common/enums/user';
 import { AuthConfigService } from '../../../common/config/auth-config.service';
 import { UserRepository } from '../../user/user.repository';
 import { ControlledError } from '../../../common/errors/controlled';
+import { TokenRepository } from '../token.repository';
+import { TokenType } from '../token.entity';
 
 @Injectable()
 export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {
   constructor(
     private readonly userRepository: UserRepository,
+    private readonly tokenRepository: TokenRepository,
     private readonly authConfigService: AuthConfigService,
   ) {
     super({
@@ -35,9 +41,22 @@ export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {
 
     if (
       user.status !== UserStatus.ACTIVE &&
-      request.url !== RESEND_EMAIL_VERIFICATION_PATH
+      request.url !== RESEND_EMAIL_VERIFICATION_PATH &&
+      request.url !== LOGOUT_PATH
     ) {
       throw new ControlledError('User not active', HttpStatus.UNAUTHORIZED);
+    }
+
+    const token = await this.tokenRepository.findOneByUserIdAndType(
+      user.id,
+      TokenType.REFRESH,
+    );
+
+    if (!token) {
+      throw new ControlledError(
+        'User is not authorized',
+        HttpStatus.UNAUTHORIZED,
+      );
     }
 
     return user;


### PR DESCRIPTION
## Description
Enhancement of the logout flow to ensure secure and efficient user session management.

## Summary of changes
- Implemented a check for LOGOUT_PATH to enable inactive users to logout securely.
- Introduced a refresh token check to prevent logged out users from accessing authorized routes.

## How to test the changes
**Case 1: Inactive user logout**
1. Sign Up as a user.
2. Attempt to logout as an inactive user.

Expected result:
Logout operation should be successful without triggering Unauthorized errors.

**Case 2: Restricted access after logout**
1. Sign Up as a user.
2. Activate the account.
3. Sign In.
4. Verify access to authorized routes (e.g., receive a 200 OK response).
5. Logout.
6. Attempt to access authorized routes again.

Expected result:
After logout, attempting to access authorized routes should result in a 401 Unauthorized response.

## Related issues
Job Launcher - Fix login/logout
[#1980](https://github.com/humanprotocol/human-protocol/issues/1980)
