### PR TITLE
[Job Launcher Server] Add qualifications to createJob endpoints and manifests

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -169,4 +169,5 @@ export enum ErrorCronJob {
  */
 export enum ErrorQualification {
   FailedToFetchQualifications = 'Failed to fetch qualifications',
+  InvalidQualification = `Invalid qualification`,
 }

--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -53,6 +53,7 @@ import { RateService } from '../payment/rate.service';
 import { StatusEvent } from '@human-protocol/sdk/dist/graphql';
 import { ethers } from 'ethers';
 import { NetworkConfigService } from '../../common/config/network-config.service';
+import { QualificationService } from '../qualification/qualification.service';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -119,6 +120,7 @@ describe('CronJobService', () => {
         CvatConfigService,
         PGPConfigService,
         NetworkConfigService,
+        QualificationService,
         {
           provide: NetworkConfigService,
           useValue: {

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -43,6 +43,11 @@ export class JobDto {
   @IsEnum(ChainId)
   @IsOptional()
   public chainId?: ChainId;
+
+  @ApiPropertyOptional()
+  @IsArray()
+  @IsOptional()
+  public qualifications?: string[];
 }
 
 export class JobQuickLaunchDto extends JobDto {
@@ -377,6 +382,10 @@ export class FortuneManifestDto {
   @ApiProperty({ enum: JobRequestType, name: 'request_type' })
   @IsEnum(JobRequestType)
   public requestType: JobRequestType;
+
+  @IsArray()
+  @IsOptional()
+  public qualifications?: string[];
 }
 
 export class CvatData {
@@ -408,6 +417,10 @@ export class Annotation {
   @IsNumber()
   @IsPositive()
   public job_size: number;
+
+  @IsArray()
+  @IsOptional()
+  public qualifications?: string[];
 }
 
 export class Validation {
@@ -746,6 +759,10 @@ export class HCaptchaManifestDto {
   @IsArray()
   @ValidateNested({ each: true })
   taskdata?: TaskData[];
+
+  @IsArray()
+  @IsOptional()
+  public qualifications?: string[];
 }
 
 class DatapointText {

--- a/packages/apps/job-launcher/server/src/modules/job/job.module.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.module.ts
@@ -16,6 +16,7 @@ import { AuthModule } from '../auth/auth.module';
 import { WebhookEntity } from '../webhook/webhook.entity';
 import { WebhookRepository } from '../webhook/webhook.repository';
 import { MutexManagerService } from '../mutex/mutex-manager.service';
+import { QualificationModule } from '../qualification/qualification.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { MutexManagerService } from '../mutex/mutex-manager.service';
     Web3Module,
     EncryptionModule,
     StorageModule,
+    QualificationModule,
   ],
   controllers: [JobController],
   providers: [

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -124,6 +124,8 @@ import { ControlledError } from '../../common/errors/controlled';
 import { RateService } from '../payment/rate.service';
 import { CronJobRepository } from '../cron-job/cron-job.repository';
 import { CronJobType } from '../../common/enums/cron-job';
+import { QualificationService } from '../qualification/qualification.service';
+import { NetworkConfigService } from '../../common/config/network-config.service';
 
 const rate = 1.5;
 jest.mock('@human-protocol/sdk', () => ({
@@ -246,6 +248,8 @@ describe('JobService', () => {
         CvatConfigService,
         PGPConfigService,
         S3ConfigService,
+        QualificationService,
+        NetworkConfigService,
         {
           provide: Web3Service,
           useValue: {

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -30,6 +30,7 @@ import {
   ErrorBucket,
   ErrorEscrow,
   ErrorJob,
+  ErrorQualification,
 } from '../../common/constants/errors';
 import {
   JobRequestType,
@@ -123,6 +124,7 @@ import { PageDto } from '../../common/pagination/pagination.dto';
 import { CronJobType } from '../../common/enums/cron-job';
 import { CronJobRepository } from '../cron-job/cron-job.repository';
 import { ModuleRef } from '@nestjs/core';
+import { QualificationService } from '../qualification/qualification.service';
 
 @Injectable()
 export class JobService {
@@ -147,6 +149,7 @@ export class JobService {
     private readonly rateService: RateService,
     private moduleRef: ModuleRef,
     @Inject(Encryption) private readonly encryption: Encryption,
+    private readonly qualificationService: QualificationService,
   ) {}
 
   onModuleInit() {
@@ -187,6 +190,9 @@ export class JobService {
         user_guide: dto.userGuide,
         type: requestType,
         job_size: this.cvatConfigService.jobSize,
+        ...(dto.qualifications && {
+          qualifications: dto.qualifications,
+        }),
       },
       validation: {
         min_quality: dto.minQuality,
@@ -224,6 +230,9 @@ export class JobService {
       oracle_stake: HCAPTCHA_ORACLE_STAKE,
       repo_uri: this.web3ConfigService.hCaptchaReputationOracleURI,
       ro_uri: this.web3ConfigService.hCaptchaRecordingOracleURI,
+      ...(jobDto.qualifications && {
+        qualifications: jobDto.qualifications,
+      }),
     };
 
     let groundTruthsData;
@@ -719,6 +728,24 @@ export class JobService {
       this.web3Service.validateChainId(chainId);
     } else {
       chainId = this.routingProtocolService.selectNetwork();
+    }
+
+    if (dto.qualifications) {
+      const validQualifications =
+        await this.qualificationService.getQualifications();
+
+      const validQualificationReferences = validQualifications.map(
+        (q) => q.reference,
+      );
+
+      dto.qualifications.forEach((qualification) => {
+        if (!validQualificationReferences.includes(qualification)) {
+          throw new ControlledError(
+            ErrorQualification.InvalidQualification,
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+      });
     }
 
     const rate = await this.rateService.getRate(Currency.USD, TokenId.HMT);
@@ -1460,18 +1487,30 @@ export class JobService {
         description: manifest.requesterDescription,
         requestType: JobRequestType.FORTUNE,
         submissionsRequired: manifest.submissionsRequired,
+        ...(manifest.qualifications &&
+          manifest.qualifications?.length > 0 && {
+            qualifications: manifest.qualifications,
+          }),
       };
     } else if (jobEntity.requestType === JobRequestType.HCAPTCHA) {
       manifest = manifest as HCaptchaManifestDto;
       specificManifestDetails = {
         requestType: JobRequestType.HCAPTCHA,
         submissionsRequired: manifest.job_total_tasks,
+        ...(manifest.qualifications &&
+          manifest.qualifications?.length > 0 && {
+            qualifications: manifest.qualifications,
+          }),
       };
     } else {
       manifest = manifest as CvatManifestDto;
       specificManifestDetails = {
         requestType: manifest.annotation?.type,
         submissionsRequired: manifest.annotation?.job_size,
+        ...(manifest.annotation.qualifications &&
+          manifest.annotation.qualifications?.length > 0 && {
+            qualifications: manifest.annotation.qualifications,
+          }),
       };
     }
 

--- a/packages/apps/job-launcher/server/src/modules/mutex/mutex-manager.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/mutex/mutex-manager.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Mutex, MutexInterface, withTimeout, E_TIMEOUT } from 'async-mutex';
+import { ControlledError } from '../../common/errors/controlled';
 
 @Injectable()
 export class MutexManagerService implements OnModuleDestroy {
@@ -59,6 +60,9 @@ export class MutexManagerService implements OnModuleDestroy {
       });
       return result;
     } catch (e) {
+      if (e instanceof ControlledError) {
+        throw e;
+      }
       if (e === E_TIMEOUT) {
         this.logger.error(
           `Function execution timed out for ${(key as any).id as string}`,

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.spec.ts
@@ -4,11 +4,15 @@ import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
 import { of, throwError } from 'rxjs';
-import { KVStoreUtils } from '@human-protocol/sdk';
-import { MOCK_REPUTATION_ORACLE_URL } from '../../../test/constants';
+import { ChainId, KVStoreUtils } from '@human-protocol/sdk';
+import {
+  MOCK_REPUTATION_ORACLE_URL,
+  MOCK_WEB3_RPC_URL,
+} from '../../../test/constants';
 import { ControlledError } from '../../common/errors/controlled';
 import { ErrorQualification, ErrorWeb3 } from '../../common/constants/errors';
 import { HttpStatus } from '@nestjs/common';
+import { NetworkConfigService } from '../../common/config/network-config.service';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -26,6 +30,7 @@ describe.only('QualificationService', () => {
         QualificationService,
         ConfigService,
         Web3ConfigService,
+        NetworkConfigService,
         {
           provide: HttpService,
           useValue: {
@@ -33,7 +38,17 @@ describe.only('QualificationService', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideProvider(NetworkConfigService)
+      .useValue({
+        networks: [
+          {
+            chainId: ChainId.LOCALHOST,
+            rpcUrl: MOCK_WEB3_RPC_URL,
+          },
+        ],
+      })
+      .compile();
 
     qualificationService =
       moduleRef.get<QualificationService>(QualificationService);

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.ts
@@ -5,7 +5,8 @@ import { HttpService } from '@nestjs/axios';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ControlledError } from '../../common/errors/controlled';
 import { ErrorQualification, ErrorWeb3 } from '../../common/constants/errors';
-import { ChainId, KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
+import { KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
+import { NetworkConfigService } from '../../common/config/network-config.service';
 
 @Injectable()
 export class QualificationService {
@@ -14,6 +15,7 @@ export class QualificationService {
   constructor(
     private httpService: HttpService,
     private readonly web3ConfigService: Web3ConfigService,
+    private readonly networkConfigService: NetworkConfigService,
   ) {}
 
   public async getQualifications(): Promise<QualificationDto[]> {
@@ -22,7 +24,7 @@ export class QualificationService {
 
       try {
         reputationOracleUrl = await KVStoreUtils.get(
-          ChainId.POLYGON_AMOY,
+          this.networkConfigService.networks[0].chainId,
           this.web3ConfigService.reputationOracleAddress,
           KVStoreKeys.url,
         );

--- a/packages/apps/reputation-oracle/server/test/setup.ts
+++ b/packages/apps/reputation-oracle/server/test/setup.ts
@@ -41,8 +41,18 @@ export async function setup(): Promise<void> {
 
   const kvStoreClient = await KVStoreClient.build(wallet);
   await kvStoreClient.setBulk(
-    [KVStoreKeys.role, KVStoreKeys.fee, KVStoreKeys.webhookUrl],
-    [Role.ReputationOracle, '1', 'http://localhost:5003/webhook'],
+    [
+      KVStoreKeys.role,
+      KVStoreKeys.fee,
+      KVStoreKeys.webhookUrl,
+      KVStoreKeys.url,
+    ],
+    [
+      Role.ReputationOracle,
+      '1',
+      'http://localhost:5003/webhook',
+      'http://localhost:5003',
+    ],
     { nonce: 0 },
   );
   await kvStoreClient.setFileUrlAndHash(


### PR DESCRIPTION
## Description

Update the create job endpoints in Job Launcher Server to include a new property, qualifications. This property should be a list of IDs representing the qualifications required for each job. The list must also be added to the job manifest

## Summary of changes

- Modify the create job endpoints to accept a new property, qualifications.
- Get qualifications list from Reputation Oracle
- Ensure qualifications is a list of IDs that identify the qualifications needed for the job.
- Update the job manifest schema to include the qualifications list.

## How test the changes

`yarn test`

## Related issues
#2465 
