### PR TITLE
[Human App] Fixed `yarn build`

### DIFF
--- a/packages/apps/human-app/frontend/vite.config.mjs
+++ b/packages/apps/human-app/frontend/vite.config.mjs
@@ -22,8 +22,14 @@ const config = defineConfig({
     includeSource: ['./src/**/*.{ts,tsx}'],
     setupFiles: ['./src/setup-tests.ts/'],
   },
+  optimizeDeps: {
+    include: ['@human-protocol/sdk'],
+  },
   build: {
     target: 'esnext',
+    commonjsOptions: {
+      include: [/human-protocol-sdk/, /node_modules/],
+    },
   },
   server: {
     host: '127.0.0.1',


### PR DESCRIPTION
## Description
Fixed `yarn build`.
```
error during build:
src/smart-contracts/contracts.ts (4:18): "NETWORKS" is not exported by "../../../sdk/typescript/human-protocol-sdk/dist/index.js", imported by "src/smart-contracts/contracts.ts".
```

## Summary of changes
Updated vite config:
```
  optimizeDeps: {
    include: ['@human-protocol/sdk'],
  },
  build: {
    target: 'esnext',
    commonjsOptions: {
      include: [/human-protocol-sdk/, /node_modules/],
    },
  },
```

## How test the changes
`yarn install` 
`yarn build`

## Related issues
[Human App] Fix yarn build
[#2374](https://github.com/humanprotocol/human-protocol/issues/2374)
[HUMAN App] Import contract addresses from sdk #2339
