### PR TITLE
[CVAT][Exchange Oracle] Avoid reassigning a job to the same wallet address

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/endpoints/exchange.py
+++ b/packages/examples/cvat/exchange-oracle/src/endpoints/exchange.py
@@ -111,7 +111,7 @@ async def create_assignment(
     if not assignment_id:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail="No assignments available",
+            detail="No assignments available for this wallet address.",
         )
 
     return oracle_service.serialize_task(project_id, assignment_id=assignment_id)

--- a/packages/examples/cvat/exchange-oracle/src/services/exchange.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/exchange.py
@@ -136,7 +136,10 @@ def create_assignment(project_id: int, wallet_address: str) -> str | None:
             )
 
         unassigned_job = cvat_service.get_free_job(
-            session, cvat_projects=[project.cvat_id], for_update=True
+            session,
+            cvat_projects=[project.cvat_id],
+            user_wallet_address=wallet_address,
+            for_update=True,
         )
         if not unassigned_job:
             return None

--- a/packages/examples/cvat/exchange-oracle/tests/integration/services/test_cvat.py
+++ b/packages/examples/cvat/exchange-oracle/tests/integration/services/test_cvat.py
@@ -17,6 +17,7 @@ from src.core.types import (
 )
 from src.db import SessionLocal
 from src.models.cvat import Assignment, DataUpload, Image, Job, Project, Task, User
+from src.utils.time import utcnow
 
 from tests.utils.db_helper import (
     create_project,
@@ -414,7 +415,7 @@ class ServiceIntegrationTest(unittest.TestCase):
             session=self.session,
             wallet_address=wallet_address_2,
             cvat_job_id=cvat_id_2,
-            expires_at=datetime.now(),
+            expires_at=utcnow(),
         )
 
         projects = cvat_service.get_projects_by_assignee(self.session, wallet_address_1)

--- a/packages/examples/cvat/exchange-oracle/tests/integration/services/test_exchange.py
+++ b/packages/examples/cvat/exchange-oracle/tests/integration/services/test_exchange.py
@@ -422,7 +422,45 @@ class ServiceIntegrationTest(unittest.TestCase):
 
         assert assignment_id == None
 
-    def test_create_assignment_in_validated_and_rejected_job(self):
+    def test_create_assignment_wont_reassign_job_to_previous_user(self):
+        cvat_project_1, _, cvat_job_1 = create_project_task_and_job(
+            self.session, "0x86e83d346041E8806e352681f3F14549C0d2BC67", 1
+        )
+        cvat_job_1.status = JobStatuses.new.value  # validated and rejected return to 'new'
+
+        user = User(
+            wallet_address="0x86e83d346041E8806e352681f3F14549C0d2BC69",
+            cvat_email="test@hmt.ai",
+            cvat_id=1,
+        )
+        self.session.add(user)
+
+        now = datetime.now()
+        assignment = Assignment(
+            id=str(uuid.uuid4()),
+            user_wallet_address=user.wallet_address,
+            cvat_job_id=cvat_job_1.cvat_id,
+            created_at=now - timedelta(hours=1),
+            completed_at=now - timedelta(minutes=40),
+            expires_at=datetime.now() + timedelta(days=1),
+            status=AssignmentStatuses.completed.value,
+        )
+        self.session.add(assignment)
+
+        self.session.commit()
+
+        with (
+            open("tests/utils/manifest.json") as data,
+            patch("src.services.exchange.get_escrow_manifest") as mock_get_manifest,
+            patch("src.services.exchange.cvat_api"),
+        ):
+            manifest = json.load(data)
+            mock_get_manifest.return_value = manifest
+            assignment_id = create_assignment(cvat_project_1.id, user.wallet_address)
+
+        assert assignment_id is None
+
+    def test_create_assignment_can_assign_job_to_new_user(self):
         cvat_project_1, _, cvat_job_1 = create_project_task_and_job(
             self.session, "0x86e83d346041E8806e352681f3F14549C0d2BC67", 1
         )
@@ -462,8 +500,6 @@ class ServiceIntegrationTest(unittest.TestCase):
         ):
             manifest = json.load(data)
             mock_get_manifest.return_value = manifest
-            assignment_id = create_assignment(cvat_project_1.id, previous_user.wallet_address)
-            assert assignment_id is None  # should not assign job to the same user more than once
             assignment_id = create_assignment(cvat_project_1.id, new_user.wallet_address)
 
         assignment = self.session.get(Assignment, assignment_id)


### PR DESCRIPTION

## Description

> In the current implementation a job can be annotated by the same worker multiple times. It is especially bad, because it could be siently rejected previously and now the worker has to annotate the job one more time.

> Delivery: A job can be annotated by an annotator only once. If it is rejected, it should not be visible again by the same annotator.


## Summary of changes

- Updated the `create_assignment` endpoint to check for existing assignments for a given `wallet_address` and return a relevant message if none are available.
- Modified `get_free_job` to exclude jobs already assigned to the specified `wallet_address`.

## How test the changes
- Run integration tests in `test_cvat.py` and `test_exchange.py` to validate new behavior.
- Manually test the `create_assignment` endpoint by attempting to assign jobs to the same wallet address multiple times; ensure it blocks subsequent assignments correctly.

## Related issues
<!-- Does this close any open issues? -->
