### PR TITLE
[Reputation Oracle] Fixes for Render deployment

### DIFF
--- a/packages/apps/reputation-oracle/server/package.json
+++ b/packages/apps/reputation-oracle/server/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "migration:create": "yarn build && typeorm-ts-node-commonjs migration:create",
     "migration:generate": "yarn build && typeorm-ts-node-commonjs migration:generate -d typeorm.config.ts",
     "migration:revert": "yarn build && typeorm-ts-node-commonjs migration:revert -d typeorm.config.ts",

--- a/packages/apps/reputation-oracle/server/src/common/config/database-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/common/config/database-config.service.ts
@@ -4,6 +4,9 @@ import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class DatabaseConfigService {
   constructor(private configService: ConfigService) {}
+  get url(): string | undefined {
+    return this.configService.get<string>('POSTGRES_URL');
+  }
   get host(): string {
     return this.configService.get<string>('POSTGRES_HOST', '127.0.0.1');
   }

--- a/packages/apps/reputation-oracle/server/src/database/database.module.ts
+++ b/packages/apps/reputation-oracle/server/src/database/database.module.ts
@@ -65,6 +65,7 @@ import { CredentialEntity } from '../modules/credentials/credential.entity';
           migrations: [path.join(__dirname, '/migrations/**/*{.ts,.js}')],
           //"migrations": ["dist/migrations/*{.ts,.js}"],
           logger: typeOrmLoggerService,
+          url: databaseConfigService.url,
           host: databaseConfigService.host,
           port: databaseConfigService.port,
           username: databaseConfigService.user,

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
@@ -23,7 +23,6 @@ import { ReputationModule } from '../reputation/reputation.module';
     ReputationModule,
   ],
   providers: [CronJobService, CronJobRepository, WebhookRepository],
-  controllers: [CronJobController],
   exports: [CronJobService],
 })
 export class CronJobModule {}

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -14,6 +14,7 @@ import { Web3Service } from '../web3/web3.service';
 import { EscrowClient, OperatorUtils } from '@human-protocol/sdk';
 import { WebhookDto } from '../webhook/webhook.dto';
 import { ControlledError } from '../../common/errors/controlled';
+import { Cron } from '@nestjs/schedule';
 
 @Injectable()
 export class CronJobService {
@@ -82,6 +83,7 @@ export class CronJobService {
     return this.cronJobRepository.updateOne(cronJobEntity);
   }
 
+  @Cron('*/2 * * * *')
   /**
    * Process a pending webhook job.
    * @returns {Promise<void>} - Returns a promise that resolves when the operation is complete.
@@ -129,6 +131,7 @@ export class CronJobService {
     await this.completeCronJob(cronJob);
   }
 
+  @Cron('1-59/2 * * * *')
   /**
    * Process a paid webhook job.
    * @returns {Promise<void>} - Returns a promise that resolves when the operation is complete.

--- a/packages/apps/reputation-oracle/server/typeorm.config.ts
+++ b/packages/apps/reputation-oracle/server/typeorm.config.ts
@@ -10,6 +10,7 @@ dotenv.config({
 
 export default new DataSource({
   type: 'postgres',
+  url: process.env.POSTGRES_URL,
   host: process.env.POSTGRES_HOST,
   port: Number(process.env.POSTGRES_PORT),
   username: process.env.POSTGRES_USER,

--- a/render.yaml
+++ b/render.yaml
@@ -201,6 +201,8 @@ services:
         sync: false
       - key: RPC_URL_XLAYER_TESTNET
         sync: false
+      - key: SENDGRID_API_KEY
+        sync: false
     region: frankfurt
     buildCommand: yarn install; yarn workspace @human-protocol/sdk build; yarn build
     startCommand: yarn start:prod


### PR DESCRIPTION
## Description
Fixes related to deployment of Reputation Oracle on Render
- Add POSTGRES_URL support to Reputation Oracle
- Disable cron job endpoints and set scheduler
- Fix start:prod script
- Add SENDGRID_API_KEY var to render.yaml
