### PR TITLE
[Reputation Oracle] Add user status to jwt

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -287,6 +287,7 @@ describe('AuthService', () => {
       expect(jwtSignMock).toHaveBeenLastCalledWith(
         {
           email: userEntity.email,
+          status: userEntity.status,
           userId: userEntity.id,
           address: userEntity.evmAddress,
           kyc_status: userEntity.kyc?.status,

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -148,6 +148,7 @@ export class AuthService {
 
     const payload: any = {
       email: userEntity.email,
+      status: userEntity.status,
       userId: userEntity.id,
       address: userEntity.evmAddress,
       role: userEntity.role,


### PR DESCRIPTION
## Description
Add status to jwt so that in the frontend of HUMAN APP is possible to know if the user verified his email.

## Summary of changes
Add status to jwt

## How test the changes
yarn test

