### PR TITLE
[Subgraph] Remove EscrowStatusEvent from legacy contracts

### DIFF
--- a/packages/sdk/typescript/subgraph/src/mapping/legacy/EscrowFactory.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/legacy/EscrowFactory.ts
@@ -1,25 +1,14 @@
-import { Escrow, EscrowStatusEvent } from '../../../generated/schema';
+import { Escrow } from '../../../generated/schema';
 import { Launched } from '../../../generated/LegacyEscrowFactory/EscrowFactory';
 import { LegacyEscrow as EscrowTemplate } from '../../../generated/templates';
 import { ONE_BI, ZERO_BI } from '../utils/number';
 import { getEventDayData } from '../utils/dayUpdates';
 import { createOrLoadEscrowStatistics } from '../Escrow';
 import { createOrLoadLeader } from '../Staking';
-import { toEventId } from '../utils/event';
 import { createTransaction } from '../utils/transaction';
 
 export function handleLaunched(event: Launched): void {
   createTransaction(event, 'createEscrow');
-  // Create LaunchedStatusEvent entity
-  const statusEventEntity = new EscrowStatusEvent(toEventId(event));
-  statusEventEntity.block = event.block.number;
-  statusEventEntity.timestamp = event.block.timestamp;
-  statusEventEntity.txHash = event.transaction.hash;
-  statusEventEntity.escrowAddress = event.params.escrow;
-  statusEventEntity.sender = event.transaction.from;
-  statusEventEntity.launcher = event.transaction.from;
-  statusEventEntity.status = 'Launched';
-  statusEventEntity.save();
 
   // Create Escrow entity
   const entity = new Escrow(event.params.escrow.toHex());

--- a/packages/sdk/typescript/subgraph/tests/legacy/escrow-factory/escrow-factory.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/legacy/escrow-factory/escrow-factory.test.ts
@@ -134,49 +134,6 @@ describe('EscrowFactory', () => {
       '2'
     );
 
-    // EscrowStatusEvent
-    const id1 = `${data1.transaction.hash.toHex()}-${data1.logIndex.toString()}-${
-      data1.block.timestamp
-    }`;
-
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'block',
-      data1.block.number.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'timestamp',
-      data1.block.timestamp.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'txHash',
-      data1.transaction.hash.toHex()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'escrowAddress',
-      escrow1AddressString
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'sender',
-      launcherAddressString
-    );
-    assert.fieldEquals('EscrowStatusEvent', id1, 'status', 'Launched');
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'launcher',
-      launcherAddressString
-    );
-
     // Transaction
     assert.fieldEquals(
       'Transaction',

--- a/packages/sdk/typescript/subgraph/tests/legacy/escrow/escrow.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/legacy/escrow/escrow.test.ts
@@ -136,45 +136,6 @@ describe('Escrow', () => {
     assert.fieldEquals('SetupEvent', id, 'escrowAddress', escrowAddressString);
     assert.fieldEquals('SetupEvent', id, 'sender', operatorAddressString);
 
-    // EscrowStatusEvent
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id,
-      'block',
-      newPending1.block.number.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id,
-      'timestamp',
-      newPending1.block.timestamp.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id,
-      'txHash',
-      newPending1.transaction.hash.toHex()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id,
-      'escrowAddress',
-      escrowAddressString
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id,
-      'sender',
-      operatorAddressString
-    );
-    assert.fieldEquals('EscrowStatusEvent', id, 'status', 'Pending');
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id,
-      'launcher',
-      launcherAddressString
-    );
-
     // Escrow
     assert.fieldEquals('Escrow', escrowAddress.toHex(), 'status', 'Pending');
     assert.fieldEquals('Escrow', escrowAddress.toHex(), 'manifestUrl', URL);
@@ -339,45 +300,6 @@ describe('Escrow', () => {
     assert.fieldEquals('BulkPayoutEvent', id1, 'bulkPayoutTxId', '1');
     assert.fieldEquals('BulkPayoutEvent', id1, 'bulkCount', '2');
 
-    // EscrowStatusEvent
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'block',
-      bulk1.block.number.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'timestamp',
-      bulk1.block.timestamp.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'txHash',
-      bulk1.transaction.hash.toHex()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'escrowAddress',
-      escrowAddressString
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'sender',
-      operatorAddressString
-    );
-    assert.fieldEquals('EscrowStatusEvent', id1, 'status', 'Partial');
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'launcher',
-      launcherAddressString
-    );
-
     // Escrow
     assert.fieldEquals(
       'Escrow',
@@ -464,45 +386,6 @@ describe('Escrow', () => {
     assert.fieldEquals('BulkPayoutEvent', id1, 'sender', operatorAddressString);
     assert.fieldEquals('BulkPayoutEvent', id1, 'bulkPayoutTxId', '1');
     assert.fieldEquals('BulkPayoutEvent', id1, 'bulkCount', '2');
-
-    // EscrowStatusEvent
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'block',
-      bulk1.block.number.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'timestamp',
-      bulk1.block.timestamp.toString()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'txHash',
-      bulk1.transaction.hash.toHex()
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'escrowAddress',
-      escrowAddressString
-    );
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'sender',
-      operatorAddressString
-    );
-    assert.fieldEquals('EscrowStatusEvent', id1, 'status', 'Paid');
-    assert.fieldEquals(
-      'EscrowStatusEvent',
-      id1,
-      'launcher',
-      launcherAddressString
-    );
 
     // Escrow
     assert.fieldEquals('Escrow', escrowAddress.toHex(), 'status', 'Paid');


### PR DESCRIPTION
## Description

Remove EscrowStatusEvent from legacy escrow contracts

## Summary of changes

Remove EscrowStatusEvent from legacy escrow contracts
Fix tests

## How test the changes

`yarn test`

## Related issues
#2195
