### PR TITLE
[Reputation Oracle] hCaptcha auth guard

### DIFF
--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.spec.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { HCaptchaService } from './hcaptcha.service';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';

--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.ts
@@ -44,11 +44,19 @@ export class HCaptchaService {
         ),
       );
 
-      if (response && response.data && response.status === 200) {
+      if (
+        response &&
+        response.data.success === true &&
+        response.status === 200
+      ) {
         return response.data;
+      } else if (response && response.data.success === false) {
+        this.logger.error(
+          `Error occurred during token verification: ${response.data['error-codes']}`,
+        );
       }
     } catch (error) {
-      this.logger.error('Error occurred during token verification:', error);
+      this.logger.error(`Error occurred during token verification: ${error}`);
     }
 
     return false;
@@ -62,6 +70,10 @@ export class HCaptchaService {
   async registerLabeler(data: hCaptchaRegisterLabeler): Promise<boolean> {
     try {
       const { ip, email, language, country, address } = data;
+
+      if (!country) {
+        this.logger.error(`Country is not set for the user`);
+      }
 
       const queryParams: any = {
         api_key: this.hcaptchaConfigService.apiKey,

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.dto.ts
@@ -18,6 +18,10 @@ export class ForgotPasswordDto {
   @IsEmail()
   @Transform(({ value }: { value: string }) => value.toLowerCase())
   public email: string;
+
+  @ApiProperty({ name: 'h_captcha_token' })
+  @IsString()
+  public hCaptchaToken: string;
 }
 
 export class SignInDto {
@@ -56,6 +60,10 @@ export class ResendEmailVerificationDto {
   @IsEmail()
   @Transform(({ value }: { value: string }) => value.toLowerCase())
   public email: string;
+
+  @ApiProperty({ name: 'h_captcha_token' })
+  @IsString()
+  public hCaptchaToken: string;
 }
 
 export class RestorePasswordDto extends ValidatePasswordDto {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { UserEntity } from '../user/user.entity';
 import { UserRepository } from '../user/user.repository';
 import { Web3Module } from '../web3/web3.module';
 import { AuthConfigService } from '../../common/config/auth-config.service';
+import { HCaptchaModule } from '../../integrations/hcaptcha/hcaptcha.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { AuthConfigService } from '../../common/config/auth-config.service';
     TypeOrmModule.forFeature([TokenEntity, UserEntity]),
     SendGridModule,
     Web3Module,
+    HCaptchaModule,
   ],
   providers: [JwtHttpStrategy, AuthService, TokenRepository, UserRepository],
   controllers: [AuthJwtController],

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -339,19 +339,6 @@ describe('AuthService', () => {
         );
       });
 
-      it('should throw Unauthorized exception if user is not active', () => {
-        userEntity.status = UserStatus.INACTIVE;
-        findByEmailMock.mockResolvedValue(userEntity);
-        expect(
-          authService.forgotPassword({
-            email: 'user@example.com',
-            hCaptchaToken: 'token',
-          }),
-        ).rejects.toThrow(
-          new ControlledError(ErrorUser.UserNotActive, HttpStatus.FORBIDDEN),
-        );
-      });
-
       it('should remove existing token if it exists', async () => {
         findTokenMock.mockResolvedValue(tokenEntity);
         await authService.forgotPassword({

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -330,7 +330,10 @@ describe('AuthService', () => {
       it('should throw NotFound exception if user is not found', () => {
         findByEmailMock.mockResolvedValue(null);
         expect(
-          authService.forgotPassword({ email: 'user@example.com' }),
+          authService.forgotPassword({
+            email: 'user@example.com',
+            hCaptchaToken: 'token',
+          }),
         ).rejects.toThrow(
           new ControlledError(ErrorUser.NotFound, HttpStatus.NO_CONTENT),
         );
@@ -340,7 +343,10 @@ describe('AuthService', () => {
         userEntity.status = UserStatus.INACTIVE;
         findByEmailMock.mockResolvedValue(userEntity);
         expect(
-          authService.forgotPassword({ email: 'user@example.com' }),
+          authService.forgotPassword({
+            email: 'user@example.com',
+            hCaptchaToken: 'token',
+          }),
         ).rejects.toThrow(
           new ControlledError(ErrorUser.UserNotActive, HttpStatus.FORBIDDEN),
         );
@@ -348,7 +354,10 @@ describe('AuthService', () => {
 
       it('should remove existing token if it exists', async () => {
         findTokenMock.mockResolvedValue(tokenEntity);
-        await authService.forgotPassword({ email: 'user@example.com' });
+        await authService.forgotPassword({
+          email: 'user@example.com',
+          hCaptchaToken: 'token',
+        });
 
         expect(tokenRepository.deleteOne).toHaveBeenCalled();
       });
@@ -357,7 +366,32 @@ describe('AuthService', () => {
         sendGridService.sendEmail = jest.fn();
         const email = 'user@example.com';
 
-        await authService.forgotPassword({ email });
+        await authService.forgotPassword({ email, hCaptchaToken: 'token' });
+
+        expect(sendGridService.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            personalizations: [
+              {
+                dynamicTemplateData: {
+                  service_name: SERVICE_NAME,
+                  url: expect.stringContaining(
+                    'http://localhost:3001/reset-password?token=',
+                  ),
+                },
+                to: email,
+              },
+            ],
+            templateId: SENDGRID_TEMPLATES.resetPassword,
+          }),
+        );
+      });
+
+      it('should create a new token and send email if user is not active', async () => {
+        sendGridService.sendEmail = jest.fn();
+        userEntity.status = UserStatus.PENDING;
+        const email = 'user@example.com';
+
+        await authService.forgotPassword({ email, hCaptchaToken: 'token' });
 
         expect(sendGridService.sendEmail).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -530,7 +564,10 @@ describe('AuthService', () => {
       it('should throw an error if user is not found', () => {
         findByEmailMock.mockResolvedValue(null);
         expect(
-          authService.resendEmailVerification({ email: 'user@example.com' }),
+          authService.resendEmailVerification({
+            email: 'user@example.com',
+            hCaptchaToken: 'token',
+          }),
         ).rejects.toThrow(
           new ControlledError(ErrorUser.NotFound, HttpStatus.NO_CONTENT),
         );
@@ -540,7 +577,10 @@ describe('AuthService', () => {
         userEntity.status = UserStatus.ACTIVE;
         findByEmailMock.mockResolvedValue(userEntity);
         expect(
-          authService.resendEmailVerification({ email: 'user@example.com' }),
+          authService.resendEmailVerification({
+            email: 'user@example.com',
+            hCaptchaToken: 'token',
+          }),
         ).rejects.toThrow(
           new ControlledError(ErrorUser.NotFound, HttpStatus.NO_CONTENT),
         );
@@ -552,7 +592,10 @@ describe('AuthService', () => {
         sendGridService.sendEmail = jest.fn();
         const email = 'user@example.com';
 
-        await authService.resendEmailVerification({ email });
+        await authService.resendEmailVerification({
+          email,
+          hCaptchaToken: 'token',
+        });
 
         expect(createTokenMock).toHaveBeenCalled();
         expect(sendGridService.sendEmail).toHaveBeenCalledWith(

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 
 import { ErrorAuth, ErrorUser } from '../../common/constants/errors';
@@ -31,6 +31,8 @@ import { AuthConfigService } from '../../common/config/auth-config.service';
 import { ServerConfigService } from '../../common/config/server-config.service';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ControlledError } from '../../common/errors/controlled';
+import { HCaptchaService } from '../../integrations/hcaptcha/hcaptcha.service';
+import { HCaptchaConfigService } from '../../common/config/hcaptcha-config.service';
 
 @Injectable()
 export class AuthService {
@@ -42,26 +44,24 @@ export class AuthService {
     private readonly tokenRepository: TokenRepository,
     private readonly serverConfigService: ServerConfigService,
     private readonly authConfigService: AuthConfigService,
+    private readonly hCaptchaConfigService: HCaptchaConfigService,
     private readonly web3ConfigService: Web3ConfigService,
     private readonly sendgridService: SendGridService,
     private readonly web3Service: Web3Service,
     private readonly userRepository: UserRepository,
+    private readonly hCaptchaService: HCaptchaService,
   ) {}
 
   public async signin(data: SignInDto, ip?: string): Promise<AuthDto> {
-    // if (
-    //   !(
-    //     await verifyToken(
-    //       this.authConfigService.hCaptchaExchangeURL,
-    //       this.authConfigService.hCaptchaSiteKey,
-    //       this.authConfigService.hCaptchaSecret,
-    //       data.hCaptchaToken,
-    //       ip,
-    //     )
-    //   ).success
-    // ) {
-    //   throw new ControlledError(ErrorAuth.InvalidCaptchaToken, HttpStatus.UNAUTHORIZED);
-    // }
+    if (
+      !(await this.hCaptchaService.verifyToken({ token: data.hCaptchaToken }))
+        .success
+    ) {
+      throw new ControlledError(
+        ErrorAuth.InvalidToken,
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
     const userEntity = await this.userService.getByCredentials(
       data.email,
       data.password,
@@ -78,19 +78,15 @@ export class AuthService {
   }
 
   public async signup(data: UserCreateDto, ip?: string): Promise<UserEntity> {
-    // if (
-    //   !(
-    //     await verifyToken(
-    //       this.authConfigService.hCaptchaSiteKey,
-    //       this.authConfigService.hCaptchaExchangeURL,
-    //       this.authConfigService.hCaptchaSecret,
-    //       data.hCaptchaToken,
-    //       ip,
-    //     )
-    //   ).success
-    // ) {
-    //   throw new ControlledError(ErrorAuth.InvalidCaptchaToken, HttpStatus.UNAUTHORIZED)
-    // }
+    if (
+      !(await this.hCaptchaService.verifyToken({ token: data.hCaptchaToken }))
+        .success
+    ) {
+      throw new ControlledError(
+        ErrorAuth.InvalidToken,
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
     const storedUser = await this.userRepository.findByEmail(data.email);
     if (storedUser) {
       throw new ControlledError(
@@ -184,14 +180,20 @@ export class AuthService {
   }
 
   public async forgotPassword(data: ForgotPasswordDto): Promise<void> {
+    if (
+      !(await this.hCaptchaService.verifyToken({ token: data.hCaptchaToken }))
+        .success
+    ) {
+      throw new ControlledError(
+        ErrorAuth.InvalidToken,
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
     const userEntity = await this.userRepository.findByEmail(data.email);
 
     if (!userEntity) {
       throw new ControlledError(ErrorUser.NotFound, HttpStatus.NO_CONTENT);
-    }
-
-    if (userEntity.status !== UserStatus.ACTIVE) {
-      throw new ControlledError(ErrorUser.UserNotActive, HttpStatus.FORBIDDEN);
     }
 
     const existingToken = await this.tokenRepository.findOneByUserIdAndType(
@@ -231,19 +233,15 @@ export class AuthService {
     data: RestorePasswordDto,
     ip?: string,
   ): Promise<void> {
-    // if (
-    //   !(
-    //     await verifyToken(
-    //       this.authConfigService.hCaptchaExchangeURL,
-    //       this.authConfigService.hCaptchaSiteKey,
-    //       this.authConfigService.hCaptchaSecret,
-    //       data.hCaptchaToken,
-    //       ip,
-    //     )
-    //   ).success
-    // ) {
-    //   throw new ControlledError(ErrorAuth.InvalidCaptchaToken, HttpStatus.UNAUTHORIZED)
-    // }
+    if (
+      !(await this.hCaptchaService.verifyToken({ token: data.hCaptchaToken }))
+        .success
+    ) {
+      throw new ControlledError(
+        ErrorAuth.InvalidToken,
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
 
     const tokenEntity = await this.tokenRepository.findOneByUuidAndType(
       data.token,
@@ -295,6 +293,16 @@ export class AuthService {
   public async resendEmailVerification(
     data: ResendEmailVerificationDto,
   ): Promise<void> {
+    if (
+      !(await this.hCaptchaService.verifyToken({ token: data.hCaptchaToken }))
+        .success
+    ) {
+      throw new ControlledError(
+        ErrorAuth.InvalidToken,
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
     const userEntity = await this.userRepository.findByEmail(data.email);
 
     if (!userEntity || userEntity?.status != UserStatus.PENDING) {

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
@@ -4,7 +4,6 @@ import { CronJobService } from './cron-job.service';
 import { CronJobRepository } from './cron-job.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CronJobEntity } from './cron-job.entity';
-import { CronJobController } from './cron.job.controller';
 import { Web3Module } from '../web3/web3.module';
 import { WebhookModule } from '../webhook/webhook.module';
 import { WebhookRepository } from '../webhook/webhook.repository';


### PR DESCRIPTION
## Description
hCaptcha auth guard is enabled for some `/auth` endpoints

## Summary of changes

1. hCaptcha re-enabled for `/auth/signup`, `/auth/signin` and `/auth/restore-password`
2. hCaptcha added to `/auth/resend-email-verification` and `/auth/forgot-password`
3. Slightly changed the way of handling response for hCaptcha token verification and added a logline with a detailed error code.
4. Removed unused vars.
5. `/auth/forgot-password` endpoint now doesn't require user to be in `ACTIVE` status to avoid dead ends when user forgot password and also forgot to verify his email. In this case he won't be able to log in and ask for a new verification email.

**_Once merged, `HCAPTCHA_SECRET` and `HCAPTCHA_SITE_KEY` needs to be set_**

## Related issues

To close #2163 
