### PR TITLE
[dashboard] HDM-7-transactions-table-decimals

### DIFF
--- a/packages/apps/dashboard/ui-2024/src/pages/SearchResults/WalletAddress/WalletAddressTransactions/cells/TransactionTableCellValue.tsx
+++ b/packages/apps/dashboard/ui-2024/src/pages/SearchResults/WalletAddress/WalletAddressTransactions/cells/TransactionTableCellValue.tsx
@@ -15,7 +15,7 @@ export const TransactionTableCellValue = ({ value }: { value: string }) => {
 
 	return (
 		<Typography>
-			{Number(ethers.formatEther(value)).toFixed()}
+			{Number(ethers.formatEther(value)).toFixed(4)}
 			<Typography component="span">HMT</Typography>
 		</Typography>
 	);


### PR DESCRIPTION
In this PR, the HMT value in the `WalletAddressTransactions` table has been formatted to always display 4 decimal places.