### PR TITLE
[Reputation Oracle] Added message data to sendgrid template

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/index.ts
@@ -16,6 +16,11 @@ export const SENDGRID_TEMPLATES = {
   passwordChanged: 'd-ca0ac7e6fff845829cd0167af09f25cf',
 };
 
+export const SENDGRID_MESSAGES = {
+  signup:
+    "It's time to verify your email, and join the HUMAN community of contributors.",
+};
+
 export const CVAT_RESULTS_ANNOTATIONS_FILENAME = 'resulting_annotations.zip';
 export const CVAT_VALIDATION_META_FILENAME = 'validation_meta.json';
 

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -29,7 +29,11 @@ import { v4 } from 'uuid';
 import { UserStatus, Role } from '../../common/enums/user';
 import { SendGridService } from '../sendgrid/sendgrid.service';
 import { HttpStatus } from '@nestjs/common';
-import { SENDGRID_TEMPLATES, SERVICE_NAME } from '../../common/constants';
+import {
+  SENDGRID_MESSAGES,
+  SENDGRID_TEMPLATES,
+  SERVICE_NAME,
+} from '../../common/constants';
 import { generateNonce, signMessage } from '../../common/utils/signature';
 import { Web3Service } from '../web3/web3.service';
 import { ChainId, KVStoreClient, KVStoreUtils } from '@human-protocol/sdk';
@@ -615,6 +619,7 @@ describe('AuthService', () => {
                 dynamicTemplateData: {
                   service_name: SERVICE_NAME,
                   url: expect.stringContaining('/verify?token='),
+                  preview: SENDGRID_MESSAGES.signup,
                 },
                 to: email,
               },

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -26,7 +26,11 @@ import { TokenRepository } from './token.repository';
 import { verifySignature } from '../../common/utils/signature';
 import { createHash } from 'crypto';
 import { SendGridService } from '../sendgrid/sendgrid.service';
-import { SENDGRID_TEMPLATES, SERVICE_NAME } from '../../common/constants';
+import {
+  SENDGRID_MESSAGES,
+  SENDGRID_TEMPLATES,
+  SERVICE_NAME,
+} from '../../common/constants';
 import { Web3Service } from '../web3/web3.service';
 import {
   ChainId,
@@ -125,6 +129,7 @@ export class AuthService {
           dynamicTemplateData: {
             service_name: SERVICE_NAME,
             url: `${this.serverConfigService.feURL}/verify?token=${tokenEntity.uuid}`,
+            preview: SENDGRID_MESSAGES.signup,
           },
         },
       ],
@@ -385,6 +390,7 @@ export class AuthService {
           dynamicTemplateData: {
             service_name: SERVICE_NAME,
             url: `${this.serverConfigService.feURL}/verify?token=${tokenEntity.uuid}`,
+            preview: SENDGRID_MESSAGES.signup,
           },
         },
       ],


### PR DESCRIPTION
## Description
Added message data to sendgrid template

## Summary of changes
- Updated signup template in Reputation Oracle server.
- Update send grid template to add `{{preview}}` in send grid dashboard.

## How test the changes
Sign up with active sendgrid ap key.

## Related issues
[Reputation Oracle] Preview emails
[#2531](https://github.com/humanprotocol/human-protocol/issues/2531)
