### PR TITLE
[Reputation Oracle] Fixed login/logout

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/index.ts
@@ -29,6 +29,7 @@ export const CVAT_JOB_TYPES = [
 export const HEADER_SIGNATURE_KEY = 'human-signature';
 
 export const RESEND_EMAIL_VERIFICATION_PATH = '/auth/resend-email-verification';
+export const LOGOUT_PATH = '/auth/logout';
 
 export const CURSE_WORDS = [
   '4r5e',

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -165,7 +165,7 @@ export class AuthService {
     newRefreshTokenEntity.type = TokenType.REFRESH;
     const date = new Date();
     newRefreshTokenEntity.expiresAt = new Date(
-      date.getTime() + this.authConfigService.refreshTokenExpiresIn,
+      date.getTime() + this.authConfigService.refreshTokenExpiresIn * 1000,
     );
 
     await this.tokenRepository.createUnique(newRefreshTokenEntity);

--- a/render.yaml
+++ b/render.yaml
@@ -57,7 +57,7 @@ services:
   - key: JWT_ACCESS_TOKEN_EXPIRES_IN
     value: 600
   - key: REFRESH_TOKEN_EXPIRES_IN
-    value: 3600000
+    value: 3600
   - key: S3_ENDPOINT
     value: storage.googleapis.com
   - key: S3_PORT


### PR DESCRIPTION
## Description
Enhancement of the logout flow to ensure secure and efficient user session management.

## Summary of changes
- Implemented a check for LOGOUT_PATH to enable inactive users to logout securely.
- Introduced a refresh token check to prevent logged out users from accessing authorized routes.

## How to test the changes
**Case 1: Inactive user logout**
1. Sign Up as a user.
2. Attempt to logout as an inactive user.

Expected result:
Logout operation should be successful without triggering Unauthorized errors.

**Case 2: Restricted access after logout**
1. Sign Up as a user.
2. Activate the account.
3. Sign In.
4. Verify access to authorized routes (e.g., receive a 200 OK response).
5. Logout.
6. Attempt to access authorized routes again.

Expected result:
After logout, attempting to access authorized routes should result in a 401 Unauthorized response.

## Related issues
Reputation Oracle - Fix login/logout
[#2036](https://github.com/humanprotocol/human-protocol/issues/2036)
