### PR TITLE
feat: add scripts for web3 components only

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -83,3 +83,20 @@ fortune: check-core-folders minio
 	$(MAKE) reputation-oracle & PID_REPO=$$!; \
 	$(MAKE) subgraph & \
 	wait
+
+web3-subgraph:
+	docker compose -f ./web3/docker-compose.yml up -d graph-node
+	NETWORK=localhost yarn workspace @human-protocol/subgraph generate
+	@while [ $$(docker inspect --format='{{.State.Health.Status}}' graph-node) != "healthy" ]; do \
+		sleep 2; \
+	done; \
+	echo "Container is healthy."
+	yarn workspace @human-protocol/subgraph create-local
+	yarn workspace @human-protocol/subgraph deploy-local
+
+web3: check-core-folders
+	@echo "RUNNING WEB3..."
+	@trap 'echo "STOPPING WEB3.."; kill -9 $$PID_HARDHAT; docker compose -f ./web3/docker-compose.yml down; exit 0' SIGINT ERR; \
+	$(MAKE) hardhat-node & PID_HARDHAT=$$!; \
+	$(MAKE) web3-subgraph & \
+	wait

--- a/scripts/web3/.gitignore
+++ b/scripts/web3/.gitignore
@@ -1,0 +1,1 @@
+graph-node-db

--- a/scripts/web3/docker-compose.yml
+++ b/scripts/web3/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.8'
+name: human-protocol
+services:
+  graph-node-db:
+    container_name: graph-node-db
+    image: postgres:latest
+    restart: always
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    ports:
+      - 5433:5432
+    command:
+      [
+        "postgres",
+        "-cshared_preload_libraries=pg_stat_statements",
+        "-cmax_connections=200"
+      ]
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: graph-node
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+    volumes:
+      - ./graph-node-db:/var/lib/postgresql/data
+  graph-node:
+    container_name: graph-node
+    hostname: graph-node
+    image: graphprotocol/graph-node
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 8000 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    ports:
+      - 8000:8000
+      - 8001:8001
+      - 8020:8020
+      - 8030:8030
+      - 8040:8040
+    depends_on:
+      - ipfs
+      - graph-node-db
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      postgres_host: graph-node-db
+      postgres_user: user
+      postgres_pass: password
+      postgres_db: graph-node
+      ipfs: 'ipfs:5001'
+      ethereum: 'localhost:http://host.docker.internal:8545'
+      GRAPH_LOG: info
+  ipfs:
+    hostname: ipfs
+    image: ipfs/kubo:v0.14.0
+    ports:
+      - 5010:5001


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->

To make it easier for other applications run on human protocol ecosystem locally, we need to prepare web3 components of human protocol.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

- Added script to run local hardhat node, deploy contracts, and run subgraph node.


## How test the changes

<!-- If there are any special testing requirements, add them here -->
Run `make web3` inside `/scripts` folder, and make sure local hardhat node is running, contracts are deployed, subgraph node is up and running, and subgraphs are deployed properly.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
