### PR TITLE
[Reputation Oracle] Handle 500 error code correctly

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -62,6 +62,7 @@ export enum ErrorUser {
   BalanceCouldNotBeRetreived = 'User balance could not be retrieved',
   InvalidCredentials = 'Invalid credentials',
   IncorrectAddress = 'Incorrect address',
+  NoWalletAddresRegistered = 'No wallet address registered on your account',
   KycNotApproved = 'KYC not approved',
   UserNotActive = 'User not active',
   LabelingEnableFailed = 'Failed to enable labeling for this account',

--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.ts
@@ -69,7 +69,7 @@ export class HCaptchaService {
       };
 
       const response = await firstValueFrom(
-        await this.httpService.post(
+        this.httpService.post(
           `${this.hcaptchaConfigService.labelingURL}/labeler/register`,
           {
             email,

--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.ts
@@ -69,7 +69,7 @@ export class HCaptchaService {
       };
 
       const response = await firstValueFrom(
-        this.httpService.post(
+        await this.httpService.post(
           `${this.hcaptchaConfigService.labelingURL}/labeler/register`,
           {
             email,

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -325,7 +325,7 @@ describe('UserService', () => {
       );
     });
 
-    it('should throw IncorrectAddress if user does not have an evm address', async () => {
+    it('should throw NoWalletAddresRegistered if user does not have an evm address', async () => {
       const userEntity: DeepPartial<UserEntity> = {
         id: 1,
         email: MOCK_EMAIL,
@@ -342,7 +342,10 @@ describe('UserService', () => {
       await expect(
         userService.registerLabeler(userEntity as UserEntity),
       ).rejects.toThrow(
-        new ControlledError(ErrorUser.IncorrectAddress, HttpStatus.BAD_REQUEST),
+        new ControlledError(
+          ErrorUser.NoWalletAddresRegistered,
+          HttpStatus.BAD_REQUEST,
+        ),
       );
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -292,7 +292,10 @@ describe('UserService', () => {
       await expect(
         userService.registerLabeler(userEntity as UserEntity),
       ).rejects.toThrow(
-        new BadRequestException(ErrorUser.LabelingEnableFailed),
+        new ControlledError(
+          ErrorUser.LabelingEnableFailed,
+          HttpStatus.BAD_REQUEST,
+        ),
       );
     });
 
@@ -315,7 +318,10 @@ describe('UserService', () => {
       await expect(
         userService.registerLabeler(userEntity as UserEntity),
       ).rejects.toThrow(
-        new BadRequestException(ErrorUser.LabelingEnableFailed),
+        new ControlledError(
+          ErrorUser.LabelingEnableFailed,
+          HttpStatus.BAD_REQUEST,
+        ),
       );
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -324,6 +324,27 @@ describe('UserService', () => {
         ),
       );
     });
+
+    it('should throw IncorrectAddress if user does not have an evm address', async () => {
+      const userEntity: DeepPartial<UserEntity> = {
+        id: 1,
+        email: MOCK_EMAIL,
+        type: UserType.WORKER,
+        kyc: {
+          country: 'FR',
+          status: KycStatus.APPROVED,
+        },
+        save: jest.fn(),
+      };
+
+      hcaptchaService.registerLabeler = jest.fn().mockResolvedValueOnce(false);
+
+      await expect(
+        userService.registerLabeler(userEntity as UserEntity),
+      ).rejects.toThrow(
+        new ControlledError(ErrorUser.IncorrectAddress, HttpStatus.BAD_REQUEST),
+      );
+    });
   });
 
   describe('registerAddress', () => {

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -146,7 +146,10 @@ export class UserService {
     });
 
     if (!registeredLabeler) {
-      throw new BadRequestException(ErrorUser.LabelingEnableFailed);
+      throw new ControlledError(
+        ErrorUser.LabelingEnableFailed,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Retrieve labeler site key from hcaptcha foundation
@@ -154,7 +157,10 @@ export class UserService {
       email: user.email,
     });
     if (!labelerData || !labelerData.sitekeys.length) {
-      throw new BadRequestException(ErrorUser.LabelingEnableFailed);
+      throw new ControlledError(
+        ErrorUser.LabelingEnableFailed,
+        HttpStatus.BAD_REQUEST,
+      );
     }
     const siteKey = labelerData.sitekeys[0].sitekey;
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -129,6 +129,13 @@ export class UserService {
       throw new BadRequestException(ErrorUser.InvalidType);
     }
 
+    if (!user.evmAddress) {
+      throw new ControlledError(
+        ErrorUser.IncorrectAddress,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     if (user.kyc?.status !== KycStatus.APPROVED) {
       throw new BadRequestException(ErrorUser.KycNotApproved);
     }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -131,7 +131,7 @@ export class UserService {
 
     if (!user.evmAddress) {
       throw new ControlledError(
-        ErrorUser.IncorrectAddress,
+        ErrorUser.NoWalletAddresRegistered,
         HttpStatus.BAD_REQUEST,
       );
     }


### PR DESCRIPTION
## Description
Enhanced error handling in the registerLabeler function to prevent the erroneous return of HTTP 500 status codes.

## Summary of changes
- Refined error processing in the registerLabeler function.
- Added evm address check
- Added new error type NoWalletAddresRegistered
- Updated unit tests.

## How test the changes
`yarn test`

## Related issues
[Reputation Oracle] Fix 500 error during register-labeler request
[#2113](https://github.com/humanprotocol/human-protocol/issues/2113)
