### PR TITLE
[Human APP][Server / Client] Implement a feature flag for "Jobs Discovery" mechanism

### DIFF
--- a/packages/apps/human-app/frontend/src/components/layout/drawer-menu-items/drawer-menu-items-worker.tsx
+++ b/packages/apps/human-app/frontend/src/components/layout/drawer-menu-items/drawer-menu-items-worker.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@/components/layout/protected/drawer-navigation';
 import { HelpIcon, UserOutlinedIcon, WorkIcon } from '@/components/ui/icons';
 import { routerPaths } from '@/router/router-paths';
+import { env } from '@/shared/env';
 
 export const workerDrawerTopMenuItems = (
   addressRegistered: boolean
@@ -31,11 +32,15 @@ export const workerDrawerTopMenuItems = (
       link: routerPaths.worker.enableLabeler,
       disabled: !addressRegistered,
     },
-    // {
-    //   label: t('components.DrawerNavigation.jobsDiscovery'),
-    //   link: routerPaths.worker.jobsDiscovery,
-    //   disabled: !addressRegistered,
-    // },
+    ...(env.VITE_FEATURE_FLAG_JOBS_DISCOVERY
+      ? [
+          {
+            label: t('components.DrawerNavigation.jobsDiscovery'),
+            link: routerPaths.worker.jobsDiscovery,
+            disabled: !addressRegistered,
+          },
+        ]
+      : []),
   ];
 };
 

--- a/packages/apps/human-app/frontend/src/router/router-paths.ts
+++ b/packages/apps/human-app/frontend/src/router/router-paths.ts
@@ -11,7 +11,7 @@ export const routerPaths = {
     emailVerification: '/verify',
     verifyEmail: '/worker/verify-email',
     profile: '/worker/profile',
-    // jobsDiscovery: '/worker/jobs-discovery',
+    jobsDiscovery: '/worker/jobs-discovery',
     jobs: '/worker/jobs',
     HcaptchaLabeling: '/worker/hcaptcha-labeling',
     enableLabeler: '/worker/enable-labeler',

--- a/packages/apps/human-app/frontend/src/router/routes.tsx
+++ b/packages/apps/human-app/frontend/src/router/routes.tsx
@@ -20,12 +20,13 @@ import { AddKeysOperatorPage } from '@/pages/operator/sign-up/add-keys/add-keys.
 import { EditExistingKeysSuccessPage } from '@/pages/operator/sign-up/add-keys/edit-existing-keys-success.page';
 import type { PageHeaderProps } from '@/components/layout/protected/page-header';
 import { HandIcon, HomepageWorkIcon, ProfileIcon } from '@/components/ui/icons';
-// import { JobsDiscoveryPage } from '@/pages/worker/jobs-discovery/jobs-discovery.page';
+import { JobsDiscoveryPage } from '@/pages/worker/jobs-discovery/jobs-discovery.page';
 import { JobsPage } from '@/pages/worker/jobs/jobs.page';
 import { EnableLabeler } from '@/pages/worker/hcaptcha-labeling/enable-labeler.page';
 import { HcaptchaLabelingPage } from '@/pages/worker/hcaptcha-labeling/hcaptcha-labeling/hcaptcha-labeling.page';
 import { UserStatsAccordion } from '@/pages/worker/hcaptcha-labeling/hcaptcha-labeling/user-stats-accordion';
 import { SetUpOperatorPage } from '@/pages/operator/sign-up/set-up-operator';
+import { env } from '@/shared/env';
 
 export const unprotectedRoutes: RouteProps[] = [
   {
@@ -88,16 +89,20 @@ export const protectedRoutes: {
       headerText: t('protectedPagesHeaders.profile'),
     },
   },
-  // {
-  //   routerProps: {
-  //     path: routerPaths.worker.jobsDiscovery,
-  //     element: <JobsDiscoveryPage />,
-  //   },
-  //   pageHeaderProps: {
-  //     headerIcon: <HomepageWorkIcon />,
-  //     headerText: t('protectedPagesHeaders.jobsDiscovery'),
-  //   },
-  // },
+  ...(env.VITE_FEATURE_FLAG_JOBS_DISCOVERY
+    ? [
+        {
+          routerProps: {
+            path: routerPaths.worker.jobsDiscovery,
+            element: <JobsDiscoveryPage />,
+          },
+          pageHeaderProps: {
+            headerIcon: <HomepageWorkIcon />,
+            headerText: t('protectedPagesHeaders.jobsDiscovery'),
+          },
+        },
+      ]
+    : []),
   {
     routerProps: {
       path: `${routerPaths.worker.jobs}/:address`,

--- a/packages/apps/human-app/frontend/src/shared/env.ts
+++ b/packages/apps/human-app/frontend/src/shared/env.ts
@@ -31,6 +31,10 @@ const envSchema = z.object({
     return iconsArray;
   }),
   VITE_NETWORK: z.enum(['mainnet', 'testnet']),
+  VITE_FEATURE_FLAG_JOBS_DISCOVERY: z
+    .string()
+    .default('false')
+    .transform((value) => value === 'true'),
 });
 
 let validEnvs;

--- a/packages/apps/human-app/server/src/common/config/environment-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.ts
@@ -134,4 +134,10 @@ export class EnvironmentConfigService {
       DEFAULT_MAX_REQUEST_RETRIES,
     );
   }
+  get jobsDiscoveryFlag(): boolean {
+    return this.configService.get<boolean>(
+      'FEATURE_FLAG_JOBS_DISCOVERY',
+      false,
+    );
+  }
 }

