### PR TITLE
[Job Launcher] Allowed canceling failed jobs

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -746,6 +746,8 @@ describe('CronJobService', () => {
 
     it('should cancel all of the jobs with status TO_CANCEL', async () => {
       jest.spyOn(webhookRepository, 'createUnique');
+      jest.spyOn(jobService, 'isEscrowFunded').mockResolvedValue(true);
+
       const result = await service.cancelCronJob();
 
       expect(result).toBeTruthy();
@@ -760,6 +762,8 @@ describe('CronJobService', () => {
     });
 
     it('should not call process escrow cancellation when escrowAddress is not present', async () => {
+      jest.spyOn(jobService, 'isEscrowFunded').mockResolvedValue(false);
+
       const jobEntityWithoutEscrow = {
         ...jobEntityMock1,
         escrowAddress: undefined,
@@ -777,6 +781,7 @@ describe('CronJobService', () => {
     });
 
     it('should increase retriesCount by 1 if the job cancellation fails', async () => {
+      jest.spyOn(jobService, 'isEscrowFunded').mockResolvedValue(true);
       jest
         .spyOn(jobService, 'processEscrowCancellation')
         .mockRejectedValueOnce(new Error('cancellation failed'));
@@ -791,9 +796,11 @@ describe('CronJobService', () => {
     });
 
     it('should mark job as failed if the job cancellation fails more than max retries count', async () => {
+      jest.spyOn(jobService, 'isEscrowFunded').mockResolvedValue(true);
       jest
         .spyOn(jobService, 'processEscrowCancellation')
         .mockRejectedValueOnce(new Error('cancellation failed'));
+
       jobEntityMock1.retriesCount = MOCK_MAX_RETRY_COUNT;
 
       await service.cancelCronJob();

--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -20,7 +20,7 @@ import { WebhookEntity } from '../webhook/webhook.entity';
 import { JobRepository } from '../job/job.repository';
 import { ControlledError } from '../../common/errors/controlled';
 import { Cron } from '@nestjs/schedule';
-import { EscrowClient, EscrowStatus, EscrowUtils } from '@human-protocol/sdk';
+import { EscrowStatus, EscrowUtils } from '@human-protocol/sdk';
 import { Web3Service } from '../web3/web3.service';
 import { JobEntity } from '../job/job.entity';
 import { NetworkConfigService } from '../../common/config/network-config.service';
@@ -215,8 +215,12 @@ export class CronJobService {
 
       for (const jobEntity of jobEntities) {
         try {
-          if (await this.jobService.isEscrowFunded(jobEntity)) {
-            console.log(jobEntity);
+          if (
+            await this.jobService.isEscrowFunded(
+              jobEntity.chainId,
+              jobEntity.escrowAddress,
+            )
+          ) {
             const { amountRefunded } =
               await this.jobService.processEscrowCancellation(jobEntity);
             await this.paymentService.createRefundPayment({

--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -237,7 +237,7 @@ export class CronJobService {
           const oracleType = this.jobService.getOracleType(
             jobEntity.requestType,
           );
-          if (oracleType !== OracleType.HCAPTCHA && jobEntity.escrowAddress) {
+          if (oracleType !== OracleType.HCAPTCHA) {
             const webhookEntity = new WebhookEntity();
             Object.assign(webhookEntity, {
               escrowAddress: jobEntity.escrowAddress,

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1104,6 +1104,7 @@ export class JobService {
         jobId: jobEntity.id,
       });
     }
+
     jobEntity.status = status;
 
     jobEntity.retriesCount = 0;
@@ -1599,5 +1600,17 @@ export class JobService {
 
     jobEntity.status = JobStatus.COMPLETED;
     await this.jobRepository.updateOne(jobEntity);
+  }
+
+  public async isEscrowFunded(jobEntity: JobEntity): Promise<boolean> {
+    if (jobEntity.escrowAddress) {
+      const signer = this.web3Service.getSigner(jobEntity.chainId);
+      const escrowClient = await EscrowClient.build(signer);
+      const balance = await escrowClient.getBalance(jobEntity.escrowAddress);
+
+      return balance !== 0n;
+    }
+
+    return false;
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1602,11 +1602,14 @@ export class JobService {
     await this.jobRepository.updateOne(jobEntity);
   }
 
-  public async isEscrowFunded(jobEntity: JobEntity): Promise<boolean> {
-    if (jobEntity.escrowAddress) {
-      const signer = this.web3Service.getSigner(jobEntity.chainId);
+  public async isEscrowFunded(
+    chainId: ChainId,
+    escrowAddress: string,
+  ): Promise<boolean> {
+    if (escrowAddress) {
+      const signer = this.web3Service.getSigner(chainId);
       const escrowClient = await EscrowClient.build(signer);
-      const balance = await escrowClient.getBalance(jobEntity.escrowAddress);
+      const balance = await escrowClient.getBalance(escrowAddress);
 
       return balance !== 0n;
     }


### PR DESCRIPTION
## Description
Allow canceling failed jobs

## Summary of changes
- Implemented `isEscrowFunded` in Job Service.
- Implemented checks in `cancelCronJob`.
- Updated unit tests.

**Tested Scenarios:**
- **Job PAID**: Job fails after being paid without an escrowAddress, with a zero escrow balance. Funds are returned to the user.
- **Job CREATED**: Job fails after being created with an escrowAddress. The escrow balance is zero, and funds are returned to the user.
- **Job SETUP**: Job fails after setup with an escrowAddress, but the escrow is not funded yet (balance is zero), and funds are returned to the user.
- **Job LAUNCHED**: Job fails after being launched with an escrowAddress. The escrow balance is non-zero, the escrow is canceled, and funds are returned to the user.

Major changes was implemented in `cancelCronJob`, because that's where the main logic for canceling escrow is located.
Also, instead of checking the escrow status, was added a check for the escrow balance in `isEscrowFunded`, because it can't be cancelled if the balance is zero, since [`notBroke` modifier in `Escrow` contract](https://github.com/humanprotocol/human-protocol/blob/c63f033ad1693da8b06a28fa0a36216833a164ff/packages/core/contracts/Escrow.sol#L167).

## How test the changes
`yarn test`

## Related issues
[Job Launcher] Allow canceling failed jobs.
[#2438](https://github.com/humanprotocol/human-protocol/issues/2438)
