### PR TITLE
[Fortune Exchange Oracle] Add roles to JWT

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/decorators/role.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/decorators/role.ts
@@ -1,4 +1,5 @@
 import { SetMetadata } from '@nestjs/common';
-import { Role } from '../enums/role';
+import { AuthSignatureRole, Role } from '../enums/role';
 
-export const AllowedRoles = (roles: Role[]) => SetMetadata('roles', roles);
+export const AllowedRoles = (roles: AuthSignatureRole[] | Role[]) =>
+  SetMetadata('roles', roles);

--- a/packages/apps/fortune/exchange-oracle/server/src/common/enums/role.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/enums/role.ts
@@ -3,4 +3,5 @@ export enum Role {
   Recording = 'recording',
   Reputation = 'reputation',
   Worker = 'worker',
+  HumanApp = 'human_app',
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/enums/role.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/enums/role.ts
@@ -1,7 +1,11 @@
-export enum Role {
+export enum AuthSignatureRole {
   JobLauncher = 'job_launcher',
   Recording = 'recording',
   Reputation = 'reputation',
+  Worker = 'worker',
+}
+
+export enum Role {
   Worker = 'worker',
   HumanApp = 'human_app',
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/jwt.auth.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/jwt.auth.ts
@@ -28,7 +28,6 @@ export class JwtAuthGuard extends AuthGuard('jwt-http') implements CanActivate {
 
     // Try to authenticate with JWT
     const canActivate = (await super.canActivate(context)) as boolean;
-    console.log(canActivate);
     if (!canActivate) {
       throw new UnauthorizedException('JWT authentication failed');
     }
@@ -36,11 +35,9 @@ export class JwtAuthGuard extends AuthGuard('jwt-http') implements CanActivate {
     // Roles verification
     let roles = this.reflector.get<Role[]>('roles', context.getHandler());
     if (!roles) roles = [Role.Worker];
-    console.log(roles);
 
     const request = context.switchToHttp().getRequest();
     const user = request.user as JwtUser;
-    console.log(user);
     if (!user) {
       throw new UnauthorizedException('User not found in request');
     }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/jwt.auth.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/jwt.auth.ts
@@ -6,6 +6,8 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { Role } from '../enums/role';
+import { JwtUser } from '../types/jwt';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt-http') implements CanActivate {
@@ -25,12 +27,28 @@ export class JwtAuthGuard extends AuthGuard('jwt-http') implements CanActivate {
     }
 
     // Try to authenticate with JWT
-    try {
-      // see https://github.com/nestjs/passport/blob/master/lib/auth.guard.ts
-      return (await super.canActivate(context)) as boolean;
-    } catch (jwtError) {
-      console.error('JWT auth failed:', jwtError);
-      throw new UnauthorizedException(jwtError.message);
+    const canActivate = (await super.canActivate(context)) as boolean;
+    console.log(canActivate);
+    if (!canActivate) {
+      throw new UnauthorizedException('JWT authentication failed');
     }
+
+    // Roles verification
+    let roles = this.reflector.get<Role[]>('roles', context.getHandler());
+    if (!roles) roles = [Role.Worker];
+    console.log(roles);
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as JwtUser;
+    console.log(user);
+    if (!user) {
+      throw new UnauthorizedException('User not found in request');
+    }
+
+    if (!roles.includes(user.role)) {
+      throw new UnauthorizedException('Invalid role');
+    }
+
+    return true;
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/signature.auth.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/signature.auth.spec.ts
@@ -3,7 +3,7 @@ import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { SignatureAuthGuard } from './signature.auth';
 import { verifySignature } from '../utils/signature';
 import { ChainId, EscrowUtils } from '@human-protocol/sdk';
-import { Role } from '../enums/role';
+import { AuthSignatureRole } from '../enums/role';
 import { HEADER_SIGNATURE_KEY } from '../constant';
 import { AssignmentRepository } from '../../modules/assignment/assignment.repository';
 import { Reflector } from '@nestjs/core';
@@ -65,7 +65,9 @@ describe('SignatureAuthGuard', () => {
     });
 
     it('should return true if signature is verified for JobLauncher role', async () => {
-      reflector.get = jest.fn().mockReturnValue([Role.JobLauncher]);
+      reflector.get = jest
+        .fn()
+        .mockReturnValue([AuthSignatureRole.JobLauncher]);
 
       mockRequest.headers[HEADER_SIGNATURE_KEY] = 'validSignature';
       mockRequest.body = {
@@ -83,7 +85,9 @@ describe('SignatureAuthGuard', () => {
     });
 
     it('should throw UnauthorizedException if signature is not verified', async () => {
-      reflector.get = jest.fn().mockReturnValue([Role.JobLauncher]);
+      reflector.get = jest
+        .fn()
+        .mockReturnValue([AuthSignatureRole.JobLauncher]);
 
       mockRequest.headers[HEADER_SIGNATURE_KEY] = 'invalidSignature';
       mockRequest.body = {
@@ -98,7 +102,7 @@ describe('SignatureAuthGuard', () => {
     });
 
     it('should handle Worker role and verify signature', async () => {
-      reflector.get = jest.fn().mockReturnValue([Role.Worker]);
+      reflector.get = jest.fn().mockReturnValue([AuthSignatureRole.Worker]);
 
       mockRequest.headers[HEADER_SIGNATURE_KEY] = 'validSignature';
       mockRequest.body = {
@@ -115,7 +119,7 @@ describe('SignatureAuthGuard', () => {
     });
 
     it('should throw UnauthorizedException if assignment is not found for Worker role', async () => {
-      reflector.get = jest.fn().mockReturnValue([Role.Worker]);
+      reflector.get = jest.fn().mockReturnValue([AuthSignatureRole.Worker]);
 
       mockRequest.headers[HEADER_SIGNATURE_KEY] = 'validSignature';
       mockRequest.body = {
@@ -132,7 +136,10 @@ describe('SignatureAuthGuard', () => {
     it('should handle multiple roles and verify signature', async () => {
       reflector.get = jest
         .fn()
-        .mockReturnValue([Role.JobLauncher, Role.Worker]);
+        .mockReturnValue([
+          AuthSignatureRole.JobLauncher,
+          AuthSignatureRole.Worker,
+        ]);
 
       mockRequest.headers[HEADER_SIGNATURE_KEY] = 'validSignature';
       mockRequest.body = {

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/signature.auth.ts
@@ -8,7 +8,7 @@ import {
 import { verifySignature } from '../utils/signature';
 import { HEADER_SIGNATURE_KEY } from '../constant';
 import { EscrowUtils } from '@human-protocol/sdk';
-import { Role } from '../enums/role';
+import { AuthSignatureRole } from '../enums/role';
 import { Reflector } from '@nestjs/core';
 import { AssignmentRepository } from '../../modules/assignment/assignment.repository';
 import { ErrorAssignment, ErrorSignature } from '../constant/errors';
@@ -21,14 +21,17 @@ export class SignatureAuthGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const roles = this.reflector.get<Role[]>('roles', context.getHandler());
+    const roles = this.reflector.get<AuthSignatureRole[]>(
+      'roles',
+      context.getHandler(),
+    );
     if (!roles) throw new NotImplementedException(ErrorSignature.MissingRoles);
     const request = context.switchToHttp().getRequest();
     const data = request.body;
     const signature = request.headers[HEADER_SIGNATURE_KEY];
     const oracleAdresses: string[] = [];
 
-    if (roles.includes(Role.Worker)) {
+    if (roles.includes(AuthSignatureRole.Worker)) {
       const assignment = await this.assignmentRepository.findOneById(
         data.assignment_id,
       );
@@ -43,15 +46,15 @@ export class SignatureAuthGuard implements CanActivate {
         data.escrow_address,
       );
 
-      if (roles.includes(Role.JobLauncher)) {
+      if (roles.includes(AuthSignatureRole.JobLauncher)) {
         oracleAdresses.push(escrowData.launcher);
       }
 
-      if (roles.includes(Role.Recording)) {
+      if (roles.includes(AuthSignatureRole.Recording)) {
         oracleAdresses.push(escrowData.recordingOracle!);
       }
 
-      if (roles.includes(Role.Reputation)) {
+      if (roles.includes(AuthSignatureRole.Reputation)) {
         oracleAdresses.push(escrowData.reputationOracle!);
       }
     }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/strategy/jwt.http.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/strategy/jwt.http.ts
@@ -7,7 +7,7 @@ import * as jwt from 'jsonwebtoken';
 import { Web3Service } from '../../../modules/web3/web3.service';
 import { JwtUser } from '../../../common/types/jwt';
 import { JWT_KVSTORE_KEY, KYC_APPROVED } from '../../../common/constant';
-import { Role } from 'src/common/enums/role';
+import { Role } from '../../../common/enums/role';
 
 @Injectable()
 export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/strategy/jwt.http.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/strategy/jwt.http.ts
@@ -7,6 +7,7 @@ import * as jwt from 'jsonwebtoken';
 import { Web3Service } from '../../../modules/web3/web3.service';
 import { JwtUser } from '../../../common/types/jwt';
 import { JWT_KVSTORE_KEY, KYC_APPROVED } from '../../../common/constant';
+import { Role } from 'src/common/enums/role';
 
 @Injectable()
 export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {
@@ -45,19 +46,34 @@ export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {
   public async validate(
     @Req() request: any,
     payload: {
+      role: string;
       email: string;
       address: string;
       kyc_status: string;
       reputation_network: string;
     },
   ): Promise<JwtUser> {
-    if (!payload.kyc_status || !payload.email || !payload.address) {
+    if (!payload.email || !payload.role) {
       throw new UnauthorizedException('Invalid token');
     }
-    if (payload.kyc_status !== KYC_APPROVED) {
-      throw new UnauthorizedException('Invalid KYC status');
+
+    if (!Object.values(Role).includes(payload.role as Role)) {
+      throw new UnauthorizedException('Invalid role');
     }
+
+    const role: Role = payload.role as Role;
+
+    if (role !== Role.HumanApp) {
+      if (!payload.kyc_status || !payload.address) {
+        throw new UnauthorizedException('Invalid token');
+      }
+      if (payload.kyc_status !== KYC_APPROVED) {
+        throw new UnauthorizedException('Invalid KYC status');
+      }
+    }
+
     return {
+      role: role,
       address: payload.address,
       email: payload.email,
       kycStatus: payload.kyc_status,

--- a/packages/apps/fortune/exchange-oracle/server/src/common/types/jwt.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/types/jwt.ts
@@ -1,8 +1,11 @@
+import { Role } from '../enums/role';
+
 export interface RequestWithUser extends Request {
   user: JwtUser;
 }
 
 export interface JwtUser {
+  role: Role;
   email: string;
   address: string;
   kycStatus: string;

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.ts
@@ -54,6 +54,7 @@ export class JobController {
     description: 'Unauthorized. Missing or invalid credentials.',
   })
   @UseGuards(JwtAuthGuard)
+  @AllowedRoles([Role.Worker, Role.HumanApp])
   @ApiBearerAuth()
   @Get()
   getJobs(

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.ts
@@ -27,7 +27,7 @@ import { JobService } from './job.service';
 import { HEADER_SIGNATURE_KEY } from '../../common/constant';
 import { RequestWithUser } from '../../common/types/jwt';
 import { PageDto } from '../../common/pagination/pagination.dto';
-import { Role } from '../../common/enums/role';
+import { AuthSignatureRole, Role } from '../../common/enums/role';
 import { SignatureAuthGuard } from '../../common/guards/signature.auth';
 import { AllowedRoles } from '../../common/decorators/role';
 
@@ -92,7 +92,7 @@ export class JobController {
   })
   @Post('solve')
   @UseGuards(SignatureAuthGuard)
-  @AllowedRoles([Role.Worker])
+  @AllowedRoles([AuthSignatureRole.Worker])
   async solveJob(
     @Headers(HEADER_SIGNATURE_KEY) signature: string,
     @Body() solveJobDto: SolveJobDto,

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.controller.ts
@@ -6,7 +6,7 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { Role } from '../../common/enums/role';
+import { AuthSignatureRole } from '../../common/enums/role';
 import { SignatureAuthGuard } from '../../common/guards';
 import { WebhookService } from './webhook.service';
 import { HEADER_SIGNATURE_KEY } from '../../common/constant';
@@ -20,7 +20,11 @@ export class WebhookController {
 
   @Post()
   @UseGuards(SignatureAuthGuard)
-  @AllowedRoles([Role.Recording, Role.Reputation, Role.JobLauncher])
+  @AllowedRoles([
+    AuthSignatureRole.Recording,
+    AuthSignatureRole.Reputation,
+    AuthSignatureRole.JobLauncher,
+  ])
   @ApiOperation({
     summary: 'Handle Webhook Events',
     description:

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -149,9 +149,8 @@ export class AuthService {
     const payload: any = {
       email: userEntity.email,
       userId: userEntity.id,
-      role: 'human_app',
-      // address: userEntity.evmAddress,
-      // kyc_status: userEntity.kyc?.status,
+      address: userEntity.evmAddress,
+      kyc_status: userEntity.kyc?.status,
       reputation_network: this.web3Service.getOperatorAddress(),
     };
 

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -149,8 +149,9 @@ export class AuthService {
     const payload: any = {
       email: userEntity.email,
       userId: userEntity.id,
-      address: userEntity.evmAddress,
-      kyc_status: userEntity.kyc?.status,
+      role: 'human_app',
+      // address: userEntity.evmAddress,
+      // kyc_status: userEntity.kyc?.status,
       reputation_network: this.web3Service.getOperatorAddress(),
     };
 


### PR DESCRIPTION
## Description

Authorize HUMAN App to fetch jobs list using JWT generated by Reputation Oracle

## Summary of changes

Modify JWT strategy to substract role from JWT
Check roles in jwt auth
Add `human_app` to allowed roles in `getJobs` endpoint

## How test the changes
`yarn test`

## Related issues
#2176 
