### PR TITLE
[Fortune Exchange Oracle] Added filters to GET /assignment

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.controller.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.controller.ts
@@ -28,8 +28,6 @@ import { PageDto } from '../../common/pagination/pagination.dto';
 
 @ApiTags('Assignment')
 @Controller('assignment')
-@UseGuards(JwtAuthGuard)
-@ApiBearerAuth()
 export class AssignmentController {
   constructor(private readonly assignmentService: AssignmentService) {}
 

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.dto.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@human-protocol/sdk';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsString, IsDate } from 'class-validator';
 import {
   AssignmentSortField,
   AssignmentStatus,
@@ -58,6 +58,18 @@ export class GetAssignmentsDto extends PageOptionsDto {
   @IsOptional()
   @IsString()
   assignmentId?: string;
+
+  @ApiPropertyOptional({ name: 'created_after' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  createdAfter?: Date;
+
+  @ApiPropertyOptional({ name: 'updated_after' })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  updatedAfter?: Date;
 }
 
 export class AssignmentDto {

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.interface.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.interface.ts
@@ -16,6 +16,8 @@ export interface AssignmentFilterData {
   workerAddress: string;
   reputationNetwork: string;
   jobType?: JobType;
+  createdAfter?: Date;
+  updatedAfter?: Date;
 }
 
 export interface ListResult {

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.repository.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.repository.ts
@@ -165,6 +165,18 @@ export class AssignmentRepository extends BaseRepository<AssignmentEntity> {
       });
     }
 
+    if (data.createdAfter) {
+      queryBuilder.andWhere('assignment.createdAt >= :createdAfter', {
+        createdAfter: data.createdAfter,
+      });
+    }
+
+    if (data.updatedAfter) {
+      queryBuilder.andWhere('assignment.updatedAt >= :updatedAfter', {
+        updatedAfter: data.updatedAfter,
+      });
+    }
+
     queryBuilder.andWhere('job.reputationNetwork = :reputationNetwork', {
       reputationNetwork: data.reputationNetwork,
     });


### PR DESCRIPTION
## Description
Added `created_after` and `updated_after` filters to `GET /assignment`

## Summary of changes
Added this 2 new [optional query parameters.](https://human-protocol.gitbook.io/hub/human-tech-docs/architecture/components/exchange-oracle/standard#get-jobs-assigned)

## How test the changes
`yarn test`

## Related issues
[Fortune Exchange Oracle] Add filters to GET /assignment
[#2263](https://github.com/humanprotocol/human-protocol/issues/2263)