### PR TITLE
[Job Launcher] Dataset and ground truth path validation and hint

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -513,6 +513,18 @@ export const CvatJobRequestForm = () => {
                       }
                       error={touched.dataPath && Boolean(errors.dataPath)}
                       helperText={errors.dataPath}
+                      InputProps={{
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <Tooltip title="This field should contain the relative path to the data, excluding protocol symbols like '://'. For example, if the full URL is 'https://bucket.com/bucket_name/data', the input should only include 'data'.">
+                              <HelpOutlineIcon
+                                color="secondary"
+                                sx={{ cursor: 'pointer' }}
+                              />
+                            </Tooltip>
+                          </InputAdornment>
+                        ),
+                      }}
                     />
                   </FormControl>
                 </Grid>
@@ -609,6 +621,18 @@ export const CvatJobRequestForm = () => {
                         }
                         error={touched.bpPath && Boolean(errors.bpPath)}
                         helperText={errors.bpPath}
+                        InputProps={{
+                          endAdornment: (
+                            <InputAdornment position="end">
+                              <Tooltip title="This field should contain the relative path to the data, excluding protocol symbols like '://'. For example, if the full URL is 'https://bucket.com/annotations/points_15.json', the input should only include 'annotations/points_15.json'.">
+                                <HelpOutlineIcon
+                                  color="secondary"
+                                  sx={{ cursor: 'pointer' }}
+                                />
+                              </Tooltip>
+                            </InputAdornment>
+                          ),
+                        }}
                       />
                     </FormControl>
                   </Grid>
@@ -616,9 +640,17 @@ export const CvatJobRequestForm = () => {
               )}
               <Grid item container xs={12} spacing={2}>
                 <Grid item xs={12}>
-                  <Typography variant="body2" fontWeight={700}>
-                    Ground truth
-                  </Typography>
+                  <Box display="flex">
+                    <Typography variant="body2" fontWeight={700}>
+                      Ground truth
+                    </Typography>
+                    <Tooltip title="Ground truth data serves as the reference or gold standard for your annotations, representing the correct data against which annotations are compared for accuracy and quality assessment.">
+                      <HelpOutlineIcon
+                        color="secondary"
+                        sx={{ cursor: 'pointer', ml: 1 }}
+                      />
+                    </Tooltip>
+                  </Box>
                 </Grid>
                 <Grid item xs={12} sm={12} md={6}>
                   <FormControl variant="outlined" fullWidth>
@@ -701,7 +733,7 @@ export const CvatJobRequestForm = () => {
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position="end">
-                            <Tooltip title="This field should contain the relative path to the ground truth data, excluding protocol symbols like '://'. For example, if the full URL is 'https://bucket.com/annotations/points_15.json', the input should only include 'annotations/points_15.json'. Ground truth data serves as the reference or gold standard for your annotations, representing the correct data against which annotations are compared for accuracy and quality assessment.">
+                            <Tooltip title="This field should contain the relative path to the data, excluding protocol symbols like '://'. For example, if the full URL is 'https://bucket.com/annotations/gt_name.json', the input should only include 'annotations/gt_name.json'.">
                               <HelpOutlineIcon
                                 color="secondary"
                                 sx={{ cursor: 'pointer' }}

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -701,7 +701,7 @@ export const CvatJobRequestForm = () => {
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position="end">
-                            <Tooltip title="This field should contain a URL or link to the ground truth data. Ground truth data serves as the reference or gold standard for your annotations. It represents the correct or desired data, against which the annotations are compared for accuracy and quality assessment.">
+                            <Tooltip title="This field should contain the relative path to the ground truth data, excluding protocol symbols like '://'. For example, if the full URL is 'https://bucket.com/annotations/points_15.json', the input should only include 'annotations/points_15.json'. Ground truth data serves as the reference or gold standard for your annotations, representing the correct data against which annotations are compared for accuracy and quality assessment.">
                               <HelpOutlineIcon
                                 color="secondary"
                                 sx={{ cursor: 'pointer' }}

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -541,7 +541,7 @@ export class JobService {
         const gt = await this.storageService.download(
           `${urls.gtUrl.protocol}//${urls.gtUrl.host}${urls.gtUrl.pathname}`,
         );
-        if (!gt || gt.length === 0)
+        if (!gt || !gt.images || gt.images.length === 0)
           throw new ControlledError(
             ErrorJob.GroundThuthValidationFailed,
             HttpStatus.BAD_REQUEST,
@@ -574,7 +574,18 @@ export class JobService {
         const gt = await this.storageService.download(
           `${urls.gtUrl.protocol}//${urls.gtUrl.host}${urls.gtUrl.pathname}`,
         );
+        if (!gt || !gt.images || gt.images.length === 0)
+          throw new ControlledError(
+            ErrorJob.GroundThuthValidationFailed,
+            HttpStatus.BAD_REQUEST,
+          );
+
         const data = await listObjectsInBucket(urls.dataUrl);
+        if (!data || data.length === 0 || !data[0])
+          throw new ControlledError(
+            ErrorJob.DatasetValidationFailed,
+            HttpStatus.BAD_REQUEST,
+          );
 
         await this.checkImageConsistency(gt.images, data);
 
@@ -879,6 +890,13 @@ export class JobService {
   public async getCvatElementsCount(gtUrl: URL, dataUrl: URL): Promise<number> {
     const data = await this.storageService.download(dataUrl.href);
     const gt = await this.storageService.download(gtUrl.href);
+
+    if (!gt || !gt.images || gt.images.length === 0) {
+      throw new ControlledError(
+        ErrorJob.GroundThuthValidationFailed,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
 
     let gtEntries = 0;
 


### PR DESCRIPTION
## Description
Show a better message for ground truth errors

## Summary of changes
Frontend:
- Improve hint

Backend:
- Add a meaninful error when the path provided is wrong.

## How test the changes

`yarn test

## Related issues
#2513
