### PR TITLE
[Reputation Oracle] Sendgrid app name

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/config/sendgrid-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/common/config/sendgrid-config.service.ts
@@ -14,13 +14,13 @@ export class SendgridConfigService {
   get fromEmail(): string {
     return this.configService.get<string>(
       'SENDGRID_FROM_EMAIL',
-      'reputation-oracle@hmt.ai',
+      'app@humanprotocol.org',
     );
   }
   get fromName(): string {
     return this.configService.get<string>(
       'SENDGRID_FROM_NAME',
-      'Human Protocol Reputation Oracle',
+      'Human Protocol',
     );
   }
 }

--- a/packages/apps/reputation-oracle/server/src/common/constants/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/index.ts
@@ -1,6 +1,6 @@
 import { JobRequestType } from '../enums';
 
-export const SERVICE_NAME = 'Reputation Oracle';
+export const SERVICE_NAME = 'App';
 export const NS = 'hmt';
 export const RETRIES_COUNT_THRESHOLD = 3;
 export const INITIAL_REPUTATION = 0;

--- a/packages/apps/reputation-oracle/server/src/modules/sendgrid/sendgrid.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/sendgrid/sendgrid.service.spec.ts
@@ -72,7 +72,7 @@ describe('SendGridService', () => {
       expect(mock).toHaveBeenCalledWith(
         expect.objectContaining({
           from: expect.objectContaining({
-            email: 'reputation-oracle@hmt.ai',
+            email: 'app@humanprotocol.org',
           }),
         }),
       );


### PR DESCRIPTION
## Description

Modify from name used in Sendgrid templates

## Summary of changes

Update Sendgrid constants to show HUMAN App instead of Reputation Oracle

## How test the changes

`yarn test`
## Related issues
#2010
