### PR TITLE
[CVAT] Fix escrow status checks

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/db/errors.py
+++ b/packages/examples/cvat/exchange-oracle/src/db/errors.py
@@ -4,3 +4,5 @@ if db_engine.driver != "psycopg2":
     raise NotImplementedError
 
 from psycopg2.errors import LockNotAvailable
+
+# These errors can be found, e.g., in the .orig field of sqlalchemy errors

--- a/packages/examples/cvat/exchange-oracle/src/handlers/completed_escrows.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/completed_escrows.py
@@ -6,7 +6,7 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional
 
 from datumaro.util import take_by
-from sqlalchemy import exc as sa_exc
+from sqlalchemy import exc as sa_errors
 from sqlalchemy.orm import Session
 
 import src.cvat.api_calls as cvat_api
@@ -268,7 +268,7 @@ class _CompletedEscrowsHandler:
                     escrow_projects = cvat_service.get_projects_by_escrow_address(
                         session, escrow_address, limit=None, for_update=ForUpdateParams(nowait=True)
                     )
-                except sa_exc.OperationalError as ex:
+                except sa_errors.OperationalError as ex:
                     if isinstance(ex.orig, db_errors.LockNotAvailable):
                         continue
                     raise

--- a/packages/examples/cvat/exchange-oracle/src/services/cvat.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/cvat.py
@@ -146,6 +146,27 @@ def get_projects_by_status(
     return projects
 
 
+def get_escrows_by_project_status(
+    session: Session,
+    project_status: ProjectStatuses,
+    *,
+    included_types: Optional[Sequence[TaskTypes]] = None,
+    limit: int = 5,
+) -> List[tuple[str, int]]:
+    escrows = (
+        session.query(Project.escrow_address, Project.chain_id)
+        .group_by(Project.escrow_address, Project.chain_id)
+        .where(Project.status == project_status.value)
+    )
+
+    if included_types:
+        escrows = escrows.where(Project.job_type.in_([t.value for t in included_types]))
+
+    escrows = escrows.limit(limit).all()
+
+    return escrows
+
+
 def get_available_projects(session: Session, *, limit: int = 10) -> List[Project]:
     return (
         session.query(Project)

--- a/packages/examples/cvat/exchange-oracle/tests/integration/cron/state_trackers/test_track_completed_escrows.py
+++ b/packages/examples/cvat/exchange-oracle/tests/integration/cron/state_trackers/test_track_completed_escrows.py
@@ -144,48 +144,6 @@ class ServiceIntegrationTest(unittest.TestCase):
 
         self.assertEqual(db_project.status, ProjectStatuses.validation)
 
-    def test_retrieve_annotations_unfinished_jobs(self):
-        cvat_project_id = 1
-        escrow_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
-        project_id = str(uuid.uuid4())
-        cvat_project = Project(
-            id=project_id,
-            cvat_id=cvat_project_id,
-            cvat_cloudstorage_id=1,
-            status=ProjectStatuses.completed.value,
-            job_type=TaskTypes.image_label_binary.value,
-            escrow_address=escrow_address,
-            chain_id=Networks.localhost.value,
-            bucket_url="https://test.storage.googleapis.com/",
-        )
-        self.session.add(cvat_project)
-
-        cvat_task_id = 1
-        cvat_task = Task(
-            id=str(uuid.uuid4()),
-            cvat_id=cvat_task_id,
-            cvat_project_id=cvat_project_id,
-            status=TaskStatuses.completed.value,
-        )
-        self.session.add(cvat_task)
-
-        cvat_job = Job(
-            id=str(uuid.uuid4()),
-            cvat_id=1,
-            cvat_project_id=cvat_project_id,
-            cvat_task_id=cvat_task_id,
-            status=JobStatuses.in_progress,
-        )
-        self.session.add(cvat_job)
-        self.session.commit()
-
-        track_completed_escrows()
-
-        self.session.commit()
-        db_project = self.session.query(Project).filter_by(id=project_id).first()
-
-        self.assertEqual(db_project.status, ProjectStatuses.annotation)
-
     @patch("src.cvat.api_calls.get_job_annotations")
     def test_retrieve_annotations_error_getting_annotations(self, mock_annotations):
         cvat_project_id = 1

--- a/packages/examples/cvat/exchange-oracle/tests/integration/cron/state_trackers/test_track_completed_escrows.py
+++ b/packages/examples/cvat/exchange-oracle/tests/integration/cron/state_trackers/test_track_completed_escrows.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 import datumaro as dm
 
 from src.core.types import (
+    AssignmentStatuses,
     ExchangeOracleEventTypes,
     JobStatuses,
     Networks,
@@ -23,6 +24,8 @@ from src.crons.state_trackers import track_completed_escrows
 from src.db import SessionLocal
 from src.models.cvat import Assignment, Image, Job, Project, Task, User
 from src.models.webhook import Webhook
+
+from tests.utils.db_helper import create_project_task_and_job
 
 
 class ServiceIntegrationTest(unittest.TestCase):
@@ -313,3 +316,368 @@ class ServiceIntegrationTest(unittest.TestCase):
         db_project = self.session.query(Project).filter_by(id=project_id).first()
 
         self.assertEqual(db_project.status, ProjectStatuses.completed.value)
+
+    def test_retrieve_annotations_multiple_projects_per_escrow_all_completed(self):
+        escrow_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
+        project1, task1, job1 = create_project_task_and_job(self.session, escrow_address, 1)
+        project2, task2, job2 = create_project_task_and_job(self.session, escrow_address, 2)
+        project3, task3, job3 = create_project_task_and_job(self.session, escrow_address, 3)
+
+        project1.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project2.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project3.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project1.status = ProjectStatuses.completed
+        project2.status = ProjectStatuses.completed
+        project3.status = ProjectStatuses.completed
+        task1.status = TaskStatuses.completed
+        task2.status = TaskStatuses.completed
+        task3.status = TaskStatuses.completed
+        job1.status = JobStatuses.completed
+        job2.status = JobStatuses.completed
+        job3.status = JobStatuses.completed
+
+        project_images = ["sample1.jpg", "sample2.png"]
+        for project in [project1, project2, project3]:
+            for image_filename in project_images:
+                self.session.add(
+                    Image(
+                        id=str(uuid.uuid4()),
+                        cvat_project_id=project.cvat_id,
+                        filename=image_filename,
+                    )
+                )
+
+        self.session.add_all([project1, task1, job1, project2, task2, job2, project3, task3, job3])
+
+        wallet_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
+        user = User(
+            wallet_address=wallet_address,
+            cvat_email="test@hmt.ai",
+            cvat_id=1,
+        )
+        self.session.add(user)
+
+        wallet_address_2 = "0x86e83d346041E8806e352681f3F14549C0d2BC68"
+        user = User(
+            wallet_address=wallet_address_2,
+            cvat_email="test2@hmt.ai",
+            cvat_id=2,
+        )
+        self.session.add(user)
+
+        for job in [job1, job2, job3]:
+            now = datetime.now()
+            assignment = Assignment(
+                id=str(uuid.uuid4()),
+                user_wallet_address=wallet_address,
+                cvat_job_id=job.cvat_id,
+                expires_at=now + timedelta(days=1),
+                completed_at=now - timedelta(hours=1),
+                status=AssignmentStatuses.completed.value,
+            )
+            self.session.add(assignment)
+
+        self.session.commit()
+
+        with (
+            open("tests/utils/manifest.json") as manifest_data,
+            patch("src.handlers.completed_escrows.get_escrow_manifest") as mock_get_manifest,
+            patch("src.handlers.completed_escrows.validate_escrow"),
+            patch("src.handlers.completed_escrows.cvat_api") as mock_cvat_api,
+            patch("src.handlers.completed_escrows.cloud_service") as mock_cloud_service,
+            patch(
+                "src.handlers.completed_escrows.postprocess_annotations"
+            ) as mock_postprocess_annotations,
+        ):
+            manifest = json.load(manifest_data)
+            mock_get_manifest.return_value = manifest
+
+            def _fake_get_annotations(*args, **kwargs):
+                dummy_zip_file = io.BytesIO()
+                with zipfile.ZipFile(
+                    dummy_zip_file, "w"
+                ) as archive, TemporaryDirectory() as tempdir:
+                    mock_dataset = dm.Dataset(
+                        media_type=dm.Image,
+                        categories={
+                            dm.AnnotationType.label: dm.LabelCategories.from_iterable(
+                                ["cat", "dog"]
+                            )
+                        },
+                    )
+                    for image_filename in project_images:
+                        mock_dataset.put(dm.DatasetItem(id=os.path.splitext(image_filename)[0]))
+                    mock_dataset.export(tempdir, format="cvat")
+
+                    for filename in list(glob(os.path.join(tempdir, "**/*"), recursive=True)):
+                        archive.write(filename, os.path.relpath(filename, tempdir))
+                dummy_zip_file.seek(0)
+
+                return dummy_zip_file
+
+            mock_cvat_api.get_job_annotations.side_effect = _fake_get_annotations
+            mock_cvat_api.get_project_annotations.side_effect = _fake_get_annotations
+
+            def _fake_postprocess_annotations(
+                escrow_address,
+                chain_id,
+                annotations,
+                merged_annotation,
+                *,
+                manifest,
+                project_images,
+            ):
+                merged_annotation.file = io.BytesIO()
+
+            mock_postprocess_annotations.side_effect = _fake_postprocess_annotations
+
+            mock_storage_client = Mock()
+            mock_storage_client.create_file = Mock()
+            mock_storage_client.list_files = Mock(return_value=[])
+            mock_cloud_service.make_client = Mock(return_value=mock_storage_client)
+
+            track_completed_escrows()
+
+        webhook = (
+            self.session.query(Webhook)
+            .filter_by(escrow_address=escrow_address, chain_id=Networks.localhost.value)
+            .first()
+        )
+        self.assertIsNotNone(webhook)
+        self.assertEqual(webhook.event_type, ExchangeOracleEventTypes.task_finished)
+
+        db_projects = (
+            self.session.query(Project)
+            .where(Project.id.in_([project1.id, project2.id, project3.id]))
+            .all()
+        )
+        self.assertEqual(len(db_projects), 3)
+        for db_project in db_projects:
+            self.assertEqual(db_project.status, ProjectStatuses.validation)
+
+    def test_retrieve_annotations_multiple_projects_per_escrow_some_completed_some_validation(self):
+        escrow_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
+        project1, task1, job1 = create_project_task_and_job(self.session, escrow_address, 1)
+        project2, task2, job2 = create_project_task_and_job(self.session, escrow_address, 2)
+        project3, task3, job3 = create_project_task_and_job(self.session, escrow_address, 3)
+
+        project1.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project2.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project3.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project1.status = ProjectStatuses.completed
+        project2.status = ProjectStatuses.completed
+        project3.status = ProjectStatuses.validation
+        task1.status = TaskStatuses.completed
+        task2.status = TaskStatuses.completed
+        task3.status = TaskStatuses.completed
+        job1.status = JobStatuses.completed
+        job2.status = JobStatuses.completed
+        job3.status = JobStatuses.completed
+
+        project_images = ["sample1.jpg", "sample2.png"]
+        for project in [project1, project2, project3]:
+            for image_filename in project_images:
+                self.session.add(
+                    Image(
+                        id=str(uuid.uuid4()),
+                        cvat_project_id=project.cvat_id,
+                        filename=image_filename,
+                    )
+                )
+
+        self.session.add_all([project1, task1, job1, project2, task2, job2, project3, task3, job3])
+
+        wallet_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
+        user = User(
+            wallet_address=wallet_address,
+            cvat_email="test@hmt.ai",
+            cvat_id=1,
+        )
+        self.session.add(user)
+
+        wallet_address_2 = "0x86e83d346041E8806e352681f3F14549C0d2BC68"
+        user = User(
+            wallet_address=wallet_address_2,
+            cvat_email="test2@hmt.ai",
+            cvat_id=2,
+        )
+        self.session.add(user)
+
+        for job in [job1, job2, job3]:
+            now = datetime.now()
+            assignment = Assignment(
+                id=str(uuid.uuid4()),
+                user_wallet_address=wallet_address,
+                cvat_job_id=job.cvat_id,
+                expires_at=now + timedelta(days=1),
+                completed_at=now - timedelta(hours=1),
+                status=AssignmentStatuses.completed.value,
+            )
+            self.session.add(assignment)
+
+        self.session.commit()
+
+        with (
+            open("tests/utils/manifest.json") as manifest_data,
+            patch("src.handlers.completed_escrows.get_escrow_manifest") as mock_get_manifest,
+            patch("src.handlers.completed_escrows.validate_escrow"),
+            patch("src.handlers.completed_escrows.cvat_api") as mock_cvat_api,
+            patch("src.handlers.completed_escrows.cloud_service") as mock_cloud_service,
+            patch(
+                "src.handlers.completed_escrows.postprocess_annotations"
+            ) as mock_postprocess_annotations,
+        ):
+            manifest = json.load(manifest_data)
+            mock_get_manifest.return_value = manifest
+
+            def _fake_get_annotations(*args, **kwargs):
+                dummy_zip_file = io.BytesIO()
+                with zipfile.ZipFile(
+                    dummy_zip_file, "w"
+                ) as archive, TemporaryDirectory() as tempdir:
+                    mock_dataset = dm.Dataset(
+                        media_type=dm.Image,
+                        categories={
+                            dm.AnnotationType.label: dm.LabelCategories.from_iterable(
+                                ["cat", "dog"]
+                            )
+                        },
+                    )
+                    for image_filename in project_images:
+                        mock_dataset.put(dm.DatasetItem(id=os.path.splitext(image_filename)[0]))
+                    mock_dataset.export(tempdir, format="cvat")
+
+                    for filename in list(glob(os.path.join(tempdir, "**/*"), recursive=True)):
+                        archive.write(filename, os.path.relpath(filename, tempdir))
+                dummy_zip_file.seek(0)
+
+                return dummy_zip_file
+
+            mock_cvat_api.get_job_annotations.side_effect = _fake_get_annotations
+            mock_cvat_api.get_project_annotations.side_effect = _fake_get_annotations
+
+            def _fake_postprocess_annotations(
+                escrow_address,
+                chain_id,
+                annotations,
+                merged_annotation,
+                *,
+                manifest,
+                project_images,
+            ):
+                merged_annotation.file = io.BytesIO()
+
+            mock_postprocess_annotations.side_effect = _fake_postprocess_annotations
+
+            mock_storage_client = Mock()
+            mock_storage_client.create_file = Mock()
+            mock_storage_client.list_files = Mock(return_value=[])
+            mock_cloud_service.make_client = Mock(return_value=mock_storage_client)
+
+            track_completed_escrows()
+
+        webhook = (
+            self.session.query(Webhook)
+            .filter_by(escrow_address=escrow_address, chain_id=Networks.localhost.value)
+            .first()
+        )
+        self.assertIsNotNone(webhook)
+        self.assertEqual(webhook.event_type, ExchangeOracleEventTypes.task_finished)
+
+        db_projects = (
+            self.session.query(Project)
+            .where(Project.id.in_([project1.id, project2.id, project3.id]))
+            .all()
+        )
+        self.assertEqual(len(db_projects), 3)
+        for db_project in db_projects:
+            self.assertEqual(db_project.status, ProjectStatuses.validation)
+
+    def test_retrieve_annotations_multiple_projects_per_escrow_all_validation(self):
+        escrow_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
+        project1, task1, job1 = create_project_task_and_job(self.session, escrow_address, 1)
+        project2, task2, job2 = create_project_task_and_job(self.session, escrow_address, 2)
+        project3, task3, job3 = create_project_task_and_job(self.session, escrow_address, 3)
+
+        project1.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project2.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project3.job_type = TaskTypes.image_skeletons_from_boxes.value
+        project1.status = ProjectStatuses.validation
+        project2.status = ProjectStatuses.validation
+        project3.status = ProjectStatuses.validation
+        task1.status = TaskStatuses.completed
+        task2.status = TaskStatuses.completed
+        task3.status = TaskStatuses.completed
+        job1.status = JobStatuses.completed
+        job2.status = JobStatuses.completed
+        job3.status = JobStatuses.completed
+
+        project_images = ["sample1.jpg", "sample2.png"]
+        for project in [project1, project2, project3]:
+            for image_filename in project_images:
+                self.session.add(
+                    Image(
+                        id=str(uuid.uuid4()),
+                        cvat_project_id=project.cvat_id,
+                        filename=image_filename,
+                    )
+                )
+
+        self.session.add_all([project1, task1, job1, project2, task2, job2, project3, task3, job3])
+
+        wallet_address = "0x86e83d346041E8806e352681f3F14549C0d2BC67"
+        user = User(
+            wallet_address=wallet_address,
+            cvat_email="test@hmt.ai",
+            cvat_id=1,
+        )
+        self.session.add(user)
+
+        wallet_address_2 = "0x86e83d346041E8806e352681f3F14549C0d2BC68"
+        user = User(
+            wallet_address=wallet_address_2,
+            cvat_email="test2@hmt.ai",
+            cvat_id=2,
+        )
+        self.session.add(user)
+
+        for job in [job1, job2, job3]:
+            now = datetime.now()
+            assignment = Assignment(
+                id=str(uuid.uuid4()),
+                user_wallet_address=wallet_address,
+                cvat_job_id=job.cvat_id,
+                expires_at=now + timedelta(days=1),
+                completed_at=now - timedelta(hours=1),
+                status=AssignmentStatuses.completed.value,
+            )
+            self.session.add(assignment)
+
+        self.session.commit()
+
+        with (
+            open("tests/utils/manifest.json") as manifest_data,
+            patch("src.handlers.completed_escrows.get_escrow_manifest") as mock_get_manifest,
+            patch("src.handlers.completed_escrows.validate_escrow"),
+            patch("src.handlers.completed_escrows.cvat_api"),
+            patch("src.handlers.completed_escrows.cloud_service"),
+            patch(
+                "src.handlers.completed_escrows.postprocess_annotations"
+            ) as mock_postprocess_annotations,
+        ):
+            manifest = json.load(manifest_data)
+            mock_get_manifest.return_value = manifest
+            track_completed_escrows()
+
+        mock_postprocess_annotations.assert_not_called()
+
+        self.assertEqual(self.session.query(Webhook).count(), 0)
+
+        db_projects = (
+            self.session.query(Project)
+            .where(Project.id.in_([project1.id, project2.id, project3.id]))
+            .all()
+        )
+        self.assertEqual(len(db_projects), 3)
+        for db_project in db_projects:
+            self.assertEqual(db_project.status, ProjectStatuses.validation)


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

Problems:

1. In escrows with skeletons, it is possible that some projects are in the completed state, and some are in the validation state. During escrow completion checks, it wasn't checked that there's at least 1 completed project, so multiple validation requests could be sent successively, if the validation has not been completed between the escrow completion checks.

2. In escrows with skeletons, during escrow completion checks, it was possible to repeatedly fail on acquiring a locked project, aborting validation for other completed escrows in the batch.

3. In escrows with skeletons, during escrow completion, there were unnecessary calls to escrow validation

This PR fixes them by following:
- Escrow validation is now independent for each escrow in the batch, errors from 1 escrow should not affect other escrows in the batch
- Optimized out unnecessary escrow validation calls
- Fixed the project status check for escrow to have at least 1 completed project
- Fixed invalid row lock acquiring error checks (escrow creation, escrow completion, job creation)

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
