### PR TITLE
[Fortune Exchange Oracle] Allow reassignation

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.ts
@@ -55,7 +55,10 @@ export class AssignmentService {
         jwtUser.address,
       );
 
-    if (assignmentEntity) {
+    if (
+      assignmentEntity &&
+      assignmentEntity.status !== AssignmentStatus.CANCELED
+    ) {
       this.logger.log(ErrorAssignment.AlreadyExists, AssignmentService.name);
       throw new BadRequestException(ErrorAssignment.AlreadyExists);
     }
@@ -91,6 +94,12 @@ export class AssignmentService {
     if (expirationDate < new Date()) {
       this.logger.log(ErrorAssignment.ExpiredEscrow, AssignmentService.name);
       throw new BadRequestException(ErrorAssignment.ExpiredEscrow);
+    }
+
+    // Allow reassignation when status is Canceled
+    if (assignmentEntity) {
+      assignmentEntity.status = AssignmentStatus.ACTIVE;
+      return this.assignmentRepository.updateOne(assignmentEntity);
     }
 
     const newAssignmentEntity = new AssignmentEntity();

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
@@ -34,7 +34,7 @@ export class JobsDiscoveryService {
     filters: JobsDiscoveryParamsCommand['data'],
   ): JobsDiscoveryResponseItem[] {
     const difference = Object.values(JobDiscoveryFieldName).filter(
-      (value) => !filters.fields.includes(value),
+      (value) => !filters.fields?.includes(value),
     );
     return jobs
       .filter((job) => {


### PR DESCRIPTION
## Description

Allow a user that canceled an assignment be able to get the assignation again

## Summary of changes

Allow reassignation only when status is `Canceled`

## How test the changes

- Create a new assignation
- Cancel it
- Try to assign it again

## Related issues
#2559