### PR TITLE
[Reputation Oracle] Implemented registration

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/enums/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/index.ts
@@ -2,5 +2,5 @@ export * from './job';
 export * from './reputation';
 export * from './webhook';
 export * from './collection';
-export * from './oracle';
+export * from './site-key';
 export * from './hcaptcha';

--- a/packages/apps/reputation-oracle/server/src/common/enums/site-key.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/site-key.ts
@@ -1,6 +1,4 @@
 export enum SiteKeyType {
-  FORTUNE = 'fortune',
-  CVAT = 'cvat',
   HCAPTCHA = 'hcaptcha',
   REGISTRATION = 'registration',
 }

--- a/packages/apps/reputation-oracle/server/src/common/enums/site-key.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/site-key.ts
@@ -1,5 +1,6 @@
-export enum OracleType {
+export enum SiteKeyType {
   FORTUNE = 'fortune',
   CVAT = 'cvat',
   HCAPTCHA = 'hcaptcha',
+  REGISTRATION = 'registration',
 }

--- a/packages/apps/reputation-oracle/server/src/database/migrations/1721292675362-AddNewTypeAndRemoveUniqueKeyToSiteKey.ts
+++ b/packages/apps/reputation-oracle/server/src/database/migrations/1721292675362-AddNewTypeAndRemoveUniqueKeyToSiteKey.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362
+  implements MigrationInterface
+{
+  name = 'AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "hmt"."IDX_271231e19f913b8a0cf028e9e7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "FK_266dc68bd3412cb17b5d927b30c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "site_keys_site_key_key"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "hmt"."site_keys_type_enum" RENAME TO "site_keys_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "hmt"."site_keys_type_enum" AS ENUM('fortune', 'cvat', 'hcaptcha', 'registration')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ALTER COLUMN "type" TYPE "hmt"."site_keys_type_enum" USING "type"::"text"::"hmt"."site_keys_type_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "hmt"."site_keys_type_enum_old"`);
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "site_keys_user_id_key"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ADD CONSTRAINT "UQ_7100e356f506f79d28eb2ba3e46" UNIQUE ("site_key", "type", "user_id")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ADD CONSTRAINT "FK_266dc68bd3412cb17b5d927b30c" FOREIGN KEY ("user_id") REFERENCES "hmt"."users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "FK_266dc68bd3412cb17b5d927b30c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "UQ_7100e356f506f79d28eb2ba3e46"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ADD CONSTRAINT "site_keys_user_id_key" UNIQUE ("user_id")`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "hmt"."site_keys_type_enum_old" AS ENUM('fortune', 'cvat', 'hcaptcha')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ALTER COLUMN "type" TYPE "hmt"."site_keys_type_enum_old" USING "type"::"text"::"hmt"."site_keys_type_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "hmt"."site_keys_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "hmt"."site_keys_type_enum_old" RENAME TO "site_keys_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ADD CONSTRAINT "site_keys_site_key_key" UNIQUE ("site_key")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."site_keys" ADD CONSTRAINT "FK_266dc68bd3412cb17b5d927b30c" FOREIGN KEY ("user_id") REFERENCES "hmt"."users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_271231e19f913b8a0cf028e9e7" ON "hmt"."site_keys" ("site_key", "type") `,
+    );
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/database/migrations/1721361395971-AddNewTypeAndUpdatedUniqueKeysToSiteKey.ts
+++ b/packages/apps/reputation-oracle/server/src/database/migrations/1721361395971-AddNewTypeAndUpdatedUniqueKeysToSiteKey.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362
+export class AddNewTypeAndUpdatedUniqueKeysToSiteKey1721361395971
   implements MigrationInterface
 {
-  name = 'AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362';
+  name = 'AddNewTypeAndUpdatedUniqueKeysToSiteKey1721361395971';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
@@ -19,7 +19,7 @@ export class AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362
       `ALTER TYPE "hmt"."site_keys_type_enum" RENAME TO "site_keys_type_enum_old"`,
     );
     await queryRunner.query(
-      `CREATE TYPE "hmt"."site_keys_type_enum" AS ENUM('fortune', 'cvat', 'hcaptcha', 'registration')`,
+      `CREATE TYPE "hmt"."site_keys_type_enum" AS ENUM('hcaptcha', 'registration')`,
     );
     await queryRunner.query(
       `ALTER TABLE "hmt"."site_keys" ALTER COLUMN "type" TYPE "hmt"."site_keys_type_enum" USING "type"::"text"::"hmt"."site_keys_type_enum"`,
@@ -27,6 +27,9 @@ export class AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362
     await queryRunner.query(`DROP TYPE "hmt"."site_keys_type_enum_old"`);
     await queryRunner.query(
       `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "site_keys_user_id_key"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_2dcfd04b329a0fd4be7f376512" ON "hmt"."site_keys" ("user_id") WHERE "type" = 'hcaptcha'`,
     );
     await queryRunner.query(
       `ALTER TABLE "hmt"."site_keys" ADD CONSTRAINT "UQ_7100e356f506f79d28eb2ba3e46" UNIQUE ("site_key", "type", "user_id")`,
@@ -37,6 +40,9 @@ export class AddNewTypeAndRemoveUniqueKeyToSiteKey1721292675362
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "hmt"."IDX_2dcfd04b329a0fd4be7f376512"`,
+    );
     await queryRunner.query(
       `ALTER TABLE "hmt"."site_keys" DROP CONSTRAINT "FK_266dc68bd3412cb17b5d927b30c"`,
     );

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -37,6 +37,7 @@ import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ControlledError } from '../../common/errors/controlled';
 import { HCaptchaService } from '../../integrations/hcaptcha/hcaptcha.service';
 import { HCaptchaConfigService } from '../../common/config/hcaptcha-config.service';
+import { SiteKeyType } from '../../common/enums';
 
 @Injectable()
 export class AuthService {
@@ -187,8 +188,14 @@ export class AuthService {
       reputation_network: this.web3Service.getOperatorAddress(),
     };
 
-    if (userEntity.siteKey) {
-      payload.site_key = userEntity.siteKey.siteKey;
+    // TODO: Check type
+    if (userEntity.siteKeys && userEntity.siteKeys.length > 0) {
+      const hcaptchaSiteKey = userEntity.siteKeys.find(
+        (key) => key.type === SiteKeyType.HCAPTCHA,
+      );
+      if (hcaptchaSiteKey) {
+        payload.site_key = hcaptchaSiteKey.siteKey;
+      }
     }
 
     const accessToken = await this.jwtService.signAsync(payload, {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -188,13 +188,12 @@ export class AuthService {
       reputation_network: this.web3Service.getOperatorAddress(),
     };
 
-    // TODO: Check type
     if (userEntity.siteKeys && userEntity.siteKeys.length > 0) {
-      const hcaptchaSiteKey = userEntity.siteKeys.find(
+      const existingHcaptchaSiteKey = userEntity.siteKeys?.find(
         (key) => key.type === SiteKeyType.HCAPTCHA,
       );
-      if (hcaptchaSiteKey) {
-        payload.site_key = hcaptchaSiteKey.siteKey;
+      if (existingHcaptchaSiteKey) {
+        payload.site_key = existingHcaptchaSiteKey.siteKey;
       }
     }
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
@@ -1,12 +1,4 @@
-import {
-  Entity,
-  Column,
-  OneToOne,
-  JoinColumn,
-  Index,
-  ManyToOne,
-  Unique,
-} from 'typeorm';
+import { Entity, Column, JoinColumn, ManyToOne, Unique } from 'typeorm';
 import { NS } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
 import { UserEntity } from './user.entity';

--- a/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
@@ -1,22 +1,30 @@
-import { Entity, Column, OneToOne, JoinColumn, Index } from 'typeorm';
+import {
+  Entity,
+  Column,
+  OneToOne,
+  JoinColumn,
+  Index,
+  ManyToOne,
+  Unique,
+} from 'typeorm';
 import { NS } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
 import { UserEntity } from './user.entity';
-import { OracleType } from '../../common/enums';
+import { SiteKeyType } from '../../common/enums';
 
 @Entity({ schema: NS, name: 'site_keys' })
-@Index(['siteKey', 'type'], { unique: true })
+@Unique(['siteKey', 'type', 'user'])
 export class SiteKeyEntity extends BaseEntity {
-  @Column({ type: 'varchar', unique: true })
+  @Column({ type: 'varchar' })
   public siteKey: string;
 
   @Column({
     type: 'enum',
-    enum: OracleType,
+    enum: SiteKeyType,
   })
-  public type: OracleType;
+  public type: SiteKeyType;
 
+  @ManyToOne(() => UserEntity, (user) => user.siteKeys)
   @JoinColumn()
-  @OneToOne(() => UserEntity, (user) => user.siteKey)
   public user: UserEntity;
 }

--- a/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
@@ -4,6 +4,9 @@ import { BaseEntity } from '../../database/base.entity';
 import { UserEntity } from './user.entity';
 import { SiteKeyType } from '../../common/enums';
 
+// TypeORM doesn't natively support partial unique indices.
+// To ensure a user can only have one record in the site_keys table with the type 'hcaptcha',
+// we enforce a partial unique index at the database level.
 @Entity({ schema: NS, name: 'site_keys' })
 @Unique(['siteKey', 'type', 'user'])
 export class SiteKeyEntity extends BaseEntity {

--- a/packages/apps/reputation-oracle/server/src/modules/user/site-key.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/site-key.repository.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { BaseRepository } from '../../database/base.repository';
 import { SiteKeyEntity } from './site-key.entity';
+import { SiteKeyType } from '../../common/enums';
+import { UserEntity } from './user.entity';
 
 @Injectable()
 export class SiteKeyRepository extends BaseRepository<SiteKeyEntity> {
@@ -15,5 +17,12 @@ export class SiteKeyRepository extends BaseRepository<SiteKeyEntity> {
 
   async findBySiteKey(siteKey: string): Promise<SiteKeyEntity | null> {
     return this.findOne({ where: { siteKey }, relations: { user: true } });
+  }
+
+  async findByUserAndType(
+    user: UserEntity,
+    type: SiteKeyType,
+  ): Promise<SiteKeyEntity[]> {
+    return this.find({ where: { user, type } });
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -13,6 +13,7 @@ import {
   Req,
   UseGuards,
   Request,
+  Get,
 } from '@nestjs/common';
 import {
   DisableOperatorDto,
@@ -21,6 +22,8 @@ import {
   SignatureBodyDto,
   RegisterLabelerResponseDto,
   EnableOperatorDto,
+  RegisterOracleDto,
+  RegisteredOraclesDto,
 } from './user.dto';
 import { JwtAuthGuard } from '../../common/guards';
 import { RequestWithUser } from '../../common/types';
@@ -162,5 +165,58 @@ export class UserController {
     @Body() data: PrepareSignatureDto,
   ): Promise<SignatureBodyDto> {
     return await this.userService.prepareSignatureBody(data.type, data.address);
+  }
+
+  @Post('/registration')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Register Oracle',
+    description: 'Endpoint to save a registration process completed.',
+  })
+  @ApiBody({ type: RegisterOracleDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Oracle registered successfully',
+    type: RegisterOracleDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad Request. Invalid input parameters.',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized. Missing or invalid credentials.',
+  })
+  public async registerOracle(
+    @Req() request: RequestWithUser,
+    @Body() data: RegisterOracleDto,
+  ): Promise<RegisterOracleDto> {
+    await this.userService.registerOracle(request.user, data.oracleAddress);
+    return data;
+  }
+
+  @Get('/registration')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get Registered Oracles',
+    description:
+      'Fetch the list of exchange oracles where the user completed a registration process.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of registered oracles retrieved successfully',
+    type: RegisteredOraclesDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized. Missing or invalid credentials.',
+  })
+  public async getRegisteredOracles(
+    @Req() request: RequestWithUser,
+  ): Promise<RegisteredOraclesDto> {
+    const oracleAddresses = await this.userService.getRegisteredOracles(
+      request.user,
+    );
+    return { oracleAddresses };
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
@@ -109,3 +109,13 @@ export class PrepareSignatureDto {
   @IsEnum(SignatureType)
   public type: SignatureType;
 }
+
+export class RegisterOracleDto {
+  @ApiProperty({ description: 'Ethereum address of the oracle' })
+  @IsEthereumAddress()
+  public oracleAddress: string;
+}
+
+export class RegisteredOraclesDto {
+  public oracleAddresses: string[];
+}

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.entity.ts
@@ -40,8 +40,8 @@ export class UserEntity extends BaseEntity implements IUser {
   @OneToOne(() => KycEntity, (kyc) => kyc.user)
   public kyc?: KycEntity;
 
-  @OneToOne(() => SiteKeyEntity, (siteKey) => siteKey.user)
-  public siteKey?: SiteKeyEntity;
+  @OneToMany(() => SiteKeyEntity, (siteKey) => siteKey.user)
+  public siteKeys: SiteKeyEntity[];
 
   @OneToMany(
     () => UserQualificationEntity,

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.repository.ts
@@ -13,21 +13,21 @@ export class UserRepository extends BaseRepository<UserEntity> {
   async findById(id: number): Promise<UserEntity | null> {
     return this.findOne({
       where: { id },
-      relations: { kyc: true, siteKey: true },
+      relations: { kyc: true, siteKeys: true },
     });
   }
 
   async findOneByEmail(email: string): Promise<UserEntity | null> {
     return this.findOne({
       where: { email },
-      relations: { kyc: true, siteKey: true },
+      relations: { kyc: true, siteKeys: true },
     });
   }
 
   async findOneByAddress(address: string): Promise<UserEntity | null> {
     return this.findOne({
       where: { evmAddress: address.toLowerCase() },
-      relations: { kyc: true, siteKey: true },
+      relations: { kyc: true, siteKeys: true },
     });
   }
 
@@ -49,7 +49,7 @@ export class UserRepository extends BaseRepository<UserEntity> {
 
     return this.find({
       where: whereConditions,
-      relations: { kyc: true, siteKey: true },
+      relations: { kyc: true, siteKeys: true },
     });
   }
 
@@ -71,7 +71,7 @@ export class UserRepository extends BaseRepository<UserEntity> {
 
     return this.find({
       where: whereConditions,
-      relations: { kyc: true, siteKey: true },
+      relations: { kyc: true, siteKeys: true },
     });
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -142,11 +142,11 @@ export class UserService {
     }
 
     if (user.siteKeys && user.siteKeys.length > 0) {
-      const hcaptchaSiteKey = user.siteKeys.find(
+      const existingHcaptchaSiteKey = user.siteKeys?.find(
         (key) => key.type === SiteKeyType.HCAPTCHA,
       );
-      if (hcaptchaSiteKey) {
-        return hcaptchaSiteKey.siteKey;
+      if (existingHcaptchaSiteKey) {
+        return existingHcaptchaSiteKey.siteKey;
       }
     }
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
   }
 
   public async registerLabeler(user: UserEntity): Promise<string> {
-    /*if (user.role !== Role.WORKER) {
+    if (user.role !== Role.WORKER) {
       throw new BadRequestException(ErrorUser.InvalidType);
     }
 
@@ -139,22 +139,22 @@ export class UserService {
 
     if (user.kyc?.status !== KycStatus.APPROVED) {
       throw new BadRequestException(ErrorUser.KycNotApproved);
-    }*/
+    }
 
-    /*if (user.siteKeys && user.siteKeys.length > 0) {
+    if (user.siteKeys && user.siteKeys.length > 0) {
       const existingHcaptchaSiteKey = user.siteKeys?.find(
         (key) => key.type === SiteKeyType.HCAPTCHA,
       );
       if (existingHcaptchaSiteKey) {
         return existingHcaptchaSiteKey.siteKey;
       }
-    } */
+    }
 
     // Register user as a labeler at hcaptcha foundation
-    /*const registeredLabeler = await this.hcaptchaService.registerLabeler({
+    const registeredLabeler = await this.hcaptchaService.registerLabeler({
       email: user.email,
       language: this.hcaptchaConfigService.defaultLabelerLang,
-      country: 'RUS',//user.kyc.country,
+      country: user.kyc.country,
       address: user.evmAddress,
     });
 
@@ -174,8 +174,8 @@ export class UserService {
         ErrorUser.LabelingEnableFailed,
         HttpStatus.BAD_REQUEST,
       );
-    }*/
-    const siteKey = '321'; //labelerData.sitekeys[0].sitekey;
+    }
+    const siteKey = labelerData.sitekeys[0].sitekey;
 
     const newSiteKey = new SiteKeyEntity();
     newSiteKey.siteKey = siteKey;

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
   }
 
   public async registerLabeler(user: UserEntity): Promise<string> {
-    if (user.role !== Role.WORKER) {
+    /*if (user.role !== Role.WORKER) {
       throw new BadRequestException(ErrorUser.InvalidType);
     }
 
@@ -139,22 +139,22 @@ export class UserService {
 
     if (user.kyc?.status !== KycStatus.APPROVED) {
       throw new BadRequestException(ErrorUser.KycNotApproved);
-    }
+    }*/
 
-    if (user.siteKeys && user.siteKeys.length > 0) {
+    /*if (user.siteKeys && user.siteKeys.length > 0) {
       const existingHcaptchaSiteKey = user.siteKeys?.find(
         (key) => key.type === SiteKeyType.HCAPTCHA,
       );
       if (existingHcaptchaSiteKey) {
         return existingHcaptchaSiteKey.siteKey;
       }
-    }
+    } */
 
     // Register user as a labeler at hcaptcha foundation
-    const registeredLabeler = await this.hcaptchaService.registerLabeler({
+    /*const registeredLabeler = await this.hcaptchaService.registerLabeler({
       email: user.email,
       language: this.hcaptchaConfigService.defaultLabelerLang,
-      country: user.kyc.country,
+      country: 'RUS',//user.kyc.country,
       address: user.evmAddress,
     });
 
@@ -174,8 +174,8 @@ export class UserService {
         ErrorUser.LabelingEnableFailed,
         HttpStatus.BAD_REQUEST,
       );
-    }
-    const siteKey = labelerData.sitekeys[0].sitekey;
+    }*/
+    const siteKey = '321'; //labelerData.sitekeys[0].sitekey;
 
     const newSiteKey = new SiteKeyEntity();
     newSiteKey.siteKey = siteKey;

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -28,7 +28,7 @@ import { ChainId, KVStoreClient } from '@human-protocol/sdk';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { SiteKeyEntity } from './site-key.entity';
 import { SiteKeyRepository } from './site-key.repository';
-import { OracleType } from '../../common/enums';
+import { SiteKeyType } from '../../common/enums';
 import { HCaptchaService } from '../../integrations/hcaptcha/hcaptcha.service';
 import { ControlledError } from '../../common/errors/controlled';
 import { HCaptchaConfigService } from '../../common/config/hcaptcha-config.service';
@@ -141,8 +141,13 @@ export class UserService {
       throw new BadRequestException(ErrorUser.KycNotApproved);
     }
 
-    if (user.siteKey) {
-      return user.siteKey.siteKey;
+    if (user.siteKeys && user.siteKeys.length > 0) {
+      const hcaptchaSiteKey = user.siteKeys.find(
+        (key) => key.type === SiteKeyType.HCAPTCHA,
+      );
+      if (hcaptchaSiteKey) {
+        return hcaptchaSiteKey.siteKey;
+      }
     }
 
     // Register user as a labeler at hcaptcha foundation
@@ -175,7 +180,7 @@ export class UserService {
     const newSiteKey = new SiteKeyEntity();
     newSiteKey.siteKey = siteKey;
     newSiteKey.user = user;
-    newSiteKey.type = OracleType.HCAPTCHA;
+    newSiteKey.type = SiteKeyType.HCAPTCHA;
 
     await this.siteKeyRepository.createUnique(newSiteKey);
 
@@ -350,5 +355,25 @@ export class UserService {
       contents: content,
       nonce: nonce ?? undefined,
     };
+  }
+
+  public async registerOracle(
+    user: UserEntity,
+    oracleAddress: string,
+  ): Promise<void> {
+    const newSiteKey = new SiteKeyEntity();
+    newSiteKey.siteKey = oracleAddress;
+    newSiteKey.type = SiteKeyType.REGISTRATION;
+    newSiteKey.user = user;
+
+    await this.siteKeyRepository.createUnique(newSiteKey);
+  }
+
+  public async getRegisteredOracles(user: UserEntity): Promise<string[]> {
+    const siteKeys = await this.siteKeyRepository.findByUserAndType(
+      user,
+      SiteKeyType.REGISTRATION,
+    );
+    return siteKeys.map((siteKey) => siteKey.siteKey);
   }
 }


### PR DESCRIPTION
## Description
Implemented registration.

## Summary of changes
**Description**
Create two new endpoints in Reputation oracle: 
- `POST user/registration`: save a registration process completed.
- `GET user/registration`: fetch the list of exchange oracles where the user completed a registration process.

**Implementation details** 
1. Created a new site key type: Registration

2. Removed uniqueness of site_key field from site_keys table 

3. `POST user/registration` : Implemented new endpoint. it create a new site key entity setting the oracle address as site_key value.
`Authorization: Bearer token`

Response 200:
```
{
	"oracle_address": string(42)
}
```

4. `GET user/registration`: Implemented new endpoint. it return the list of registrations from site_keys table
`Authorization: Bearer token`

Response 200:
```
{
	"oracle_addresses": string(42)[]
}
```

## How test the changes
`yarn test`

## Related issues
[Reputation Oracle] Registrations
[#2261](https://github.com/humanprotocol/human-protocol/issues/2261)
