### PR TITLE
[Subgraph][SDK] Add registration data to leaders entity

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -368,3 +368,4 @@ class KVStoreKeys(Enum):
     url = "url"
     job_types = "job_types"
     registration_needed = "registration_needed"
+    registration_instructions = "registration_instructions"

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/operator.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/operator.py
@@ -19,8 +19,10 @@ fragment LeaderFields on Leader {
     fee
     publicKey
     webhookUrl
-    url,
+    url
     jobTypes
+    registrationNeeded
+    registrationInstructions
 }
 """
 

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/operator/operator_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/operator/operator_utils.py
@@ -80,6 +80,8 @@ class LeaderData:
         webhook_url: Optional[str] = None,
         url: Optional[str] = None,
         job_types: Optional[List[str]] = None,
+        registration_needed: Optional[bool] = None,
+        registration_instructions: Optional[str] = None,
     ):
         """
         Initializes an LeaderData instance.
@@ -122,6 +124,8 @@ class LeaderData:
         self.webhook_url = webhook_url
         self.url = url
         self.job_types = job_types
+        self.registration_needed = registration_needed
+        self.registration_instructions = registration_instructions
 
 
 class RewardData:
@@ -242,6 +246,10 @@ class OperatorUtils:
                             else []
                         )
                     ),
+                    registration_needed=leader.get("registrationNeeded", None),
+                    registration_instructions=leader.get(
+                        "registrationInstructions", None
+                    ),
                 )
                 for leader in leaders_raw
             ]
@@ -326,6 +334,8 @@ class OperatorUtils:
                     else []
                 )
             ),
+            registration_needed=leader.get("registrationNeeded", None),
+            registration_instructions=leader.get("registrationInstructions", None),
         )
 
     @staticmethod

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/operator/test_operator_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/operator/test_operator_utils.py
@@ -42,6 +42,8 @@ class TestOperatorUtils(unittest.TestCase):
                                 "webhookUrl": None,
                                 "url": None,
                                 "jobTypes": "type1,type2",
+                                "registrationNeeded": True,
+                                "registrationInstructions": "www.google.com",
                             }
                         ],
                     }
@@ -74,6 +76,8 @@ class TestOperatorUtils(unittest.TestCase):
             self.assertEqual(leaders[0].webhook_url, None)
             self.assertEqual(leaders[0].url, None)
             self.assertEqual(leaders[0].job_types, ["type1", "type2"])
+            self.assertEqual(leaders[0].registration_needed, True)
+            self.assertEqual(leaders[0].registration_instructions, "www.google.com")
 
     def test_get_leaders_when_job_types_is_none(self):
         filter = LeaderFilter(chain_id=ChainId.POLYGON, role="role")
@@ -135,6 +139,8 @@ class TestOperatorUtils(unittest.TestCase):
             self.assertEqual(leaders[0].public_key, None)
             self.assertEqual(leaders[0].webhook_url, None)
             self.assertEqual(leaders[0].url, None)
+            self.assertEqual(leaders[0].registration_needed, None)
+            self.assertEqual(leaders[0].registration_instructions, None)
             # Should rerutn empty array
             self.assertEqual(leaders[0].job_types, [])
 
@@ -256,6 +262,8 @@ class TestOperatorUtils(unittest.TestCase):
                             "webhookUrl": None,
                             "url": None,
                             "jobTypes": "type1,type2",
+                            "registrationNeeded": True,
+                            "registrationInstructions": "www.google.com",
                         }
                     }
                 }
@@ -287,6 +295,8 @@ class TestOperatorUtils(unittest.TestCase):
             self.assertEqual(leader.webhook_url, None)
             self.assertEqual(leader.url, None)
             self.assertEqual(leader.job_types, ["type1", "type2"])
+            self.assertEqual(leader.registration_needed, True)
+            self.assertEqual(leader.registration_instructions, "www.google.com")
 
     def test_get_leader_when_job_types_is_none(self):
         staker_address = "0x1234567890123456789012345678901234567891"
@@ -348,6 +358,8 @@ class TestOperatorUtils(unittest.TestCase):
             self.assertEqual(leader.webhook_url, None)
             self.assertEqual(leader.url, None)
             self.assertEqual(leader.job_types, [])
+            self.assertEqual(leader.registration_needed, None)
+            self.assertEqual(leader.registration_instructions, None)
 
     def test_get_leader_when_job_types_is_array(self):
         staker_address = "0x1234567890123456789012345678901234567891"

