### PR TITLE
[Job Launcher] Fixed swagger dto for `/job/cvat`

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -129,6 +129,22 @@ export class CvatDataDto {
   public boxes?: StorageDataDto;
 }
 
+export class Label {
+  @ApiProperty()
+  @IsString()
+  public name: string;
+
+  @ApiPropertyOptional()
+  @IsArray()
+  @IsOptional()
+  public nodes?: string[];
+
+  @ApiPropertyOptional()
+  @IsArray()
+  @IsOptional()
+  public joints?: string[];
+}
+
 export class JobCvatDto extends JobDto {
   @ApiProperty({ name: 'requester_description' })
   @IsString()
@@ -138,7 +154,7 @@ export class JobCvatDto extends JobDto {
   @IsObject()
   public data: CvatDataDto;
 
-  @ApiProperty()
+  @ApiProperty({ type: [Label] })
   @IsArray()
   @ArrayMinSize(1)
   public labels: Label[];
@@ -374,22 +390,6 @@ export class CvatData {
   @IsUrl()
   @IsOptional()
   public boxes_url?: string;
-}
-
-export class Label {
-  @ApiProperty()
-  @IsString()
-  public name: string;
-
-  @ApiPropertyOptional()
-  @IsArray()
-  @IsOptional()
-  public nodes?: string[];
-
-  @ApiPropertyOptional()
-  @IsArray()
-  @IsOptional()
-  public joints?: string[];
 }
 
 export class Annotation {


### PR DESCRIPTION
## Description
Fixed swagger dto for `/job/cvat`.

## Summary of changes
Updated:
```
@ApiProperty({ type: [Label] })
@IsArray()
@ArrayMinSize(1)
public labels: Label[];
```

```
"labels": [
      {
        "name": "label1"
      },
      {
        "name": "label2"
      }
    ],
```

## How test the changes
`POST /job/cvat`

## Related issues
[Job Launcher] Fix swagger dto for /job/cvat
[#2327](https://github.com/humanprotocol/human-protocol/issues/2327)