### PR TITLE
[Reputation Oracle] Fix kyc on chain and change returned value of user/register-address

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.dto.ts
@@ -40,6 +40,11 @@ export class KycUpdateWebhookQueryDto {
 }
 
 export class KycSignedAddressDto {
+  @ApiProperty({ name: 'key' })
+  @IsString()
   key: string;
+
+  @ApiProperty({ name: 'value' })
+  @IsString()
   value: string;
 }

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.spec.ts
@@ -53,6 +53,9 @@ describe('Kyc Service', () => {
           provide: Web3Service,
           useValue: {
             getSigner: jest.fn().mockReturnValue(signerMock),
+            getOperatorAddress: jest
+              .fn()
+              .mockReturnValue(MOCK_ADDRESS.toLowerCase()),
           },
         },
         ConfigService,

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
@@ -195,7 +195,7 @@ export class KycService {
       .signMessage(address);
 
     return {
-      key: `KYC-${address}`,
+      key: `KYC-${this.web3Service.getOperatorAddress()}`,
       value: signature,
     };
   }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -18,7 +18,6 @@ import {
   DisableOperatorDto,
   PrepareSignatureDto,
   RegisterAddressRequestDto,
-  RegisterAddressResponseDto,
   SignatureBodyDto,
   RegisterLabelerResponseDto,
   EnableOperatorDto,
@@ -27,6 +26,7 @@ import { JwtAuthGuard } from '../../common/guards';
 import { RequestWithUser } from '../../common/types';
 import { UserService } from './user.service';
 import { Public } from '../../common/decorators';
+import { KycSignedAddressDto } from '../kyc/kyc.dto';
 
 @ApiTags('User')
 @Controller('/user')
@@ -76,7 +76,7 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: 'Blockchain address registered successfully',
-    type: RegisterAddressResponseDto,
+    type: KycSignedAddressDto,
   })
   @ApiResponse({
     status: 400,
@@ -93,13 +93,8 @@ export class UserController {
   public async registerAddress(
     @Req() request: RequestWithUser,
     @Body() data: RegisterAddressRequestDto,
-  ): Promise<RegisterAddressResponseDto> {
-    const signedAddress = await this.userService.registerAddress(
-      request.user,
-      data,
-    );
-
-    return { signedAddress };
+  ): Promise<KycSignedAddressDto> {
+    return this.userService.registerAddress(request.user, data);
   }
 
   @Post('/enable-operator')

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
@@ -65,12 +65,6 @@ export class RegisterAddressRequestDto {
   public signature: string;
 }
 
-export class RegisterAddressResponseDto {
-  @ApiProperty({ name: 'signed_address' })
-  @IsString()
-  public signedAddress: string;
-}
-
 export class EnableOperatorDto {
   @ApiProperty()
   @IsString()

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -83,7 +83,9 @@ describe('UserService', () => {
             getSigner: jest.fn().mockReturnValue(signerMock),
             signMessage: jest.fn(),
             prepareSignatureBody: jest.fn(),
-            getOperatorAddress: jest.fn().mockReturnValue(MOCK_ADDRESS),
+            getOperatorAddress: jest
+              .fn()
+              .mockReturnValue(MOCK_ADDRESS.toLowerCase()),
             getValidChains: jest.fn().mockReturnValue([ChainId.LOCALHOST]),
           },
         },
@@ -394,7 +396,10 @@ describe('UserService', () => {
       );
 
       expect(userRepository.updateOne).toHaveBeenCalledWith(userEntity);
-      expect(result).toBe('signature');
+      expect(result).toEqual({
+        key: `KYC-${MOCK_ADDRESS.toLowerCase()}`,
+        value: 'signature',
+      });
     });
 
     it("should fail if address is different from user's evm address", async () => {


### PR DESCRIPTION
## Description
Change returned value of user/register-address and fix kyc on chain endpoint in Reputation Oracle

## Summary of changes

Change returned value of user/register-address and fix kyc on chain endpoint in Reputation Oracle

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
#2242 #2243