### PR TITLE
[Fortune Exchange Oracle] Extend stats

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.controller.spec.ts
@@ -1,6 +1,6 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test } from '@nestjs/testing';
-import { RequestWithUser } from 'src/common/types/jwt';
+import { RequestWithUser } from '../../common/types/jwt';
 import { JobController } from './job.controller';
 import { GetJobsDto, SolveJobDto, JobDto } from './job.dto';
 import { JobService } from './job.service';

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.repository.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.repository.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import { BaseRepository } from '../../database/base.repository';
 import { JobEntity } from './job.entity';
-import { JobSortField } from '../../common/enums/job';
+import { JobSortField, JobStatus } from '../../common/enums/job';
 import { JobFilterData, ListResult } from './job.interface';
 
 @Injectable()
@@ -95,4 +95,13 @@ export class JobRepository extends BaseRepository<JobEntity> {
     const { entities } = await queryBuilder.getRawAndEntities();
     return { entities, itemCount };
   }
+
+  public async countJobsByStatus(status: JobStatus): Promise<number> {
+    return this.count({
+      where: {
+        status,
+      },
+    });
+  }
+
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.repository.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.repository.ts
@@ -103,5 +103,4 @@ export class JobRepository extends BaseRepository<JobEntity> {
       },
     });
   }
-
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.dto.ts
@@ -2,6 +2,21 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class OracleStatsDto {
   @ApiProperty({
+    name: 'active_escrows',
+  })
+  activeEscrows: number;
+
+  @ApiProperty({
+    name: 'completed_escrows',
+  })
+  completedEscrows: number;
+
+  @ApiProperty({
+    name: 'canceled_escrows',
+  })
+  canceledEscrows: number;
+
+  @ApiProperty({
     name: 'workers_total',
   })
   workersTotal: number;

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.module.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AssignmentEntity } from '../assignment/assignment.entity';
 import { StatsService } from './stats.service';
 import { StatsController } from './stats.controller';
+import { JobRepository } from '../job/job.repository';
 import { AssignmentRepository } from '../assignment/assignment.repository';
 import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AssignmentEntity]), ConfigModule],
   controllers: [StatsController],
-  providers: [StatsService, AssignmentRepository],
+  providers: [StatsService, AssignmentRepository, JobRepository],
   exports: [StatsService],
 })
 export class StatsModule {}

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.spec.ts
@@ -1,12 +1,14 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test } from '@nestjs/testing';
 import { StatsService } from './stats.service';
+import { JobRepository } from '../job/job.repository';
 import { AssignmentRepository } from '../assignment/assignment.repository';
 
 jest.mock('../../common/utils/signature');
 
 describe('statsService', () => {
   let statsService: StatsService;
+  let jobRepository: JobRepository;
   let assignmentRepository: AssignmentRepository;
   const userAddress = '0x1234567890123456789012345678901234567890';
 
@@ -16,6 +18,10 @@ describe('statsService', () => {
       controllers: [StatsService],
       providers: [
         {
+          provide: JobRepository,
+          useValue: createMock<JobRepository>(),
+        },
+        {
           provide: AssignmentRepository,
           useValue: createMock<AssignmentRepository>(),
         },
@@ -23,6 +29,8 @@ describe('statsService', () => {
     }).compile();
 
     statsService = moduleRef.get<StatsService>(StatsService);
+    jobRepository =
+      moduleRef.get<JobRepository>(JobRepository);
     assignmentRepository =
       moduleRef.get<AssignmentRepository>(AssignmentRepository);
   });
@@ -30,6 +38,7 @@ describe('statsService', () => {
   describe('getOracleStats', () => {
     it('should call assignmentRepository', async () => {
       await statsService.getOracleStats();
+      expect(jobRepository.countJobsByStatus).toHaveBeenCalledTimes(3);
       expect(assignmentRepository.countTotalWorkers).toHaveBeenCalledWith();
       expect(
         assignmentRepository.countCompletedAssignments,

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.spec.ts
@@ -29,8 +29,7 @@ describe('statsService', () => {
     }).compile();
 
     statsService = moduleRef.get<StatsService>(StatsService);
-    jobRepository =
-      moduleRef.get<JobRepository>(JobRepository);
+    jobRepository = moduleRef.get<JobRepository>(JobRepository);
     assignmentRepository =
       moduleRef.get<AssignmentRepository>(AssignmentRepository);
   });

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.ts
@@ -9,14 +9,20 @@ export class StatsService {
   public readonly logger = new Logger(StatsService.name);
   constructor(
     private jobRepository: JobRepository,
-    private assignmentRepository: AssignmentRepository
+    private assignmentRepository: AssignmentRepository,
   ) {}
 
   async getOracleStats(): Promise<OracleStatsDto> {
     return new OracleStatsDto({
-      activeEscrows: await this.jobRepository.countJobsByStatus(JobStatus.ACTIVE),
-      completedEscrows: await this.jobRepository.countJobsByStatus(JobStatus.COMPLETED),
-      canceledEscrows: await this.jobRepository.countJobsByStatus(JobStatus.CANCELED),
+      activeEscrows: await this.jobRepository.countJobsByStatus(
+        JobStatus.ACTIVE,
+      ),
+      completedEscrows: await this.jobRepository.countJobsByStatus(
+        JobStatus.COMPLETED,
+      ),
+      canceledEscrows: await this.jobRepository.countJobsByStatus(
+        JobStatus.CANCELED,
+      ),
       workersTotal: await this.assignmentRepository.countTotalWorkers(),
       assignmentsCompleted:
         await this.assignmentRepository.countCompletedAssignments(),

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.ts
@@ -1,14 +1,22 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { JobRepository } from '../job/job.repository';
 import { AssignmentRepository } from '../assignment/assignment.repository';
 import { AssignmentStatsDto, OracleStatsDto } from './stats.dto';
+import { JobStatus } from '../../common/enums/job';
 
 @Injectable()
 export class StatsService {
   public readonly logger = new Logger(StatsService.name);
-  constructor(private assignmentRepository: AssignmentRepository) {}
+  constructor(
+    private jobRepository: JobRepository,
+    private assignmentRepository: AssignmentRepository
+  ) {}
 
   async getOracleStats(): Promise<OracleStatsDto> {
     return new OracleStatsDto({
+      activeEscrows: await this.jobRepository.countJobsByStatus(JobStatus.ACTIVE),
+      completedEscrows: await this.jobRepository.countJobsByStatus(JobStatus.COMPLETED),
+      canceledEscrows: await this.jobRepository.countJobsByStatus(JobStatus.CANCELED),
       workersTotal: await this.assignmentRepository.countTotalWorkers(),
       assignmentsCompleted:
         await this.assignmentRepository.countCompletedAssignments(),


### PR DESCRIPTION
## Description
Extended stats.

## Summary of changes
Added the following properties to the response of /stats endpoint:
- completed_escrows
- active_escrows
- canceled_escrows
- workers_count*

* Was implemented before, and has the name: `workers_total`.


## How test the changes
`yarn test`
`GET /stats`

## Related issues
[Fortune Exchange Oracle] Extend stats #2235
