### PR TITLE
[Dashboard][Server] `hash` is replaced with `txHash` in `TransactionPaginationDto`

### DIFF
--- a/packages/apps/dashboard/server/src/modules/details/dto/transaction.dto.ts
+++ b/packages/apps/dashboard/server/src/modules/details/dto/transaction.dto.ts
@@ -15,7 +15,7 @@ export class TransactionPaginationDto {
   })
   @IsString()
   @Expose()
-  public hash: string;
+  public txHash: string;
 
   @ApiProperty({ example: '0xad1F7e45D83624A0c628F1B03477c6E129EddB78' })
   @IsString()


### PR DESCRIPTION
## Description

hash` is replaced with `txHash` in `TransactionPaginationDto`

## Summary of changes

hash` is replaced with `txHash` in `TransactionPaginationDto` to allow automapping due to the fact that SDK method `.getTransactions()` returns `txHash`
