### PR TITLE
[Fortune Exchange Oracle | Reputation Oracle] Completed escrow webhook

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/constant/errors.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/constant/errors.ts
@@ -50,6 +50,7 @@ export enum ErrorJob {
   ManifestDecryptionFailed = 'Unable to decrypt manifest',
   ManifestNotFound = 'Unable to get manifest',
   NotFound = 'Job not found',
+  AlreadyCompleted = 'Job already completed',
   AlreadyCanceled = 'Job already canceled',
 }
 

--- a/packages/apps/fortune/exchange-oracle/server/src/common/enums/webhook.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/enums/webhook.ts
@@ -1,5 +1,6 @@
 export enum EventType {
   ESCROW_CREATED = 'escrow_created',
+  ESCROW_COMPLETED = 'escrow_completed',
   ESCROW_CANCELED = 'escrow_canceled',
   TASK_CREATION_FAILED = 'task_creation_failed',
   SUBMISSION_REJECTED = 'submission_rejected',

--- a/packages/apps/fortune/exchange-oracle/server/src/database/migrations/1720453476309-AddEscrowCompletedEventTypeToWebhookTable.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/database/migrations/1720453476309-AddEscrowCompletedEventTypeToWebhookTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddEscrowCompletedEventTypeToWebhookTable1720453476309 implements MigrationInterface {
+    name = 'AddEscrowCompletedEventTypeToWebhookTable1720453476309'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TYPE "hmt"."webhooks_event_type_enum"
+            RENAME TO "webhooks_event_type_enum_old"
+        `);
+        await queryRunner.query(`
+            CREATE TYPE "hmt"."webhooks_event_type_enum" AS ENUM(
+                'escrow_created',
+                'escrow_completed',
+                'escrow_canceled',
+                'task_creation_failed',
+                'submission_rejected',
+                'submission_in_review'
+            )
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "hmt"."webhooks"
+            ALTER COLUMN "event_type" TYPE "hmt"."webhooks_event_type_enum" USING "event_type"::"text"::"hmt"."webhooks_event_type_enum"
+        `);
+        await queryRunner.query(`
+            DROP TYPE "hmt"."webhooks_event_type_enum_old"
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TYPE "hmt"."webhooks_event_type_enum_old" AS ENUM(
+                'escrow_created',
+                'escrow_canceled',
+                'task_creation_failed',
+                'submission_rejected',
+                'submission_in_review'
+            )
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "hmt"."webhooks"
+            ALTER COLUMN "event_type" TYPE "hmt"."webhooks_event_type_enum_old" USING "event_type"::"text"::"hmt"."webhooks_event_type_enum_old"
+        `);
+        await queryRunner.query(`
+            DROP TYPE "hmt"."webhooks_event_type_enum"
+        `);
+        await queryRunner.query(`
+            ALTER TYPE "hmt"."webhooks_event_type_enum_old"
+            RENAME TO "webhooks_event_type_enum"
+        `);
+    }
+
+}

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.controller.ts
@@ -19,10 +19,21 @@ export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
   @Post()
+  @UseGuards(SignatureAuthGuard)
+  @AllowedRoles([
+    AuthSignatureRole.Recording,
+    AuthSignatureRole.Reputation,
+    AuthSignatureRole.JobLauncher,
+  ])
   @ApiOperation({
     summary: 'Handle Webhook Events',
     description:
       'Receives webhook events related to escrow and task operations.',
+  })
+  @ApiHeader({
+    name: HEADER_SIGNATURE_KEY,
+    description: 'Signature header for authenticating the webhook request.',
+    required: true,
   })
   @ApiBody({
     description:
@@ -46,7 +57,7 @@ export class WebhookController {
     description: 'Not Found. Could not find the requested content.',
   })
   public async processWebhook(
-    //@Headers(HEADER_SIGNATURE_KEY) _: string,
+    @Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() body: WebhookDto,
   ): Promise<void> {
     return this.webhookService.handleWebhook(body);

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.controller.ts
@@ -19,21 +19,10 @@ export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
   @Post()
-  @UseGuards(SignatureAuthGuard)
-  @AllowedRoles([
-    AuthSignatureRole.Recording,
-    AuthSignatureRole.Reputation,
-    AuthSignatureRole.JobLauncher,
-  ])
   @ApiOperation({
     summary: 'Handle Webhook Events',
     description:
       'Receives webhook events related to escrow and task operations.',
-  })
-  @ApiHeader({
-    name: HEADER_SIGNATURE_KEY,
-    description: 'Signature header for authenticating the webhook request.',
-    required: true,
   })
   @ApiBody({
     description:
@@ -57,7 +46,7 @@ export class WebhookController {
     description: 'Not Found. Could not find the requested content.',
   })
   public async processWebhook(
-    @Headers(HEADER_SIGNATURE_KEY) _: string,
+    //@Headers(HEADER_SIGNATURE_KEY) _: string,
     @Body() body: WebhookDto,
   ): Promise<void> {
     return this.webhookService.handleWebhook(body);

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.service.ts
@@ -42,6 +42,10 @@ export class WebhookService {
       case EventType.ESCROW_CREATED:
         await this.jobService.createJob(webhook);
         break;
+      
+      case EventType.ESCROW_COMPLETED:
+        await this.jobService.completeJob(webhook);
+        break;
 
       case EventType.ESCROW_CANCELED:
         await this.jobService.cancelJob(webhook);

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -37,6 +37,7 @@ jest.mock('@human-protocol/sdk', () => ({
     build: jest.fn().mockImplementation(() => ({
       createEscrow: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       getJobLauncherAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+      getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       setup: jest.fn().mockResolvedValue(null),
       fund: jest.fn().mockResolvedValue(null),

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -176,6 +176,12 @@ export class CronJobService {
                 await escrowClient.getJobLauncherAddress(escrowAddress),
               )
             ).webhookUrl,
+            (
+              await OperatorUtils.getLeader(
+                chainId,
+                await escrowClient.getExchangeOracleAddress(escrowAddress),
+              )
+            ).webhookUrl,
             // Temporarily disable sending webhook to Recording Oracle
             // (
             //   await OperatorUtils.getLeader(


### PR DESCRIPTION
## Description
Implemented completed webhook from Reputation Oracle to Exchange Oracle.

## Summary of changes
- Updated cron service in Reputation Oracle.
- Updated webhook service in Fortune.
- Added new event type in Fortune.

## How test the changes
**Reputation Oracle:**
1. Create web hook entity with `PAID` status.
2. It will automatically be called `processPaidWebhooks`. 

**Fortune Exchange Oracle:** 
`POST /webhook`
```json
{
  "chain_id": 80002,
  "escrow_address": "test_escrow_address",
  "event_type": "escrow_completed",
  "event_data": {}
}
```

## Related issues
[Fortune Exchange Oracle | Reputation Oracle] Completed escrow webhook
[#2234](https://github.com/humanprotocol/human-protocol/issues/2234)
