### PR TITLE
[Exchange Oracle] Check qualifications on job assignment

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/constant/errors.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/constant/errors.ts
@@ -30,6 +30,7 @@ export enum ErrorAssignment {
   NotFound = 'Assignment not found',
   InvalidStatus = 'Invalid assignment status',
   InvalidAssignment = 'Invalid assignment',
+  InvalidAssignmentQualification = 'Invalid assignment qualification',
   InvalidUser = 'Assignment does not belong to the user',
   AlreadyExists = 'Assignment already exists',
   FullyAssigned = 'Fully assigned job',

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/strategy/jwt.http.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/strategy/jwt.http.ts
@@ -49,6 +49,7 @@ export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {
       wallet_address: string;
       kyc_status: string;
       reputation_network: string;
+      qualifications?: string[];
     },
   ): Promise<JwtUser> {
     if (!payload.email) {
@@ -89,6 +90,7 @@ export class JwtHttpStrategy extends PassportStrategy(Strategy, 'jwt-http') {
       email: payload.email,
       kycStatus: payload.kyc_status,
       reputationNetwork: payload.reputation_network,
+      qualifications: payload.qualifications,
     };
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/types/jwt.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/types/jwt.ts
@@ -10,4 +10,5 @@ export interface JwtUser {
   address: string;
   kycStatus: string;
   reputationNetwork: string;
+  qualifications?: string[];
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.spec.ts
@@ -214,6 +214,30 @@ describe('AssignmentService', () => {
       ).rejects.toThrow('Fully assigned job');
     });
 
+    it('should fail if job qualifications does not match with user qualifications', async () => {
+      manifest.qualifications = ['test'];
+      jest
+        .spyOn(jobRepository, 'findOneByChainIdAndEscrowAddress')
+        .mockResolvedValue({
+          id: 1,
+          reputationNetwork: reputationNetwork,
+        } as any);
+      jest
+        .spyOn(assignmentRepository, 'findOneByJobIdAndWorker')
+        .mockResolvedValue(null);
+      jest.spyOn(assignmentRepository, 'countByJobId').mockResolvedValue(5);
+      jest.spyOn(jobService, 'getManifest').mockResolvedValue(manifest);
+
+      await expect(
+        assignmentService.createAssignment(createAssignmentDto, {
+          address: workerAddress,
+          reputationNetwork: reputationNetwork,
+          qualifications: ['test2'],
+        } as any),
+      ).rejects.toThrow(ErrorAssignment.InvalidAssignmentQualification);
+      manifest.qualifications = undefined;
+    });
+
     it('should fail if job is expired', async () => {
       jest
         .spyOn(jobRepository, 'findOneByChainIdAndEscrowAddress')

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.ts
@@ -69,6 +69,17 @@ export class AssignmentService {
       data.escrowAddress,
     );
 
+    // Check if all required qualifications are present
+    const userQualificationsSet = new Set(jwtUser.qualifications);
+    const missingQualifications = manifest.qualifications?.filter(
+      (qualification) => !userQualificationsSet.has(qualification),
+    );
+    if (missingQualifications && missingQualifications.length > 0) {
+      throw new BadRequestException(
+        ErrorAssignment.InvalidAssignmentQualification,
+      );
+    }
+
     if (currentAssignments >= manifest.submissionsRequired) {
       this.logger.log(ErrorAssignment.FullyAssigned, AssignmentService.name);
       throw new BadRequestException(ErrorAssignment.FullyAssigned);

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
@@ -20,6 +20,7 @@ export class ManifestDto {
   requesterDescription: string;
   submissionsRequired: number;
   fundAmount: number;
+  qualifications?: string[];
 }
 
 export class SolveJobDto {


### PR DESCRIPTION
## Description

Update Exchange Oracle to check users qualifications against the qualifications required for a job when the user attempts to assign themselves to a job

## Summary of changes

Read user's qualifications from JWT
Read job's qualifications from manifest
Compare the user’s qualifications against the job’s requirements

## How test the changes

`yarn test`

## Related issues
#2467