### PR TITLE
[Human App] Jobs qualifications filter

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/enums/job.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/enums/job.ts
@@ -18,6 +18,7 @@ export enum JobFieldName {
   RewardToken = 'reward_token',
   CreatedAt = 'created_at',
   UpdatedAt = 'updated_at',
+  Qualifications = 'qualifications',
 }
 
 export enum AssignmentStatus {

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
@@ -109,6 +109,9 @@ export class JobDto {
   @ApiProperty({ name: 'updated_at' })
   updatedAt?: string;
 
+  @ApiProperty()
+  qualifications?: string[];
+
   constructor(
     escrowAddress: string,
     chainId: number,

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
@@ -20,6 +20,7 @@ export class ManifestDto {
   requesterDescription: string;
   submissionsRequired: number;
   fundAmount: number;
+  qualifications?: string[];
 }
 
 export class SolveJobDto {

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -158,6 +158,7 @@ export class JobService {
           data.fields?.includes(JobFieldName.JobDescription) ||
           data.fields?.includes(JobFieldName.RewardAmount) ||
           data.fields?.includes(JobFieldName.RewardToken) ||
+          data.fields?.includes(JobFieldName.Qualifications) ||
           data.sortField === JobSortField.REWARD_AMOUNT
         ) {
           const manifest = await this.getManifest(
@@ -176,6 +177,9 @@ export class JobService {
           }
           if (data.fields?.includes(JobFieldName.RewardToken)) {
             job.rewardToken = TOKEN;
+          }
+          if (data.fields?.includes(JobFieldName.Qualifications)) {
+            job.qualifications = manifest.qualifications;
           }
         }
 

--- a/packages/apps/human-app/server/src/common/constants/cache.ts
+++ b/packages/apps/human-app/server/src/common/constants/cache.ts
@@ -1,4 +1,4 @@
-export const JOB_DISCOVERY_CACHE_KEY = 'jobs:avialable';
+export const JOB_DISCOVERY_CACHE_KEY = 'jobs:available';
 export const JOB_ASSIGNMENT_CACHE_KEY = 'jobs:assigned';
 export const ORACLE_URL_CACHE_KEY = 'oracle:url';
 export const DAILY_HMT_SPENT_CACHE_KEY = 'daily:hmt-spent';

--- a/packages/apps/human-app/server/src/common/enums/global-common.ts
+++ b/packages/apps/human-app/server/src/common/enums/global-common.ts
@@ -3,6 +3,7 @@ export enum JobDiscoveryFieldName {
   RewardAmount = 'reward_amount',
   RewardToken = 'reward_token',
   CreatedAt = 'created_at',
+  Qualifications = 'qualifications',
 }
 export enum JobStatus {
   ACTIVE = 'ACTIVE',

--- a/packages/apps/human-app/server/src/common/utils/jwt-token.model.ts
+++ b/packages/apps/human-app/server/src/common/utils/jwt-token.model.ts
@@ -12,6 +12,8 @@ export class JwtUserData {
   @AutoMap()
   reputation_network: string;
   @AutoMap()
+  qualifications?: string[];
+  @AutoMap()
   site_key: string;
   @AutoMap()
   iat: number;

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -68,6 +68,7 @@ export class CronJobService {
         JobDiscoveryFieldName.JobDescription,
         JobDiscoveryFieldName.RewardAmount,
         JobDiscoveryFieldName.RewardToken,
+        JobDiscoveryFieldName.Qualifications,
       ];
       const initialResponse =
         await this.exchangeOracleGateway.fetchJobs(command);

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
@@ -38,7 +38,7 @@ export class JobsDiscoveryController {
     @JwtPayload() jwtPayload: JwtUserData,
     @Authorization() token: string,
   ): Promise<JobsDiscoveryResponse> {
-    // throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
+    throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
     const jobsDiscoveryParamsCommand: JobsDiscoveryParamsCommand =
       this.mapper.map(
         jobsDiscoveryParamsDto,

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
@@ -38,7 +38,7 @@ export class JobsDiscoveryController {
     @JwtPayload() jwtPayload: JwtUserData,
     @Authorization() token: string,
   ): Promise<JobsDiscoveryResponse> {
-    throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
+    // throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
     const jobsDiscoveryParamsCommand: JobsDiscoveryParamsCommand =
       this.mapper.map(
         jobsDiscoveryParamsDto,
@@ -46,9 +46,7 @@ export class JobsDiscoveryController {
         JobsDiscoveryParamsCommand,
       );
     jobsDiscoveryParamsCommand.token = token;
-    return await this.service.processJobsDiscovery(
-      jobsDiscoveryParamsCommand,
-      jwtPayload.qualifications,
-    );
+    jobsDiscoveryParamsCommand.data.qualifications = jwtPayload.qualifications;
+    return await this.service.processJobsDiscovery(jobsDiscoveryParamsCommand);
   }
 }

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
@@ -14,7 +14,11 @@ import {
   JobsDiscoveryParamsDto,
   JobsDiscoveryResponse,
 } from './model/jobs-discovery.model';
-import { Authorization } from '../../common/config/params-decorators';
+import {
+  Authorization,
+  JwtPayload,
+} from '../../common/config/params-decorators';
+import { JwtUserData } from '../../common/utils/jwt-token.model';
 
 @Controller()
 export class JobsDiscoveryController {
@@ -31,9 +35,10 @@ export class JobsDiscoveryController {
   })
   public async getJobs(
     @Query() jobsDiscoveryParamsDto: JobsDiscoveryParamsDto,
+    @JwtPayload() jwtPayload: JwtUserData,
     @Authorization() token: string,
   ): Promise<JobsDiscoveryResponse> {
-    throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
+    // throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
     const jobsDiscoveryParamsCommand: JobsDiscoveryParamsCommand =
       this.mapper.map(
         jobsDiscoveryParamsDto,
@@ -41,6 +46,9 @@ export class JobsDiscoveryController {
         JobsDiscoveryParamsCommand,
       );
     jobsDiscoveryParamsCommand.token = token;
-    return await this.service.processJobsDiscovery(jobsDiscoveryParamsCommand);
+    return await this.service.processJobsDiscovery(
+      jobsDiscoveryParamsCommand,
+      jwtPayload.qualifications,
+    );
   }
 }

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
@@ -16,14 +16,9 @@ export class JobsDiscoveryService {
 
   async processJobsDiscovery(
     command: JobsDiscoveryParamsCommand,
-    qualifications?: string[],
   ): Promise<JobsDiscoveryResponse> {
     const allJobs = await this.getCachedJobs(command.oracleAddress);
-    const filteredJobs = this.applyFilters(
-      allJobs || [],
-      command.data,
-      qualifications,
-    );
+    const filteredJobs = this.applyFilters(allJobs || [], command.data);
 
     return paginateAndSortResults(
       filteredJobs,
@@ -37,7 +32,6 @@ export class JobsDiscoveryService {
   private applyFilters(
     jobs: JobsDiscoveryResponseItem[],
     filters: JobsDiscoveryParamsCommand['data'],
-    qualifications?: string[],
   ): JobsDiscoveryResponseItem[] {
     const difference = Object.values(JobDiscoveryFieldName).filter(
       (value) => !filters.fields.includes(value),
@@ -62,12 +56,15 @@ export class JobsDiscoveryService {
           matches = matches && job.status === filters.status;
         }
 
-        if (qualifications !== undefined && qualifications !== null) {
+        if (
+          filters.qualifications !== undefined &&
+          filters.qualifications !== null
+        ) {
           if (job.qualifications && job.qualifications.length > 0) {
             matches =
               matches &&
               job.qualifications.every((qualification) =>
-                qualifications.includes(qualification),
+                filters.qualifications?.includes(qualification),
               );
           }
         }

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/model/jobs-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/model/jobs-discovery.model.ts
@@ -67,6 +67,7 @@ export class JobsDiscoveryParams extends PageableParams {
   status: JobStatus;
   @AutoMap()
   updatedAfter?: string;
+  qualifications?: string[];
 }
 export class JobsDiscoveryParamsData extends PageableData {
   @AutoMap()

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/model/jobs-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/model/jobs-discovery.model.ts
@@ -98,6 +98,11 @@ export class JobsDiscoveryResponseItem {
   chain_id: number;
   job_type: string;
   status: JobStatus;
+  created_at?: string;
+  job_description?: string;
+  reward_amount?: number;
+  reward_token?: string;
+  qualifications?: string[];
 }
 
 export class JobsDiscoveryResponse extends PageableResponse {


### PR DESCRIPTION

## Description
Update Human App to filter jobs based on the user’s qualifications. The app receives all jobs from the Exchange Oracle without filtering, so it needs to filter out jobs that the user is not qualified to handle based on their qualifications


## Summary of changes

Add qualifications filter to Human App getAvailableJobs
Fix extra fields in getAvailableJobs endpoint


## How test the changes
`yarn test`

## Related issues
#2469
