### PR TITLE
[Reputation Oracle] Fixed nullable `expiresAt` bugs

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -148,4 +148,5 @@ export enum ErrorQualification {
   NotFound = 'Qualification not found',
   NoWorkersFound = 'No workers found for the provided addresses or emails',
   AddressesOrEmailsMustBeProvided = 'Either addresses or emails must be provided',
+  CannotDeleteAssignedQualification = 'Cannot delete qualification because it is assigned to users',
 }

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.controller.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.controller.spec.ts
@@ -62,6 +62,31 @@ describe('QualificationController', () => {
         createQualificationDto,
       );
     });
+
+    it('should create a qualification without expiresAt', async () => {
+      const createQualificationDto: CreateQualificationDto = {
+        reference: 'test-ref',
+        title: 'Test Title',
+        description: 'Test Description',
+      };
+      const result: QualificationDto = {
+        reference: 'test-ref',
+        title: 'Test Title',
+        description: 'Test Description',
+        expiresAt: null,
+      };
+
+      jest
+        .spyOn(qualificationService, 'createQualification')
+        .mockResolvedValue(result);
+
+      expect(await qualificationController.create(createQualificationDto)).toBe(
+        result,
+      );
+      expect(qualificationService.createQualification).toHaveBeenCalledWith(
+        createQualificationDto,
+      );
+    });
   });
 
   describe('getQualifications', () => {

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BaseRepository } from '../../database/base.repository';
-import { DataSource, In, MoreThan } from 'typeorm';
+import { DataSource, In, IsNull, MoreThan } from 'typeorm';
 import { QualificationEntity } from './qualification.entity';
 import { UserEntity } from '../user/user.entity';
 import { UserQualificationEntity } from './user-qualification.entity';
@@ -18,17 +18,24 @@ export class QualificationRepository extends BaseRepository<QualificationEntity>
   ): Promise<QualificationEntity | null> {
     const currentDate = new Date();
 
-    const qualificationEntity = this.findOne({
-      where: { reference, expiresAt: MoreThan(currentDate) },
+    const qualificationEntity = await this.findOne({
+      where: [
+        { reference, expiresAt: MoreThan(currentDate) },
+        { reference, expiresAt: IsNull() },
+      ],
       relations: ['userQualifications', 'userQualifications.user'],
     });
+
     return qualificationEntity;
   }
 
   async getQualifications(): Promise<QualificationEntity[]> {
     const currentDate = new Date();
 
-    return this.findBy({ expiresAt: MoreThan(currentDate) });
+    return this.findBy([
+      { expiresAt: MoreThan(currentDate) },
+      { expiresAt: IsNull() },
+    ]);
   }
 
   async saveUserQualifications(

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.ts
@@ -95,6 +95,13 @@ export class QualificationService {
       );
     }
 
+    if (qualificationEntity.userQualifications.length > 0) {
+      throw new ControlledError(
+        ErrorQualification.CannotDeleteAssignedQualification,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     return this.qualificationRepository.deleteOne(qualificationEntity);
   }
 


### PR DESCRIPTION
## Description
Fixed nullable `expiresAt` bugs

## Summary of changes
- [x] Should include in the list the qualifications without expiration date.
- [x] Should allow to assing a qualification without expiration date.
- [x] Should allow to delete a qualification assigned without expiration date.
- [x] Should allow to delete a qualification without expiration date.

## How test the changes
`yarn test`

## Related issues
[Reputation Oracle] Qualifications bugs
[#2361](https://github.com/humanprotocol/human-protocol/issues/2361)