--- a/packages/apps/human-app/server/src/common/config/environment-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.ts
@@ -135,9 +135,10 @@ export class EnvironmentConfigService {
     );
   }
   get jobsDiscoveryFlag(): boolean {
-    return this.configService.get<boolean>(
+    const flag = this.configService.get<string>(
       'FEATURE_FLAG_JOBS_DISCOVERY',
-      false,
+      'false',
     );
+    return flag === 'true';
   }
 }

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -36,7 +36,7 @@ export class CronJobService {
   }
 
   initializeCronJob() {
-    const job = new CronJob('*/30 * * * * *', () => {
+    const job = new CronJob('*/3 * * * *', () => {
       this.updateJobsListCron();
     });
 

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -33,6 +33,8 @@ export class CronJobService {
   async updateJobsListCron() {
     this.logger.log('CRON START');
 
+    if (!this.configService.jobsDiscoveryFlag) return;
+
     const oracleDiscoveryCommand: OracleDiscoveryCommand = {};
     const oracles = await this.oracleDiscoveryService.processOracleDiscovery(
       oracleDiscoveryCommand,

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
-import { Cron } from '@nestjs/schedule';
+import { CronJob } from 'cron';
 import { ExchangeOracleGateway } from '../../integrations/exchange-oracle/exchange-oracle.gateway';
 import {
   JobsDiscoveryParams,
@@ -17,6 +17,7 @@ import {
 } from '../oracle-discovery/model/oracle-discovery.model';
 import { WorkerService } from '../user-worker/worker.service';
 import { JobDiscoveryFieldName } from '../../common/enums/global-common';
+import { SchedulerRegistry } from '@nestjs/schedule';
 
 @Injectable()
 export class CronJobService {
@@ -27,13 +28,24 @@ export class CronJobService {
     private configService: EnvironmentConfigService,
     private oracleDiscoveryService: OracleDiscoveryService,
     private workerService: WorkerService,
-  ) {}
+    private schedulerRegistry: SchedulerRegistry,
+  ) {
+    if (this.configService.jobsDiscoveryFlag) {
+      this.initializeCronJob();
+    }
+  }
 
-  @Cron('*/3 * * * *')
+  initializeCronJob() {
+    const job = new CronJob('*/30 * * * * *', () => {
+      this.updateJobsListCron();
+    });
+
+    this.schedulerRegistry.addCronJob('updateJobsList', job);
+    job.start();
+  }
+
   async updateJobsListCron() {
     this.logger.log('CRON START');
-
-    if (!this.configService.jobsDiscoveryFlag) return;
 
     const oracleDiscoveryCommand: OracleDiscoveryCommand = {};
     const oracles = await this.oracleDiscoveryService.processOracleDiscovery(

--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -12,6 +12,7 @@ import {
 import { JOB_DISCOVERY_CACHE_KEY } from '../../../common/constants/cache';
 import { JobStatus } from '../../../common/enums/global-common';
 import { OracleDiscoveryResponse } from '../../../modules/oracle-discovery/model/oracle-discovery.model';
+import { SchedulerRegistry } from '@nestjs/schedule';
 
 describe('CronJobService', () => {
   let service: CronJobService;
@@ -44,7 +45,6 @@ describe('CronJobService', () => {
       password: 'Test1234*',
       cacheTtlOracleDiscovery: 600,
       chainIdsEnabled: ['137', '1'],
-      jobsDiscoveryFlag: true,
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -58,6 +58,7 @@ describe('CronJobService', () => {
         { provide: WorkerService, useValue: workerServiceMock },
         { provide: CACHE_MANAGER, useValue: cacheManagerMock },
         { provide: EnvironmentConfigService, useValue: configServiceMock },
+        SchedulerRegistry,
       ],
     }).compile();
 

--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -44,6 +44,7 @@ describe('CronJobService', () => {
       password: 'Test1234*',
       cacheTtlOracleDiscovery: 600,
       chainIdsEnabled: ['137', '1'],
+      jobsDiscoveryFlag: true,
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.controller.ts
@@ -19,11 +19,13 @@ import {
   JwtPayload,
 } from '../../common/config/params-decorators';
 import { JwtUserData } from '../../common/utils/jwt-token.model';
+import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 
 @Controller()
 export class JobsDiscoveryController {
   constructor(
     private readonly service: JobsDiscoveryService,
+    private readonly environmentConfigService: EnvironmentConfigService,
     @InjectMapper() private readonly mapper: Mapper,
   ) {}
 
@@ -38,7 +40,12 @@ export class JobsDiscoveryController {
     @JwtPayload() jwtPayload: JwtUserData,
     @Authorization() token: string,
   ): Promise<JobsDiscoveryResponse> {
-    throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
+    if (!this.environmentConfigService.jobsDiscoveryFlag) {
+      throw new HttpException(
+        'Jobs discovery is disabled',
+        HttpStatus.FORBIDDEN,
+      );
+    }
     const jobsDiscoveryParamsCommand: JobsDiscoveryParamsCommand =
       this.mapper.map(
         jobsDiscoveryParamsDto,

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -12,6 +12,9 @@ import { AutomapperModule } from '@automapper/nestjs';
 import { classes } from '@automapper/classes';
 import { JobsDiscoveryProfile } from '../jobs-discovery.mapper.profile';
 import { HttpService } from '@nestjs/axios';
+import { CommonConfigModule } from '../../../common/config/common-config.module';
+import { ConfigModule } from '@nestjs/config';
+import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
 
 describe('JobsDiscoveryController', () => {
   let controller: JobsDiscoveryController;
@@ -24,10 +27,16 @@ describe('JobsDiscoveryController', () => {
         AutomapperModule.forRoot({
           strategyInitializer: classes(),
         }),
+        CommonConfigModule,
+        ConfigModule.forRoot({
+          envFilePath: '.env',
+          isGlobal: true,
+        }),
       ],
       providers: [
         JobsDiscoveryService,
         JobsDiscoveryProfile,
+        EnvironmentConfigService,
         {
           provide: HttpService,
           useValue: {

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
@@ -16,11 +16,13 @@ import {
 } from './model/oracle-discovery.model';
 import { InjectMapper } from '@automapper/nestjs';
 import { Mapper } from '@automapper/core';
+import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 
 @Controller()
 export class OracleDiscoveryController {
   constructor(
     private readonly service: OracleDiscoveryService,
+    private readonly environmentConfigService: EnvironmentConfigService,
     @InjectMapper() private readonly mapper: Mapper,
   ) {}
   @ApiTags('Oracle-Discovery')
@@ -30,7 +32,12 @@ export class OracleDiscoveryController {
   public getOracles(
     @Query() dto: OracleDiscoveryDto,
   ): Promise<OracleDiscoveryResponse[]> {
-    throw new HttpException('Jobs discovery is disabled', HttpStatus.FORBIDDEN);
+    if (!this.environmentConfigService.jobsDiscoveryFlag) {
+      throw new HttpException(
+        'Oracles discovery is disabled',
+        HttpStatus.FORBIDDEN,
+      );
+    }
     const command = this.mapper.map(
       dto,
       OracleDiscoveryDto,

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -11,6 +11,9 @@ import {
 } from '../model/oracle-discovery.model';
 import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
+import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
+import { CommonConfigModule } from '../../../common/config/common-config.module';
+import { ConfigModule } from '@nestjs/config';
 
 describe('OracleDiscoveryController', () => {
   let controller: OracleDiscoveryController;
@@ -23,8 +26,17 @@ describe('OracleDiscoveryController', () => {
         AutomapperModule.forRoot({
           strategyInitializer: classes(),
         }),
+        CommonConfigModule,
+        ConfigModule.forRoot({
+          envFilePath: '.env',
+          isGlobal: true,
+        }),
       ],
-      providers: [OracleDiscoveryService, OracleDiscoveryProfile],
+      providers: [
+        OracleDiscoveryService,
+        OracleDiscoveryProfile,
+        EnvironmentConfigService,
+      ],
     })
       .overrideProvider(OracleDiscoveryService)
       .useValue(oracleDiscoveryServiceMock)


### PR DESCRIPTION
## Description

Implement a feature flag for "Jobs Discovery" mechanism

## Summary of changes

Frontend:

Add FEATURE_FLAG_JOBS_DISCOVERY env variable.
If this env is set to false, don't show Jobs Discovery tab and it's content (just in case someone will try to directly go to /worker/jobs-discovery
Backend:

Add FEATURE_FLAG_JOBS_DISCOVERY env variable.
In case this variable is set to false, all mechanisms related to this feature should be disabled (cron-jobs, endpoints for calling exchnage oracles etc.)

## Related issues
#2532
