### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,34 @@
+# Purpose:
+# This file is used to improve the accuracy of `git blame` by ignoring specific commits that
+# introduce non-functional changes, such as formatting, refactoring, or large dependency updates.
+# By skipping these commits and using `git blame`, you can focus on meaningful code changes,
+# making it easier to trace the origin of code for debugging, understanding the history, or reviewing.
+#
+# Usage:
+# To automatically use this file with all `git blame` operations in this repository, run the following command:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# And optionally:
+#
+#   git config blame.markIgnoredLines true
+#   git config blame.markUnblamableLines true
+#
+# This ensures that every `git blame` operation, whether invoked manually or through tools like IDEs,
+# ignores the revisions listed here.
+#
+# It also seamlessly works with GitHub. If you want to view original changes in GitHub, append ~ to viewed commit hash.
+#
+# For more details on the rationale and usage, see the following links:
+# - https://www.michaelheap.com/git-ignore-rev/
+# - https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+# - https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+#
+# Structure:
+# Below, you will find sections for different projects or types of changes.
+# Each commit hash should be accompanied by commit title and PR url.
+
+# [Exchange Oracle] Add ruff (#2395) - https://github.com/humanprotocol/human-protocol/pull/2395
+e9ad17660a38864a73b28c4a5b610dedb5d767b4
+# [Recording Oracle] Add ruff (#2396) - https://github.com/humanprotocol/human-protocol/pull/2396
+2736ceb685967feacfcacfd8453868444995aabf

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ If you are a developer and would like to build on top of HUMAN please see [examp
 
 Navigate to the folder that you would like to install and follow the instructions in the README file
 
+Managing Git Blame with `.git-blame-ignore-revs`
+
+To improve `git blame` accuracy by ignoring non-functional commits (e.g., formatting or refactoring), we've added a `.git-blame-ignore-revs` file at the root of the repository.
+
+**To enable this:**  
+Run:
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+git config blame.markIgnoredLines true
+git config blame.markUnblamableLines true
+```
+
 ## LEGAL NOTICE
 
 The Protocol is an open-source, blockchain-based network that organizes, evaluates, and compensates human labor (the “Protocol”).  Your use of the Protocol is entirely at your own risk. The Protocol is available on an “as is” basis without warranties of any kind, either express or implied, including, but not limited to, warranties of merchantability, title, fitness for a particular purpose and non-infringement. You assume all risks associated with using the Protocol, and digital assets   and   decentralized   systems   generally,   including   but   not


### PR DESCRIPTION
## Summary of changes
- Added a new `.git-blame-ignore-revs` file at the root of the repository
- Included merge commits hashes `.git-blame-ignore-revs` for #2395 and #2396
- Updated README.md with instructions on how to configure git to use the new `.git-blame-ignore-revs` file

## How to test the changes
1. Clone the repository and navigate to its root
2. Run the following git commands:
   ```bash
   git config blame.ignoreRevsFile .git-blame-ignore-revs
   git config blame.markIgnoredLines true
   git config blame.markUnblamableLines true
   ```
3. Perform a `git blame` on a file affected by #2395 and #2396