### PR TITLE
[Reputation Oracle] Fix JWT site_key

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/auth/token.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/token.repository.ts
@@ -18,7 +18,7 @@ export class TokenRepository extends BaseRepository<TokenEntity> {
         uuid,
         type,
       },
-      relations: ['user', 'user.kyc'],
+      relations: ['user', 'user.kyc', 'user.siteKey'],
     });
   }
 


### PR DESCRIPTION
## Description

JWT token generated in refresh token endpoint doesn't contain `site_key`

## Summary of changes

Add user sitekey to token relations

## How test the changes

`yarn test`

## Related issues
#2208
