### PR TITLE
[SDK] Fix KvstoreUtils.get for compatibility with old versions

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore/kvstore_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore/kvstore_utils.py
@@ -157,7 +157,7 @@ class KVStoreUtils:
             or "kvstores" not in kvstore_data["data"]
             or len(kvstore_data["data"]["kvstores"]) == 0
         ):
-            return ""
+            raise KVStoreClientError(f"Key '{key}' not found for address {address}")
 
         return kvstore_data["data"]["kvstores"][0]["value"]
 

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore/kvstore_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore/kvstore_utils.py
@@ -157,7 +157,7 @@ class KVStoreUtils:
             or "kvstores" not in kvstore_data["data"]
             or len(kvstore_data["data"]["kvstores"]) == 0
         ):
-            raise KVStoreClientError(f"Key '{key}' not found for address {address}")
+            return ""
 
         return kvstore_data["data"]["kvstores"][0]["value"]
 

--- a/packages/sdk/typescript/human-protocol-sdk/src/kvstore.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/kvstore.ts
@@ -406,12 +406,10 @@ export class KVStoreUtils {
     );
 
     if (!kvstores || kvstores.length === 0) {
-      throw new Error(`Key "${key}" not found for address ${address}`);
+      return '';
     }
 
-    const value = kvstores[0].value;
-
-    return value;
+    return kvstores[0].value;
   }
 
   /**

--- a/packages/sdk/typescript/human-protocol-sdk/test/kvstore.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/kvstore.test.ts
@@ -402,26 +402,27 @@ describe('KVStoreUtils', () => {
       ).rejects.toThrow(ErrorInvalidAddress);
     });
 
-    test('should throw an error if key not found for address', async () => {
-      const key = 'key1';
-      const kvstores = [];
+    //Temporally disabled
+    // test('should throw an error if key not found for address', async () => {
+    //   const key = 'key1';
+    //   const kvstores = [];
 
-      const gqlFetchSpy = vi
-        .spyOn(gqlFetch, 'default')
-        .mockResolvedValue({ kvstores });
+    //   const gqlFetchSpy = vi
+    //     .spyOn(gqlFetch, 'default')
+    //     .mockResolvedValue({ kvstores });
 
-      await expect(
-        KVStoreUtils.get(ChainId.LOCALHOST, ethers.ZeroAddress, key)
-      ).rejects.toThrow(
-        `Key "${key}" not found for address ${ethers.ZeroAddress}`
-      );
+    //   await expect(
+    //     KVStoreUtils.get(ChainId.LOCALHOST, ethers.ZeroAddress, key)
+    //   ).rejects.toThrow(
+    //     `Key "${key}" not found for address ${ethers.ZeroAddress}`
+    //   );
 
-      expect(gqlFetchSpy).toHaveBeenCalledWith(
-        NETWORKS[ChainId.LOCALHOST]?.subgraphUrl,
-        GET_KVSTORE_BY_ADDRESS_AND_KEY_QUERY(),
-        { address: ethers.ZeroAddress, key: 'key1' }
-      );
-    });
+    //   expect(gqlFetchSpy).toHaveBeenCalledWith(
+    //     NETWORKS[ChainId.LOCALHOST]?.subgraphUrl,
+    //     GET_KVSTORE_BY_ADDRESS_AND_KEY_QUERY(),
+    //     { address: ethers.ZeroAddress, key: 'key1' }
+    //   );
+    // });
 
     test('should return empty string if both address and key are valid and address does not set any value', async () => {
       const kvstores = [


### PR DESCRIPTION
## Description

Fix KvstoreUtils.get for compatibility with old versions.

## Summary of changes

Return an empty string instead of an exception in case the key is not found

## How test the changes

`yarn test`