### PR TITLE
[Dashboard][Server] `amountJobsProcessed` instead of `amountJobsLaunched`

### DIFF
--- a/packages/apps/dashboard/server/src/modules/details/dto/leader.dto.ts
+++ b/packages/apps/dashboard/server/src/modules/details/dto/leader.dto.ts
@@ -66,5 +66,5 @@ export class LeaderDto {
   @ApiProperty({ example: 1 })
   @IsNumber()
   @Expose()
-  public amountJobsLaunched: number;
+  public amountJobsProcessed: number;
 }


### PR DESCRIPTION
## Description

`amountJobsProcessed` instead of `amountJobsLaunched` in Leader Dto
