### PR TITLE
[Fortune - Recording Oracle] Fixed production build path

### DIFF
--- a/packages/apps/fortune/recording-oracle/package.json
+++ b/packages/apps/fortune/recording-oracle/package.json
@@ -10,7 +10,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest",


### PR DESCRIPTION
## Description
Fixed production build command, since `yarn start:prod` command return error: Error: Cannot find module '/opt/render/project/src/packages/apps/fortune/recording-oracle/dist/main'

## Summary of changes
- Updated `yarn start:prod` in `package.json` scripts.

## How test the changes
`yarn start:prod`

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
