### PR TITLE
[Reputation Oracle] Converted addresses to lower case for signatures

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/pipes/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/pipes/index.ts
@@ -1,1 +1,2 @@
 export * from './validation';
+export * from './lower-case-address';

--- a/packages/apps/reputation-oracle/server/src/common/pipes/lower-case-address.ts
+++ b/packages/apps/reputation-oracle/server/src/common/pipes/lower-case-address.ts
@@ -1,0 +1,15 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class LowerCaseAddressPipe implements PipeTransform {
+  transform(value: any) {
+    if (typeof value === 'object' && value !== null) {
+      for (const key in value) {
+        if (key === 'address' && typeof value[key] === 'string') {
+          value[key] = value[key].toLowerCase();
+        }
+      }
+    }
+    return value;
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -35,7 +35,10 @@ import { AuthService } from './auth.service';
 import { JwtAuthGuard } from '../../common/guards';
 import { RequestWithUser } from '../../common/types';
 import { TokenRepository } from './token.repository';
-import { PasswordValidationPipe } from '../../common/pipes';
+import {
+  LowerCaseAddressPipe,
+  PasswordValidationPipe,
+} from '../../common/pipes';
 import { TokenType } from './token.entity';
 
 @ApiTags('Auth')
@@ -130,7 +133,9 @@ export class AuthJwtController {
     status: 401,
     description: 'Unauthorized. Missing or invalid credentials.',
   })
-  public async web3SignUp(@Body() data: Web3SignUpDto): Promise<AuthDto> {
+  public async web3SignUp(
+    @Body(new LowerCaseAddressPipe()) data: Web3SignUpDto,
+  ): Promise<AuthDto> {
     return this.authService.web3Signup(data);
   }
 
@@ -151,7 +156,9 @@ export class AuthJwtController {
     status: 401,
     description: 'Unauthorized. Missing or invalid credentials.',
   })
-  public async web3SignIn(@Body() data: Web3SignInDto): Promise<AuthDto> {
+  public async web3SignIn(
+    @Body(new LowerCaseAddressPipe()) data: Web3SignInDto,
+  ): Promise<AuthDto> {
     return this.authService.web3Signin(data);
   }
   @Public()

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -26,6 +26,7 @@ import { JwtAuthGuard } from '../../common/guards';
 import { RequestWithUser } from '../../common/types';
 import { UserService } from './user.service';
 import { Public } from '../../common/decorators';
+import { LowerCaseAddressPipe } from 'src/common/pipes';
 
 @ApiTags('User')
 @Controller('/user')
@@ -141,7 +142,7 @@ export class UserController {
     description: 'Unauthorized. Missing or invalid credentials.',
   })
   public async prepareSignature(
-    @Body() data: PrepareSignatureDto,
+    @Body(new LowerCaseAddressPipe()) data: PrepareSignatureDto,
   ): Promise<SignatureBodyDto> {
     return await this.userService.prepareSignatureBody(data.type, data.address);
   }


### PR DESCRIPTION
## Description
Converted addresses from body to lower case in `prepare-signature`, `web3/signup` and `web3/signin` endpoints

## Summary of changes
- Implemented `LowerCaseAddressPipe`

## How test the changes
`yarn test`

## Related issues
[Reputation Oracle] Convert addresses to lower case for signatures
[#2201](https://github.com/humanprotocol/human-protocol/issues/2201)
