### PR TITLE
Add qualifications in Job Launcher Frontend

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -31,6 +31,7 @@ import {
   CvatJobType,
   GCSRegions,
   Label,
+  Qualification,
   StorageProviders,
 } from '../../../types';
 import { CvatJobRequestValidationSchema, dataValidationSchema } from './schema';
@@ -40,9 +41,9 @@ export const CvatJobRequestForm = () => {
     useCreateJobPageUI();
   const [searchParams] = useSearchParams();
   const [expanded, setExpanded] = useState<string[]>(['panel1']);
-  const [qualificationsOptions, setQualificationsOptions] = useState<string[]>(
-    [],
-  );
+  const [qualificationsOptions, setQualificationsOptions] = useState<
+    Qualification[]
+  >([]);
 
   const initialValues = {
     labels: [],
@@ -69,10 +70,7 @@ export const CvatJobRequestForm = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const fetchedQualifications = await getQualifications();
-        setQualificationsOptions(
-          fetchedQualifications.map((qualification) => qualification.reference),
-        );
+        setQualificationsOptions(await getQualifications());
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error fetching data:', error);
@@ -142,7 +140,9 @@ export const CvatJobRequestForm = () => {
         labels: labelArray,
         type,
         description,
-        qualifications,
+        qualifications: (qualifications as Qualification[]).map(
+          (qualification) => qualification.reference,
+        ),
         data: {
           dataset: {
             provider: dataProvider,
@@ -380,7 +380,7 @@ export const CvatJobRequestForm = () => {
                   <Autocomplete
                     multiple
                     options={qualificationsOptions}
-                    getOptionLabel={(option) => option}
+                    getOptionLabel={(option) => option.title}
                     value={values.qualifications}
                     onChange={(event, newValues) => {
                       setFieldValue('qualifications', newValues);
@@ -390,7 +390,10 @@ export const CvatJobRequestForm = () => {
                     handleHomeEndKeys
                     renderTags={(value, getTagProps) =>
                       value.map((option, index) => (
-                        <Chip label={option} {...getTagProps({ index })} />
+                        <Chip
+                          label={option.title}
+                          {...getTagProps({ index })}
+                        />
                       ))
                     }
                     renderInput={(params) => (

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
@@ -18,15 +18,16 @@ import {
 import { CollectionsFilledIcon } from '../../../components/Icons/CollectionsFilledIcon';
 import { useCreateJobPageUI } from '../../../providers/CreateJobPageUIProvider';
 import { getQualifications } from '../../../services/qualification';
+import { Qualification } from '../../../types';
 import { FortuneJobRequestValidationSchema } from './schema';
 
 export const FortuneJobRequestForm = () => {
   const { jobRequest, updateJobRequest, goToPrevStep, goToNextStep } =
     useCreateJobPageUI();
   const [expanded, setExpanded] = useState<string | false>('panel1');
-  const [qualificationsOptions, setQualificationsOptions] = useState<string[]>(
-    [],
-  );
+  const [qualificationsOptions, setQualificationsOptions] = useState<
+    Qualification[]
+  >([]);
 
   const initialValues = {
     title: '',
@@ -38,10 +39,7 @@ export const FortuneJobRequestForm = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const fetchedQualifications = await getQualifications();
-        setQualificationsOptions(
-          fetchedQualifications.map((qualification) => qualification.reference),
-        );
+        setQualificationsOptions(await getQualifications());
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error fetching data:', error);
@@ -68,7 +66,9 @@ export const FortuneJobRequestForm = () => {
         title,
         fortunesRequested,
         description,
-        qualifications,
+        qualifications: (qualifications as Qualification[]).map(
+          (qualification) => qualification.reference,
+        ),
       },
     });
     goToNextStep?.();
@@ -166,7 +166,7 @@ export const FortuneJobRequestForm = () => {
                       <Autocomplete
                         multiple
                         options={qualificationsOptions}
-                        getOptionLabel={(option) => option}
+                        getOptionLabel={(option) => option.title}
                         value={values.qualifications}
                         onChange={(event, newValues) => {
                           setFieldValue('qualifications', newValues);
@@ -176,7 +176,10 @@ export const FortuneJobRequestForm = () => {
                         handleHomeEndKeys
                         renderTags={(value, getTagProps) =>
                           value.map((option, index) => (
-                            <Chip label={option} {...getTagProps({ index })} />
+                            <Chip
+                              label={option.title}
+                              {...getTagProps({ index })}
+                            />
                           ))
                         }
                         renderInput={(params) => (

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
@@ -34,7 +34,7 @@ import languages from '../../../data/languages.json';
 import locations from '../../../data/locations.json';
 import { useCreateJobPageUI } from '../../../providers/CreateJobPageUIProvider';
 import { getQualifications } from '../../../services/qualification';
-import { HCaptchaJobType } from '../../../types';
+import { HCaptchaJobType, Qualification } from '../../../types';
 import { HCaptchaJobRequesteValidationSchema } from './schema';
 
 export const HCaptchaJobRequestForm = () => {
@@ -42,9 +42,9 @@ export const HCaptchaJobRequestForm = () => {
     useCreateJobPageUI();
   const [expanded, setExpanded] = useState<string[]>(['panel1']);
   const [searchParams] = useSearchParams();
-  const [qualificationsOptions, setQualificationsOptions] = useState<string[]>(
-    [],
-  );
+  const [qualificationsOptions, setQualificationsOptions] = useState<
+    Qualification[]
+  >([]);
 
   const initialValues = {
     dataUrl: '',
@@ -82,7 +82,10 @@ export const HCaptchaJobRequestForm = () => {
       accuracyTarget: Number(data.accuracyTarget) / 100,
       minRequests: Number(data.minRequests),
       maxRequests: Number(data.maxRequests),
-      qualifications: data.qualifications,
+
+      qualifications: (data.qualifications as Qualification[]).map(
+        (qualification) => qualification.reference,
+      ),
       advanced: {
         workerLanguage: data.workerLanguage,
         workerLocation: data.workerLocation,
@@ -132,10 +135,7 @@ export const HCaptchaJobRequestForm = () => {
     }
     const fetchData = async () => {
       try {
-        const fetchedQualifications = await getQualifications();
-        setQualificationsOptions(
-          fetchedQualifications.map((qualification) => qualification.reference),
-        );
+        setQualificationsOptions(await getQualifications());
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error fetching data:', error);
@@ -306,7 +306,7 @@ export const HCaptchaJobRequestForm = () => {
                   <Autocomplete
                     multiple
                     options={qualificationsOptions}
-                    getOptionLabel={(option) => option}
+                    getOptionLabel={(option) => option.title}
                     value={values.qualifications}
                     onChange={(event, newValues) => {
                       setFieldValue('qualifications', newValues);
@@ -316,7 +316,10 @@ export const HCaptchaJobRequestForm = () => {
                     handleHomeEndKeys
                     renderTags={(value, getTagProps) =>
                       value.map((option, index) => (
-                        <Chip label={option} {...getTagProps({ index })} />
+                        <Chip
+                          label={option.title}
+                          {...getTagProps({ index })}
+                        />
                       ))
                     }
                     renderInput={(params) => (

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
@@ -4,8 +4,10 @@ import CloudIcon from '@mui/icons-material/Cloud';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import InfoIcon from '@mui/icons-material/Info';
 import {
+  Autocomplete,
   Box,
   Button,
+  Chip,
   FormControl,
   FormHelperText,
   Grid,
@@ -24,13 +26,14 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Accordion,
-  AccordionSummary,
   AccordionDetails,
+  AccordionSummary,
 } from '../../../components/Accordion';
 import { CollectionsFilledIcon } from '../../../components/Icons/CollectionsFilledIcon';
 import languages from '../../../data/languages.json';
 import locations from '../../../data/locations.json';
 import { useCreateJobPageUI } from '../../../providers/CreateJobPageUIProvider';
+import { getQualifications } from '../../../services/qualification';
 import { HCaptchaJobType } from '../../../types';
 import { HCaptchaJobRequesteValidationSchema } from './schema';
 
@@ -39,6 +42,9 @@ export const HCaptchaJobRequestForm = () => {
     useCreateJobPageUI();
   const [expanded, setExpanded] = useState<string[]>(['panel1']);
   const [searchParams] = useSearchParams();
+  const [qualificationsOptions, setQualificationsOptions] = useState<string[]>(
+    [],
+  );
 
   const initialValues = {
     dataUrl: '',
@@ -46,6 +52,7 @@ export const HCaptchaJobRequestForm = () => {
     completionDate: null,
     minRequests: null,
     maxRequests: null,
+    qualifications: [],
     // Advanced
     workerLanguage: null,
     workerLocation: null,
@@ -75,6 +82,7 @@ export const HCaptchaJobRequestForm = () => {
       accuracyTarget: Number(data.accuracyTarget) / 100,
       minRequests: Number(data.minRequests),
       maxRequests: Number(data.maxRequests),
+      qualifications: data.qualifications,
       advanced: {
         workerLanguage: data.workerLanguage,
         workerLocation: data.workerLocation,
@@ -122,6 +130,19 @@ export const HCaptchaJobRequestForm = () => {
     ) {
       setFieldValue('type', type);
     }
+    const fetchData = async () => {
+      try {
+        const fetchedQualifications = await getQualifications();
+        setQualificationsOptions(
+          fetchedQualifications.map((qualification) => qualification.reference),
+        );
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -277,6 +298,38 @@ export const HCaptchaJobRequestForm = () => {
                     onBlur={handleBlur}
                     error={touched.maxRequests && Boolean(errors.maxRequests)}
                     type="number"
+                  />
+                </FormControl>
+              </Grid>
+              <Grid item xs={12}>
+                <FormControl fullWidth>
+                  <Autocomplete
+                    multiple
+                    options={qualificationsOptions}
+                    getOptionLabel={(option) => option}
+                    value={values.qualifications}
+                    onChange={(event, newValues) => {
+                      setFieldValue('qualifications', newValues);
+                    }}
+                    selectOnFocus
+                    onBlur={handleBlur}
+                    handleHomeEndKeys
+                    renderTags={(value, getTagProps) =>
+                      value.map((option, index) => (
+                        <Chip label={option} {...getTagProps({ index })} />
+                      ))
+                    }
+                    renderInput={(params) => (
+                      <Box display="flex" alignItems="center" width="100%">
+                        <TextField
+                          {...params}
+                          label="Qualifications"
+                          variant="outlined"
+                          onBlur={handleBlur}
+                          fullWidth
+                        />
+                      </Box>
+                    )}
                   />
                 </FormControl>
               </Grid>

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/schema.ts
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/schema.ts
@@ -19,7 +19,7 @@ export const CvatJobRequestValidationSchema = Yup.object().shape({
     .required('Accuracy target is required')
     .moreThan(0, 'Accuracy target must be greater than 0')
     .max(100, 'Accuracy target must be less than or equal to 100'),
-  qualifications: Yup.array().of(Yup.string()),
+  qualifications: Yup.array().of(Yup.object()),
 });
 
 export const dataValidationSchema = (type: CvatJobType) => {
@@ -60,7 +60,7 @@ export const FortuneJobRequestValidationSchema = Yup.object().shape({
   fortunesRequested: Yup.number()
     .required('FortunesRequested is required')
     .moreThan(0, 'FortunesRequested must be greater than 0'),
-  qualifications: Yup.array().of(Yup.string()),
+  qualifications: Yup.array().of(Yup.object()),
 });
 
 export const HCaptchaJobRequesteValidationSchema = Yup.object().shape({
@@ -87,5 +87,5 @@ export const HCaptchaJobRequesteValidationSchema = Yup.object().shape({
     .max(100, 'Accuracy target must be less than or equal to 100'),
   targetBrowser: Yup.string().required('Target Browser is required'),
   images: Yup.array().of(Yup.string().url('Invalid Image URL')),
-  qualifications: Yup.array().of(Yup.string()),
+  qualifications: Yup.array().of(Yup.object()),
 });

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/schema.ts
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/schema.ts
@@ -19,6 +19,7 @@ export const CvatJobRequestValidationSchema = Yup.object().shape({
     .required('Accuracy target is required')
     .moreThan(0, 'Accuracy target must be greater than 0')
     .max(100, 'Accuracy target must be less than or equal to 100'),
+  qualifications: Yup.array().of(Yup.string()),
 });
 
 export const dataValidationSchema = (type: CvatJobType) => {
@@ -59,6 +60,7 @@ export const FortuneJobRequestValidationSchema = Yup.object().shape({
   fortunesRequested: Yup.number()
     .required('FortunesRequested is required')
     .moreThan(0, 'FortunesRequested must be greater than 0'),
+  qualifications: Yup.array().of(Yup.string()),
 });
 
 export const HCaptchaJobRequesteValidationSchema = Yup.object().shape({
@@ -85,4 +87,5 @@ export const HCaptchaJobRequesteValidationSchema = Yup.object().shape({
     .max(100, 'Accuracy target must be less than or equal to 100'),
   targetBrowser: Yup.string().required('Target Browser is required'),
   images: Yup.array().of(Yup.string().url('Invalid Image URL')),
+  qualifications: Yup.array().of(Yup.string()),
 });

--- a/packages/apps/job-launcher/client/src/services/job.ts
+++ b/packages/apps/job-launcher/client/src/services/job.ts
@@ -24,6 +24,7 @@ export const createFortuneJob = async (
     requesterDescription: data.description,
     currency: currency,
     fundAmount: Number(amount),
+    qualifications: data.qualifications,
   };
   await api.post('/job/fortune', body);
 };
@@ -45,6 +46,7 @@ export const createCvatJob = async (
     groundTruth: data.groundTruth,
     userGuide: data.userGuide,
     type: data.type,
+    qualifications: data.qualifications,
   };
   await api.post('/job/cvat', body);
 };

--- a/packages/apps/job-launcher/client/src/services/qualification.ts
+++ b/packages/apps/job-launcher/client/src/services/qualification.ts
@@ -1,0 +1,7 @@
+import { Qualification } from '../types';
+import api from '../utils/api';
+
+export const getQualifications = async () => {
+  const { data } = await api.get<Qualification[]>(`/qualification`);
+  return data;
+};

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -40,11 +40,13 @@ export type CreateFortuneJobRequest = {
   requesterDescription: string;
   currency: string;
   fundAmount: number;
+  qualifications?: string[];
 };
 
 export type CreateCvatJobRequest = {
   chainId: number;
   requesterDescription: string;
+  qualifications?: string[];
   fundAmount: number;
   currency: string;
   data: CvatDataSource;
@@ -92,6 +94,7 @@ export type FortuneRequest = {
   title: string;
   fortunesRequested: number;
   description: string;
+  qualifications?: string[];
 };
 
 export enum StorageProviders {
@@ -199,6 +202,7 @@ export type CvatRequest = {
   labels: Label[];
   type: CvatJobType;
   description: string;
+  qualifications?: string[];
   data: CvatData;
   groundTruth: CvatDataSource;
   userGuide: string;
@@ -211,6 +215,7 @@ export type HCaptchaRequest = {
   completionDate: Date;
   minRequests: number;
   maxRequests: number;
+  qualifications?: string[];
   advanced: {
     workerLanguage: string;
     workerLocation: string;
@@ -268,6 +273,7 @@ export type JobDetailsResponse = {
     exchangeOracleAddress: string;
     recordingOracleAddress: string;
     reputationOracleAddress: string;
+    qualifications?: string[];
   };
   staking: {
     staker: string;
@@ -284,4 +290,11 @@ export type FortuneFinalResult = {
   exchangeAddress: string;
   workerAddress: string;
   solution: string;
+};
+
+export type Qualification = {
+  reference: string;
+  title: string;
+  description: string;
+  expires_at: string;
 };


### PR DESCRIPTION
## Description

Include Qualifications in Job Creation

## Summary of changes

- Fetch the available qualifications from the get qualifications endpoint.
- Add a dropdown menu to the job creation page under the section for qualifications.
- Display the fetched qualifications in a multiselect input, allowing users to select zero, one or more.
- Add the selected qualifications to the job creation request sent to the server.

## Related issues
#2466
