### PR TITLE
fix when currentDateStats is undefined

### DIFF
--- a/packages/apps/human-app/server/src/integrations/h-captcha-labeling/h-captcha-statistics.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/h-captcha-labeling/h-captcha-statistics.gateway.ts
@@ -79,8 +79,13 @@ export class HCaptchaStatisticsGateway {
       served: response.served,
       solved: response.solved,
       verified: response.verified,
-      currentDateStats: Object.values(response.dropoff_data).pop(),
-      currentEarningsStats: Object.values(response.earnings_data).pop()
+      currentDateStats: Object.values(response.dropoff_data).pop() || {
+        billing_units: 0,
+        bypass: 0,
+        served: 0,
+        solved: 0,
+      },
+      currentEarningsStats: Object.values(response.earnings_data).pop() || 0,
     } as UserStatsResponse;
   }
 }


### PR DESCRIPTION
## Description
Fix the following issue
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/62e18e37-fe13-4b5b-90d9-83229291c6ed">

currentDateStats or currentEarningsStats are undefined
