### PR TITLE
[Reputation Oracle] Get kyc on chain endpoint

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -61,7 +61,7 @@ export enum ErrorUser {
   AccountCannotBeRegistered = 'Account cannot be registered',
   BalanceCouldNotBeRetreived = 'User balance could not be retrieved',
   InvalidCredentials = 'Invalid credentials',
-  IncorrectAddress = 'Incorrect address',
+  AlreadyAssigned = 'User already has an address assigned',
   NoWalletAddresRegistered = 'No wallet address registered on your account',
   KycNotApproved = 'KYC not approved',
   UserNotActive = 'User not active',

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.spec.ts
@@ -4,10 +4,23 @@ import { KycController } from './kyc.controller';
 import { KycService } from './kyc.service';
 import { KycSessionDto } from './kyc.dto';
 import { KycStatus } from '../../common/enums/user';
+import { Web3Service } from '../web3/web3.service';
+import { MOCK_ADDRESS } from '../../../test/constants';
+import { NetworkConfigService } from '../../common/config/network-config.service';
+import { ConfigService } from '@nestjs/config';
+import { ChainId } from '@human-protocol/sdk';
 
 describe('KycController', () => {
   let kycController: KycController;
   let kycService: KycService;
+  let web3Service: Web3Service;
+  let networkConfigService: NetworkConfigService;
+
+  const signerMock = {
+    address: MOCK_ADDRESS,
+    getNetwork: jest.fn().mockResolvedValue({ chainId: 1 }),
+    signMessage: jest.fn(),
+  };
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -19,11 +32,28 @@ describe('KycController', () => {
             updateKycStatus: jest.fn(),
           },
         },
+        {
+          provide: Web3Service,
+          useValue: {
+            getSigner: jest.fn().mockReturnValue(signerMock),
+          },
+        },
+        ConfigService,
+        {
+          provide: NetworkConfigService,
+          useValue: {
+            networks: [{ chainId: ChainId.LOCALHOST }],
+          },
+        },
       ],
+      controllers: [KycController],
     }).compile();
 
     kycService = moduleRef.get<KycService>(KycService);
-    kycController = new KycController(kycService);
+    web3Service = moduleRef.get<Web3Service>(Web3Service);
+    networkConfigService =
+      moduleRef.get<NetworkConfigService>(NetworkConfigService);
+    kycController = moduleRef.get<KycController>(KycController);
   });
 
   describe('startKyc', () => {
@@ -62,6 +92,18 @@ describe('KycController', () => {
         session_id: '123',
         state: KycStatus.APPROVED,
       });
+    });
+  });
+
+  describe('updateKycStatus', () => {
+    it('should call web3Service', async () => {
+      await kycController.getSignedAddress({
+        user: { evmAddress: '0x123' },
+      } as any);
+
+      expect(web3Service.getSigner).toHaveBeenCalledWith(
+        networkConfigService.networks[0].chainId,
+      );
     });
   });
 });

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.dto.ts
@@ -67,3 +67,8 @@ export class KycUpdateDto {
   @IsOptional()
   public message?: string;
 }
+
+export class KycSignedAddressDto {
+  key: string;
+  value: string;
+}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.dto.ts
@@ -38,3 +38,8 @@ export class KycUpdateWebhookQueryDto {
   @IsString()
   public secret: string;
 }
+
+export class KycSignedAddressDto {
+  key: string;
+  value: string;
+}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.module.ts
@@ -8,6 +8,7 @@ import { KycRepository } from './kyc.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { KycEntity } from './kyc.entity';
 import { UserModule } from '../user/user.module';
+import { Web3Module } from '../web3/web3.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { UserModule } from '../user/user.module';
     TypeOrmModule.forFeature([KycEntity]),
     ConfigModule,
     HttpModule,
+    Web3Module,
   ],
   providers: [KycService, KycRepository],
   controllers: [KycController],

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -413,7 +413,7 @@ describe('UserService', () => {
           signature,
         }),
       ).rejects.toThrow(
-        new ControlledError(ErrorUser.IncorrectAddress, HttpStatus.BAD_REQUEST),
+        new ControlledError(ErrorUser.AlreadyAssigned, HttpStatus.BAD_REQUEST),
       );
     });
 
@@ -421,7 +421,6 @@ describe('UserService', () => {
       const userEntity: DeepPartial<UserEntity> = {
         id: 1,
         email: '',
-        evmAddress: '0x123',
         kyc: {
           country: 'FR',
           status: KycStatus.PENDING_VERIFICATION,
@@ -441,7 +440,7 @@ describe('UserService', () => {
       );
     });
 
-    it("should fail if user's email already exists", async () => {
+    it("should fail if user's address already exists", async () => {
       const userEntity: DeepPartial<UserEntity> = {
         id: 1,
         email: '',
@@ -458,6 +457,35 @@ describe('UserService', () => {
       jest
         .spyOn(userRepository, 'findByAddress')
         .mockResolvedValue(userEntity as any);
+
+      await expect(
+        userService.registerAddress(userEntity as UserEntity, {
+          address,
+          signature,
+        }),
+      ).rejects.toThrow(
+        new ControlledError(ErrorUser.AlreadyAssigned, HttpStatus.BAD_REQUEST),
+      );
+    });
+
+    it('should fail if address already registered with another user', async () => {
+      const userEntity: DeepPartial<UserEntity> = {
+        id: 1,
+        email: '',
+        kyc: {
+          country: 'FR',
+          status: KycStatus.APPROVED,
+        },
+      };
+
+      const address = '0x123';
+      const signature = 'valid-signature';
+
+      jest.spyOn(userRepository, 'findByAddress').mockResolvedValue({
+        id: 2,
+        email: '',
+        evmAddress: '0x123',
+      } as any);
 
       await expect(
         userService.registerAddress(userEntity as UserEntity, {

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -185,9 +185,11 @@ export class UserService {
     user: UserEntity,
     data: RegisterAddressRequestDto,
   ): Promise<string> {
-    if (user.evmAddress && user.evmAddress !== data.address) {
+    data.address = data.address.toLowerCase();
+
+    if (user.evmAddress) {
       throw new ControlledError(
-        ErrorUser.IncorrectAddress,
+        ErrorUser.AlreadyAssigned,
         HttpStatus.BAD_REQUEST,
       );
     }


### PR DESCRIPTION
## Description

Create a new endpoint that returns the data that users need to save in kvstore to save their kyc verification on chain

## Summary of changes

Create a new endpoint in kyc.controller.ts that signs the address of the user

## How test the changes

`yarn test`

## Related issues
#2226
