### PR TITLE
[Dashboard][Server] Added `/stats/general` endpoint for retrieving HMT general stats

### DIFF
--- a/packages/apps/dashboard/server/src/common/config/redis-config.service.ts
+++ b/packages/apps/dashboard/server/src/common/config/redis-config.service.ts
@@ -6,6 +6,7 @@ const DEFAULT_REDIS_PORT = 6379;
 const DEFAULT_CACHE_HMT_PRICE_TTL = 60;
 const DEFAULT_CACHE_HMT_GENERAL_STATS_TTL = 2 * 60;
 const DEFAULT_HMT_PRICE_CACHE_KEY = 'hmt-price';
+const DEFAULT_HMT_GENERAL_STATS_CACHE_KEY = 'hmt-general';
 export const HCAPTCHA_PREFIX = 'hcaptcha-';
 
 @Injectable()
@@ -33,6 +34,12 @@ export class RedisConfigService {
     return this.configService.get<string>(
       'HMT_PRICE_CACHE_KEY',
       DEFAULT_HMT_PRICE_CACHE_KEY,
+    );
+  }
+  get hmtGeneralStatsCacheKey(): string {
+    return this.configService.get<string>(
+      'HMT_GENERAL_STATS_CACHE_KEY',
+      DEFAULT_HMT_GENERAL_STATS_CACHE_KEY,
     );
   }
 }

--- a/packages/apps/dashboard/server/src/modules/stats/dto/hmt-general-stats.dto.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/dto/hmt-general-stats.dto.ts
@@ -1,0 +1,12 @@
+import { IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class HmtGeneralStatsDto {
+  @ApiProperty({ example: 10000 })
+  @IsNumber()
+  public totalHolders: number;
+
+  @ApiProperty({ example: 10000 })
+  @IsNumber()
+  public totalTransactions: number;
+}

--- a/packages/apps/dashboard/server/src/modules/stats/stats.controller.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/stats.controller.ts
@@ -8,6 +8,7 @@ import {
   HcaptchaStats,
 } from './dto/hcaptcha.dto';
 import { DateValidationPipe } from '../../common/pipes/date-validation.pipe';
+import { HmtGeneralStatsDto } from './dto/hmt-general-stats.dto';
 
 @ApiTags('Stats')
 @Controller('/stats')
@@ -76,5 +77,22 @@ export class StatsController {
     const result: HcaptchaStats =
       await this.statsService.hCaptchaGeneralStats();
     return result;
+  }
+
+  @Get('/general')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get HMT general stats',
+    description: 'Endpoint to return HMT general stats.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'General stats retrieved successfully',
+    type: HmtGeneralStatsDto,
+  })
+  public async hmtGeneral(): Promise<HmtGeneralStatsDto> {
+    const results: HmtGeneralStatsDto =
+      await this.statsService.hmtGeneralStats();
+    return results;
   }
 }

--- a/packages/apps/dashboard/server/src/modules/stats/utils/constants.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/utils/constants.ts
@@ -1,0 +1,10 @@
+export const MainnetsId = {
+  MAINNET: 1,
+  SEPOLIA: 11155111,
+  BSC_MAINNET: 56,
+  POLYGON: 137,
+  MOONBEAM: 1284,
+  AVALANCHE: 43114,
+  CELO: 42220,
+  XLAYER: 196,
+};


### PR DESCRIPTION
## Description

Added `/stats/general` endpoint for retrieving HMT general stats

## Summary of changes

1. Added `/stats/general` endpoint for retrieving HMT general stats
2. Added cron job which will run every 15 minutes to update stats

