### PR TITLE
[Credentialing] Validate Endpoint 

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.controller.ts
@@ -8,7 +8,6 @@ import {
   Req,
   HttpException,
   HttpStatus,
-  UseFilters,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -23,6 +22,7 @@ import {
   CredentialQueryDto,
   CredentialDto,
   AddCredentialOnChainDto,
+  ValidateCredentialDto,
 } from './credential.dto';
 import { Public } from '../../common/decorators';
 import { UserType } from '../../common/enums/user';
@@ -113,5 +113,17 @@ export class CredentialController {
       chainId,
       escrowAddress,
     );
+  }
+
+  @Post('validate')
+  @UseGuards(JwtAuthGuard)
+  async validateCredential(
+    @Body() validateCredentialDto: ValidateCredentialDto,
+  ) {
+    await this.credentialService.validateCredential(
+      validateCredentialDto.reference,
+      validateCredentialDto.worker_address,
+    );
+    return { message: 'Credential successfully validated' };
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.dto.ts
@@ -101,3 +101,13 @@ export class AddCredentialOnChainDto {
   @IsString()
   public escrowAddress: string;
 }
+
+export class ValidateCredentialDto {
+  @ApiProperty()
+  @IsString()
+  public reference: string;
+
+  @ApiProperty()
+  @IsString()
+  public worker_address: string;
+}

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.entity.ts
@@ -37,7 +37,7 @@ export class CredentialEntity extends BaseEntity {
   validations: CredentialValidationEntity[];
 }
 
-@Entity({ schema: NS, name: 'credential_validations' })
+@Entity('credential_validations')
 export class CredentialValidationEntity extends BaseEntity {
   @ManyToOne(() => CredentialEntity, { eager: true })
   credential: CredentialEntity;

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.module.ts
@@ -1,22 +1,21 @@
-import { Logger, Module } from '@nestjs/common';
+import { Module, Logger } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule } from '@nestjs/config';
 import { CredentialService } from './credential.service';
-import { CredentialEntity } from './credential.entity';
 import { CredentialRepository } from './credential.repository';
-import { Web3Module } from '../web3/web3.module'; // Assuming integration with blockchain
 import { CredentialController } from './credential.controller';
+import {
+  CredentialEntity,
+  CredentialValidationEntity,
+} from './credential.entity';
 import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([CredentialEntity]),
-    ConfigModule,
-    Web3Module,
+    TypeOrmModule.forFeature([CredentialEntity, CredentialValidationEntity]),
     UserModule,
   ],
   controllers: [CredentialController],
-  providers: [Logger, CredentialService, CredentialRepository],
+  providers: [CredentialService, CredentialRepository, Logger],
   exports: [CredentialService],
 })
 export class CredentialModule {}

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.repository.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BaseRepository } from '../../database/base.repository';
 import { DataSource } from 'typeorm';
-import { CredentialEntity } from './credential.entity';
+import {
+  CredentialEntity,
+  CredentialValidationEntity,
+} from './credential.entity';
 
 @Injectable()
 export class CredentialRepository extends BaseRepository<CredentialEntity> {
@@ -14,6 +17,12 @@ export class CredentialRepository extends BaseRepository<CredentialEntity> {
   async findByReference(reference: string): Promise<CredentialEntity | null> {
     const credentialEntity = this.findOne({ where: { reference } });
     return credentialEntity;
+  }
+
+  async saveValidation(validation: CredentialValidationEntity): Promise<void> {
+    await this.dataSource
+      .getRepository(CredentialValidationEntity)
+      .save(validation);
   }
 
   async getCredentials(status?: string): Promise<CredentialEntity[]> {

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.service.spec.ts
@@ -19,7 +19,6 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
-import { UserRepository } from '../user/user.repository';
 
 jest.mock('../../common/utils/signature', () => ({
   verifySignature: jest.fn(),
@@ -44,7 +43,6 @@ describe('CredentialService', () => {
   let credentialService: CredentialService;
   let credentialRepository: CredentialRepository;
   let userService: UserService;
-  let userRepository: UserRepository;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -369,21 +367,30 @@ describe('CredentialService', () => {
   describe('validateCredential', () => {
     it('should validate an active credential', async () => {
       const credential = { status: 'ACTIVE' } as CredentialEntity;
+      const workerAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+
       jest
         .spyOn(credentialRepository, 'findByReference')
         .mockResolvedValue(credential);
-      jest.spyOn(credentialRepository, 'save').mockResolvedValue(credential);
+      jest
+        .spyOn(credentialRepository, 'save')
+        .mockImplementation(async (cred) => {
+          cred.status = 'VALIDATED' as any;
+          return cred as CredentialEntity;
+        });
 
-      await credentialService.validateCredential('ref123');
+      await credentialService.validateCredential('ref123', workerAddress);
       expect(credential.status).toEqual('VALIDATED');
     });
 
     it('should throw an error if the credential is not found', async () => {
+      const workerAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+
       jest
         .spyOn(credentialRepository, 'findByReference')
         .mockResolvedValue(null);
       await expect(
-        credentialService.validateCredential('ref123'),
+        credentialService.validateCredential('ref123', workerAddress),
       ).rejects.toThrow('Credential not found.');
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.service.ts
@@ -1,7 +1,10 @@
 import { HttpStatus, Injectable, Logger, HttpException } from '@nestjs/common';
 import { CreateCredentialDto } from './credential.dto';
 import { CredentialRepository } from './credential.repository';
-import { CredentialEntity } from './credential.entity';
+import {
+  CredentialEntity,
+  CredentialValidationEntity,
+} from './credential.entity';
 import { CredentialStatus } from '../../common/enums/credential';
 import { Web3Service } from '../web3/web3.service';
 import { verifySignature } from '../../common/utils/signature';
@@ -120,7 +123,10 @@ export class CredentialService {
     return credentialEntity;
   }
 
-  public async validateCredential(reference: string): Promise<void> {
+  public async validateCredential(
+    reference: string,
+    workerAddress: string,
+  ): Promise<void> {
     const credential =
       await this.credentialRepository.findByReference(reference);
 
@@ -137,6 +143,7 @@ export class CredentialService {
         HttpStatus.BAD_REQUEST,
       );
     }
+
     credential.status = CredentialStatus.VALIDATED;
     await this.credentialRepository.save(credential);
 


### PR DESCRIPTION
## Description

- Implement `POST /credential/validate` endpoint for validating credentials linked to users.

## Summary of changes

- Added `ValidateCredentialDto`.
- Created `CredentialValidationEntity`.
- Updated `CredentialController` and `CredentialService`.
- Extended `CredentialRepository`.
- Added unit tests.


Closes [#2046](https://github.com/humanprotocol/human-protocol/issues/2046)

