### PR TITLE
[HUMAN App] Show escrow stats in operator profile

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/operator/get-stats.ts
+++ b/packages/apps/human-app/frontend/src/api/services/operator/get-stats.ts
@@ -9,6 +9,9 @@ const operatorStatsSuccessResponseSchema = z.object({
   assignments_completed: z.number(),
   assignments_expired: z.number(),
   assignments_rejected: z.number(),
+  escrows_processed: z.number(),
+  escrows_active: z.number(),
+  escrows_cancelled: z.number(),
 });
 
 export type OperatorStatsSuccessResponse = z.infer<
@@ -20,6 +23,9 @@ const failedResponse = {
   assignments_completed: '-',
   assignments_expired: '-',
   assignments_rejected: '-',
+  escrows_processed: '-',
+  escrows_active: '-',
+  escrows_cancelled: '-',
 };
 
 export function useGetOperatorStats() {

--- a/packages/apps/human-app/frontend/src/pages/operator/profile/profile.page.tsx
+++ b/packages/apps/human-app/frontend/src/pages/operator/profile/profile.page.tsx
@@ -194,15 +194,15 @@ export function OperatorProfilePage() {
             <List>
               <ProfileListItem
                 header={t('operator.profile.statistics.escrowsProcessed')}
-                paragraph="-"
+                paragraph={statsData.escrows_processed.toString()}
               />
               <ProfileListItem
                 header={t('operator.profile.statistics.escrowsActive')}
-                paragraph="-"
+                paragraph={statsData.escrows_active.toString()}
               />
               <ProfileListItem
                 header={t('operator.profile.statistics.escrowsCancelled')}
-                paragraph="-"
+                paragraph={statsData.escrows_cancelled.toString()}
               />
               <ProfileListItem
                 header={t('operator.profile.statistics.workersAmount')}


### PR DESCRIPTION
## Description
Show response values for escrow stats in operator profile.
Before a `-` was shown.

## Summary of changes

- Show response in profile page

## How test the changes
yarn test