--- a/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
@@ -350,6 +350,7 @@ export const KVStoreKeys = {
   url: 'url',
   jobTypes: 'job_types',
   registrationNeeded: 'registration_needed',
+  registrationInstructions: 'registration_instructions',
 };
 
 export const Role = {

--- a/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/operator.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/operator.ts
@@ -20,6 +20,8 @@ const LEADER_FRAGMENT = gql`
     webhookUrl
     url
     jobTypes
+    registrationNeeded
+    registrationInstructions
   }
 `;
 

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -33,6 +33,8 @@ export interface ILeader {
   webhookUrl?: string;
   url?: string;
   jobTypes?: string[];
+  registrationNeeded?: boolean;
+  registrationInstructions?: string;
 }
 
 export interface ILeaderSubgraph extends Omit<ILeader, 'jobTypes'> {

--- a/packages/sdk/typescript/human-protocol-sdk/test/operator.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/operator.test.ts
@@ -48,6 +48,8 @@ describe('OperatorUtils', () => {
       reward: ethers.parseEther('25'),
       amountJobsProcessed: ethers.parseEther('25'),
       jobTypes: 'type1,type2',
+      registrationNeeded: true,
+      registrationInstructions: 'www.google.com',
     };
 
     const mockLeader: ILeader = {
@@ -182,6 +184,8 @@ describe('OperatorUtils', () => {
       reward: ethers.parseEther('25'),
       amountJobsProcessed: ethers.parseEther('25'),
       jobTypes: 'type1,type2',
+      registrationNeeded: true,
+      registrationInstructions: 'www.google.com',
     };
 
     const mockLeader: ILeader = {

--- a/packages/sdk/typescript/subgraph/schema.graphql
+++ b/packages/sdk/typescript/subgraph/schema.graphql
@@ -50,6 +50,8 @@ type Leader @entity {
   url: String
   urls: [LeaderURL!]! @derivedFrom(field: "leader")
   reputationNetwork: ReputationNetwork
+  registrationNeeded: Boolean
+  registrationInstructions: String
 }
 
 type LeaderURL @entity {

--- a/packages/sdk/typescript/subgraph/src/mapping/KVStore.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/KVStore.ts
@@ -108,6 +108,10 @@ export function handleDataSaved(event: DataSaved): void {
       operator.reputationNetwork = null;
     }
     operator.save();
+  } else if (key == 'registration_needed') {
+    leader.registrationNeeded = event.params.value === 'true';
+  } else if (key == 'registration_instructions') {
+    leader.registrationInstructions = event.params.value;
   }
 
   if (key.indexOf('url') > -1) {

--- a/packages/sdk/typescript/subgraph/tests/kvstore/kvstore.test.ts
+++ b/packages/sdk/typescript/subgraph/tests/kvstore/kvstore.test.ts
@@ -462,4 +462,68 @@ describe('KVStore', () => {
       'Job Launcher'
     );
   });
+
+  test("Should properly update leader's registration needed", () => {
+    const data1 = createDataSavedEvent(
+      '0xD979105297fB0eee83F7433fC09279cb5B94fFC6',
+      'registration_needed',
+      'true',
+      BigInt.fromI32(10)
+    );
+    const data2 = createDataSavedEvent(
+      '0x92a2eEF7Ff696BCef98957a0189872680600a959',
+      'registration_needed',
+      'false',
+      BigInt.fromI32(11)
+    );
+
+    handleDataSaved(data1);
+    handleDataSaved(data2);
+
+    assert.fieldEquals(
+      'Leader',
+      data1.params.sender.toHex(),
+      'registrationNeeded',
+      'true'
+    );
+
+    assert.fieldEquals(
+      'Leader',
+      data2.params.sender.toHex(),
+      'registrationNeeded',
+      'false'
+    );
+  });
+
+  test("Should properly update leader's registration instructions", () => {
+    const data1 = createDataSavedEvent(
+      '0xD979105297fB0eee83F7433fC09279cb5B94fFC6',
+      'registration_instructions',
+      'https://validator.example.com',
+      BigInt.fromI32(10)
+    );
+    const data2 = createDataSavedEvent(
+      '0x92a2eEF7Ff696BCef98957a0189872680600a959',
+      'registration_instructions',
+      'https://validator.example.com',
+      BigInt.fromI32(11)
+    );
+
+    handleDataSaved(data1);
+    handleDataSaved(data2);
+
+    assert.fieldEquals(
+      'Leader',
+      data1.params.sender.toHex(),
+      'registrationInstructions',
+      'https://validator.example.com'
+    );
+
+    assert.fieldEquals(
+      'Leader',
+      data2.params.sender.toHex(),
+      'registrationInstructions',
+      'https://validator.example.com'
+    );
+  });
 });


### PR DESCRIPTION
## Description

Add information about registration in exchange oracle/annotation tool to the leader entity

## Summary of changes

1. Add two new properties to the entity:
- registrationNeeded: boolean based on value of the kvstore for the key registration_needed
- registrationInstructions: value of the kvstore for the key registration_instructions
2. Update SDK get leaders and get reputation network

## How test the changes

`yarn test` in Typescript
`make run-test` in python

## Related issues
#2410