### PR TITLE
[Human APP][Server][Client] Fixed incorrect way of handling hcaptcha daily user stats

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/worker/hcaptcha-user-stats.ts
+++ b/packages/apps/human-app/frontend/src/api/services/worker/hcaptcha-user-stats.ts
@@ -13,12 +13,14 @@ const hcaptchaUserStatsSchema = z.object({
   served: z.number(),
   solved: z.number(),
   verified: z.number(),
-  // TODO verify response
-  currentDateStats: z.unknown(),
-  // TODO verify response
-  currentEarningsStats: z.object({
-    hmtEarned: z.unknown(),
+  currentDateStats: z.object({
+    // eslint-disable-next-line camelcase
+    billing_units: z.number(),
+    bypass: z.number(),
+    served: z.number(),
+    solved: z.number(),
   }),
+  currentEarningsStats: z.number(),
 });
 
 export type HCaptchaUserStatsSuccess = z.infer<typeof hcaptchaUserStatsSchema>;

--- a/packages/apps/human-app/frontend/src/pages/worker/hcaptcha-labeling/hcaptcha-labeling/hcaptcha-labeling.page.tsx
+++ b/packages/apps/human-app/frontend/src/pages/worker/hcaptcha-labeling/hcaptcha-labeling/hcaptcha-labeling.page.tsx
@@ -60,7 +60,8 @@ export function HcaptchaLabelingPage() {
   const canSolveCaptcha =
     dailyHmtSpent &&
     hcaptchaUserStats &&
-    hcaptchaUserStats.solved < env.VITE_DAILY_SOLVED_CAPTCHA_LIMIT &&
+    hcaptchaUserStats.currentDateStats.solved <
+      env.VITE_DAILY_SOLVED_CAPTCHA_LIMIT &&
     dailyHmtSpent.spend < env.VITE_HMT_DAILY_SPENT_LIMIT;
 
   const hcaptchaOnSuccess = (token: string) => {

--- a/packages/apps/human-app/server/src/integrations/h-captcha-labeling/h-captcha-statistics.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/h-captcha-labeling/h-captcha-statistics.gateway.ts
@@ -11,7 +11,6 @@ import { RequestDataType } from '../reputation-oracle/reputation-oracle.interfac
 import { AxiosRequestConfig } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import {
-  DateValue,
   UserStatsApiResponse,
   UserStatsResponse,
 } from '../../modules/h-captcha/model/user-stats.model';
@@ -74,21 +73,14 @@ export class HCaptchaStatisticsGateway {
       await this.handleRequestToHCaptchaLabelingApi<UserStatsApiResponse>(
         options,
       );
-    const dropoffLength = response.dropoff_data.length;
-    const earningsLength = response.earnings_data.length;
+
     return {
       balance: response.balance,
       served: response.served,
       solved: response.solved,
       verified: response.verified,
-      currentDateStats:
-        dropoffLength > 0
-          ? response.dropoff_data[dropoffLength - 1]
-          : ({} as DateValue),
-      currentEarningsStats:
-        earningsLength > 0
-          ? response.earnings_data[earningsLength - 1]
-          : ({} as DateValue),
+      currentDateStats: Object.values(response.dropoff_data).pop(),
+      currentEarningsStats: Object.values(response.earnings_data).pop()
     } as UserStatsResponse;
   }
 }

--- a/packages/apps/human-app/server/src/modules/h-captcha/model/user-stats.model.ts
+++ b/packages/apps/human-app/server/src/modules/h-captcha/model/user-stats.model.ts
@@ -16,9 +16,9 @@ export class UserStatsApiResponse {
   @AutoMap()
   balance: BalanceStats;
   @AutoMap()
-  earnings_data: DateValue[];
+  earnings_data: object;
   @AutoMap()
-  dropoff_data: DateValue[];
+  dropoff_data: object;
 }
 
 export type BalanceStats = {
@@ -27,9 +27,12 @@ export type BalanceStats = {
   recent: number;
   total: number;
 };
-export type DateValue = {
-  date: string;
-  value: number;
+
+export type CurrentDayStats = {
+  billing_units: number;
+  bypass: number;
+  served: number;
+  solved: number;
 };
 
 export class UserStatsResponse {
@@ -42,7 +45,7 @@ export class UserStatsResponse {
   @AutoMap()
   balance: BalanceStats;
   @AutoMap()
-  currentDateStats: DateValue;
+  currentDateStats: CurrentDayStats;
   @AutoMap()
-  currentEarningsStats: DateValue;
+  currentEarningsStats: number;
 }

--- a/packages/apps/human-app/server/src/modules/h-captcha/spec/h-captcha.fixtures.ts
+++ b/packages/apps/human-app/server/src/modules/h-captcha/spec/h-captcha.fixtures.ts
@@ -14,7 +14,6 @@ import {
   UserStatsApiResponse,
   UserStatsCommand,
   UserStatsResponse,
-  DateValue,
 } from '../model/user-stats.model';
 import {
   EnableLabelingCommand,
@@ -39,11 +38,36 @@ const BALANCE = {
   total: 7,
 } as BalanceStats;
 export const JWT_TOKEN = 'jwt.token.1';
-const DROPOFF_DATA_1 = { date: '2021-01-01', value: 10 } as DateValue;
-const DROPOFF_DATA_2 = { date: '2021-01-02', value: 20 } as DateValue;
-const DROPOFF_DATA_3 = { date: '2021-01-03', value: 30 } as DateValue;
-const EARNINGS_DATA_1 = { date: '2021-01-04', value: 140 } as DateValue;
-const EARNINGS_DATA_2 = { date: '2021-01-22', value: 209 } as DateValue;
+export const DROPOFF_DATA_1 = {
+  "2024-07-02": {
+    billing_units: 68,
+    bypass: 0,
+    served: 68,
+    solved: 60,
+  },
+};
+export const DROPOFF_DATA_2 = {
+  "2024-07-03": {
+    billing_units: 35,
+    bypass: 0,
+    served: 35,
+    solved: 34,
+  },
+};
+export const DROPOFF_DATA_3 = {
+  "2024-07-04": {
+    billing_units: 45,
+    bypass: 0,
+    served: 45,
+    solved: 42,
+  },
+};
+const EARNINGS_DATA_1 = {
+  "2024-07-02": 0.2,
+};
+const EARNINGS_DATA_2 = {
+  "2024-07-03": 0.1,
+};
 const SUCCESSFULLY_ENABLED = 'Enabled labeling for this account successfully';
 export const jwtUserDataFixture: JwtUserData = {
   userId: ID,
@@ -119,15 +143,8 @@ export const errorMessagesFixture = {
   withUndefinedErrorCodes:
     'Failed to verify h-captcha token. "error-codes" array is undefined. Response data: {"success":false}',
 };
-export const dropoffDataFixture: DateValue[] = [
-  DROPOFF_DATA_1,
-  DROPOFF_DATA_2,
-  DROPOFF_DATA_3,
-];
-export const earningsDataFixture: DateValue[] = [
-  EARNINGS_DATA_1,
-  EARNINGS_DATA_2,
-];
+export const dropoffDataFixture = { ...DROPOFF_DATA_1, ...DROPOFF_DATA_2, ...DROPOFF_DATA_3};
+export const earningsDataFixture = { ...EARNINGS_DATA_1, ...EARNINGS_DATA_2};
 
 export const userStatsApiResponseFixture: UserStatsApiResponse = {
   solved: SOLVED,
@@ -143,8 +160,8 @@ export const userStatsResponseFixture: UserStatsResponse = {
   served: SERVED,
   verified: VERIFIED,
   balance: BALANCE,
-  currentDateStats: DROPOFF_DATA_3,
-  currentEarningsStats: EARNINGS_DATA_2,
+  currentDateStats: DROPOFF_DATA_3['2024-07-04'],
+  currentEarningsStats: EARNINGS_DATA_2['2024-07-03'],
 };
 
 export const userStatsCommandFixture: UserStatsCommand = {


### PR DESCRIPTION
## Description

Fixed incorrect way of handling hcaptcha daily user stats

## Summary of changes

Process `dropoff_data` and `earnings_data` as objects not arrays.
Also, use today's stats for comparing with `VITE_DAILY_SOLVED_CAPTCHA_LIMIT`

