### PR TITLE
[Reputation Oracle] Fixed get reputation endpoint with lowercase address

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.repository.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@human-protocol/sdk';
 import { Injectable, Logger } from '@nestjs/common';
-import { DataSource, In } from 'typeorm';
+import { DataSource, ILike, In } from 'typeorm';
 import { BaseRepository } from '../../database/base.repository';
 import { ReputationEntity } from './reputation.entity';
 import { ReputationEntityType } from '../../common/enums';
@@ -24,7 +24,7 @@ export class ReputationRepository extends BaseRepository<ReputationEntity> {
     chainId: ChainId,
   ): Promise<ReputationEntity | null> {
     return this.findOne({
-      where: { address, chainId },
+      where: { address: ILike(address), chainId },
     });
   }
 

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -31,7 +31,6 @@ import { CvatManifestDto } from '../../common/dto/manifest';
 import { ReputationConfigService } from '../../common/config/reputation-config.service';
 import { ReputationEntity } from './reputation.entity';
 import { ControlledError } from '../../common/errors/controlled';
-import { ethers } from 'ethers';
 
 @Injectable()
 export class ReputationService {
@@ -331,20 +330,18 @@ export class ReputationService {
     chainId: ChainId,
     address: string,
   ): Promise<ReputationDto> {
-    const checksumAddress = ethers.getAddress(address);
-
     // https://github.com/humanprotocol/human-protocol/issues/1047
-    if (checksumAddress === this.web3Service.getOperatorAddress()) {
+    if (address === this.web3Service.getOperatorAddress()) {
       return {
         chainId,
-        address: checksumAddress,
+        address,
         reputation: ReputationLevel.HIGH,
       };
     }
 
     const reputationEntity =
       await this.reputationRepository.findOneByAddressAndChainId(
-        checksumAddress,
+        address,
         chainId,
       );
 

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -31,6 +31,7 @@ import { CvatManifestDto } from '../../common/dto/manifest';
 import { ReputationConfigService } from '../../common/config/reputation-config.service';
 import { ReputationEntity } from './reputation.entity';
 import { ControlledError } from '../../common/errors/controlled';
+import { ethers } from 'ethers';
 
 @Injectable()
 export class ReputationService {
@@ -330,18 +331,20 @@ export class ReputationService {
     chainId: ChainId,
     address: string,
   ): Promise<ReputationDto> {
+    const checksumAddress = ethers.getAddress(address);
+
     // https://github.com/humanprotocol/human-protocol/issues/1047
-    if (address === this.web3Service.getOperatorAddress()) {
+    if (checksumAddress === this.web3Service.getOperatorAddress()) {
       return {
         chainId,
-        address,
+        address: checksumAddress,
         reputation: ReputationLevel.HIGH,
       };
     }
 
     const reputationEntity =
       await this.reputationRepository.findOneByAddressAndChainId(
-        address,
+        checksumAddress,
         chainId,
       );
 


### PR DESCRIPTION
## Description
Fixed get reputation endpoint with lowercase address

## Summary of changes
- Added a checksum check to the incoming address, assuming that the address is stored in the database as a checksum.

⚠️ The address gets into the database during the reputation init, and it is not validated there, should we store the address as a checksum or in lowercase? Considering that we store addresses in lowercase in KVStore, this should be fixed here too.

## How test the changes
```bash
curl -X 'GET' \
  'http://localhost:5001/reputation/0x54f964b34852695c4896e4f065630034ea9e35b5?chain_id=80002' \
  -H 'accept: application/json'
```

## Related issues
[Reputation Oracle] Get reputation endpoint with lowercase address - "Reputation not found"
[#2470](https://github.com/humanprotocol/human-protocol/issues/2470)