### PR TITLE
do not change status of canceled escrows

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -378,7 +378,12 @@ export class CronJobService {
         const key = `${event.chainId}-${ethers.getAddress(event.escrowAddress)}`;
         const job = jobMap.get(key);
 
-        if (!job || job.status === JobStatus.TO_CANCEL) continue;
+        if (
+          !job ||
+          job.status === JobStatus.TO_CANCEL ||
+          job.status === JobStatus.CANCELED
+        )
+          continue;
 
         let newStatus: JobStatus | null = null;
         if (


### PR DESCRIPTION
## Description
Some escrows have PARTIAL status in database while in the blockcahin the status is CANCELED. 
This error might happen bacause the subgraph has not indexed it yet so the status is still PARTIAL in subgraph when the update status cron job is run.

## Summary of changes
Add a condition to don't update CANCELED jobs