### PR TITLE
Add vercel config file to allow window.location.reload()

### DIFF
--- a/packages/apps/human-app/frontend/vercel.json
+++ b/packages/apps/human-app/frontend/vercel.json
@@ -1,0 +1,9 @@
+{
+    "rewrites": [
+      {
+        "source": "/(.*)",
+        "destination": "/index.html"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
## Description
Vercel  doesn't have server-side routing configured when `window.location.reload()` is called, resulting in a 404.

## Summary of changes

Add vercel.json to handle it.

## How test the changes

Check vercel preview

