### PR TITLE
[Human App] Change the way assignments stored in Redis

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged
 
 # Format python file changes

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "concurrently \"yarn workspace @human-protocol/core test\" \"yarn workspace @human-protocol/sdk test\" \"yarn workspace @human-protocol/subgraph test\" \"yarn workspace @human-protocol/dashboard-ui test\" \"yarn workspace @human-protocol/faucet-server test\" \"yarn workspace @human-protocol/job-launcher-server test\" \"yarn workspace @human-protocol/job-launcher-client test\" \"yarn workspace @human-protocol/human-app-server test\" \"yarn workspace @human-protocol/reputation-oracle test\" \"yarn workspace @human-protocol/fortune-exchange-oracle-server test\" \"yarn workspace @human-protocol/fortune-recording-oracle test\"",
     "lint": "concurrently \"yarn workspace @human-protocol/core lint\" \"yarn workspace @human-protocol/sdk lint\" \"yarn workspace @human-protocol/subgraph lint\" \"yarn workspace @human-protocol/dashboard-ui lint\" \"yarn workspace @human-protocol/faucet-server lint\" \"yarn workspace @human-protocol/job-launcher-server lint\" \"yarn workspace @human-protocol/job-launcher-client lint\" \"yarn workspace @human-protocol/human-app-server lint\" \"yarn workspace @human-protocol/reputation-oracle lint\" \"yarn workspace @human-protocol/fortune-exchange-oracle-server lint\" \"yarn workspace @human-protocol/fortune-recording-oracle lint\"",
-    "prepare": "husky install",
+    "prepare": "husky",
     "postinstall": "yarn workspace @human-protocol/sdk build"
   },
   "workspaces": {

--- a/packages/apps/human-app/server/.eslintrc.js
+++ b/packages/apps/human-app/server/.eslintrc.js
@@ -22,5 +22,14 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     'linebreak-style': 0,
+    '@typescript-eslint/no-unused-vars': ['error', {
+      "args": "all",
+      "argsIgnorePattern": "^_",
+      "caughtErrors": "all",
+      "caughtErrorsIgnorePattern": "^_",
+      "destructuredArrayIgnorePattern": "^_",
+      "varsIgnorePattern": "^_",
+      "ignoreRestSiblings": true
+    }],
   },
 };

--- a/packages/apps/human-app/server/.gitignore
+++ b/packages/apps/human-app/server/.gitignore
@@ -35,7 +35,7 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 # Redis Data
-./redis_data
+/redis_data
 
 .env.development
 .env.production

--- a/packages/apps/human-app/server/src/app.module.ts
+++ b/packages/apps/human-app/server/src/app.module.ts
@@ -42,6 +42,8 @@ import { CronJobModule } from './modules/cron-job/cron-job.module';
 import { EnvironmentConfigService } from './common/config/environment-config.service';
 import { ForbidUnauthorizedHostMiddleware } from './common/middleware/host-check.middleware';
 
+const JOI_BOOLEAN_STRING_SCHEMA = Joi.string().valid('true', 'false');
+
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -71,7 +73,24 @@ import { ForbidUnauthorizedHostMiddleware } from './common/middleware/host-check
             return value;
           })
           .required(),
+        HUMAN_APP_EMAIL: Joi.string().email().required(),
+        HUMAN_APP_PASSWORD: Joi.string().required(),
+        IS_AXIOS_REQUEST_LOGGING_ENABLED: JOI_BOOLEAN_STRING_SCHEMA,
         ALLOWED_HOST: Joi.string().required(),
+        CORS_ENABLED: JOI_BOOLEAN_STRING_SCHEMA,
+        CORS_ALLOWED_ORIGIN: Joi.string(),
+        CORS_ALLOWED_HEADERS: Joi.string(),
+        IS_CACHE_TO_RESTART: JOI_BOOLEAN_STRING_SCHEMA,
+        CACHE_TTL_ORACLE_STATS: Joi.number(),
+        CACHE_TTL_USER_STATS: Joi.number(),
+        CACHE_TTL_DAILY_HMT_SPENT: Joi.number(),
+        CACHE_TTL_HCAPTCHA_USER_STATS: Joi.number(),
+        CACHE_TTL_ORACLE_DISCOVERY: Joi.number(),
+        CACHE_TTL_JOB_ASSIGNMENTS: Joi.number(),
+        CACHE_TTL_EXCHANGE_ORACLE_URL: Joi.number(),
+        CACHE_TTL_EXCHANGE_ORACLE_REGISTRATION_NEEDED: Joi.number(),
+        MAX_REQUEST_RETRIES: Joi.number(),
+        FEATURE_FLAG_JOBS_DISCOVERY: JOI_BOOLEAN_STRING_SCHEMA,
       }),
     }),
     AutomapperModule.forRoot({

--- a/packages/apps/human-app/server/src/common/config/environment-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.ts
@@ -5,6 +5,7 @@ const DEFAULT_CACHE_TTL_HCAPTCHA_USER_STATS = 12 * 60 * 60;
 const DEFAULT_CACHE_TTL_ORACLE_STATS = 12 * 60 * 60;
 const DEFAULT_CACHE_TTL_USER_STATS = 15 * 60;
 const DEFAULT_CACHE_TTL_ORACLE_DISCOVERY = 24 * 60 * 60;
+const DEFAULT_CACHE_TTL_JOB_ASSIGNMENTS = 45 * 24 * 60 * 60;
 const DEFAULT_CACHE_TTL_DAILY_HMT_SPENT = 24 * 60 * 60;
 const DEFAULT_CORS_ALLOWED_ORIGIN = 'http://localhost:5173';
 const DEFAULT_CORS_ALLOWED_HEADERS =
@@ -137,6 +138,17 @@ export class EnvironmentConfigService {
     return this.configService.get<number>(
       'CACHE_TTL_ORACLE_DISCOVERY',
       DEFAULT_CACHE_TTL_ORACLE_DISCOVERY,
+    );
+  }
+
+  /**
+   * The cache time-to-live (TTL) for user job assignments.
+   * Default: 45 days
+   */
+  get cacheTtlJobAssignments(): number {
+    return this.configService.get<number>(
+      'CACHE_TTL_JOB_ASSIGNMENTS',
+      DEFAULT_CACHE_TTL_JOB_ASSIGNMENTS,
     );
   }
 

--- a/packages/apps/human-app/server/src/common/config/params-decorators.ts
+++ b/packages/apps/human-app/server/src/common/config/params-decorators.ts
@@ -11,7 +11,7 @@ import { JwtUserData } from '../utils/jwt-token.model';
 const logger = new Logger('JwtPayloadDecorator');
 
 export const Authorization = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext) => {
+  (_data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
     const token = request.headers['authorization'];
     if (token) {
@@ -22,7 +22,7 @@ export const Authorization = createParamDecorator(
 );
 
 export const JwtPayload = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext): any => {
+  (_data: unknown, ctx: ExecutionContext): any => {
     const request = ctx.switchToHttp().getRequest();
     const token = request.headers['authorization']?.split(' ')[1];
     if (!token) {

--- a/packages/apps/human-app/server/src/common/middleware/host-check.middleware.ts
+++ b/packages/apps/human-app/server/src/common/middleware/host-check.middleware.ts
@@ -6,7 +6,7 @@ import { EnvironmentConfigService } from '../config/environment-config.service';
 export class ForbidUnauthorizedHostMiddleware implements NestMiddleware {
   constructor(private readonly envConfigService: EnvironmentConfigService) {}
 
-  use(req: Request, res: Response, next: NextFunction) {
+  use(req: Request, _res: Response, next: NextFunction) {
     const allowedHost = this.envConfigService.allowedHost;
     const requestHost = req.get('host');
 

--- a/packages/apps/human-app/server/src/common/utils/gateway-common.utils.ts
+++ b/packages/apps/human-app/server/src/common/utils/gateway-common.utils.ts
@@ -2,7 +2,7 @@ import { instanceToPlain } from 'class-transformer';
 
 function cleanParams(obj: any): any {
   return Object.entries(obj)
-    .filter(([_, v]) => v != null)
+    .filter(([_k, v]) => v != null)
     .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
 }
 export function toCleanObjParams(params: any, existingParams: any = {}): any {

--- a/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.gateway.ts
@@ -1,4 +1,4 @@
-import { HttpException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AxiosRequestConfig } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import {

--- a/packages/apps/human-app/server/src/modules/job-assignment/job-assignment.service.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/job-assignment.service.ts
@@ -29,6 +29,10 @@ export class JobAssignmentService {
     return decoded.wallet_address;
   }
 
+  private makeJobAssignmentCacheKey(userWalledAddress: string, oracleAddress: string): string {
+    return `${JOB_ASSIGNMENT_CACHE_KEY}:${userWalledAddress}:${oracleAddress}`;
+  }
+
   async processJobAssignment(
     command: JobAssignmentCommand,
   ): Promise<JobAssignmentResponse> {
@@ -67,7 +71,7 @@ export class JobAssignmentService {
     command: JobsFetchParamsCommand,
   ): Promise<JobsFetchResponse> {
     const evmAddress = this.getEvmAddressFromToken(command.token);
-    const cacheKey = `${JOB_ASSIGNMENT_CACHE_KEY}:${evmAddress}`;
+    const cacheKey = this.makeJobAssignmentCacheKey(evmAddress, command.oracleAddress);
 
     const cachedData =
       await this.cacheManager.get<JobsFetchResponseItem[]>(cacheKey);
@@ -96,7 +100,7 @@ export class JobAssignmentService {
     command: JobsFetchParamsCommand,
     evmAddress: string,
   ): Promise<void> {
-    const cacheKey = `${JOB_ASSIGNMENT_CACHE_KEY}:${evmAddress}`;
+    const cacheKey = this.makeJobAssignmentCacheKey(evmAddress, command.oracleAddress);
 
     const cachedData =
       await this.cacheManager.get<JobsFetchResponseItem[]>(cacheKey);

--- a/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.fixtures.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.fixtures.ts
@@ -18,7 +18,7 @@ import {
   SortOrder,
 } from '../../../common/enums/global-common';
 const EXCHANGE_ORACLE_URL = 'https://www.example.com/api';
-const EXCHANGE_ORACLE_ADDRESS = '0x34df642';
+export const EXCHANGE_ORACLE_ADDRESS = '0x34df642';
 const ESCROW_ADDRESS = 'test_address';
 const CHAIN_ID = 1;
 const JOB_TYPE = 'FORTUNE';

--- a/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.service.spec.ts
@@ -5,14 +5,14 @@ import {
   jobAssignmentCommandFixture,
   jobsFetchParamsCommandFixture,
   jobsFetchResponseFixture,
+  EXCHANGE_ORACLE_ADDRESS,
   USER_ADDRESS,
 } from './job-assignment.fixtures';
 import { EscrowUtilsGateway } from '../../../integrations/escrow/escrow-utils-gateway.service';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ResignJobCommand } from '../model/job-assignment.model';
-import { JOB_ASSIGNMENT_CACHE_KEY } from '../../../common/constants/cache';
 
-const cacheKey = `${JOB_ASSIGNMENT_CACHE_KEY}:${USER_ADDRESS}`;
+const cacheKey = `jobs:assigned:${USER_ADDRESS}:${EXCHANGE_ORACLE_ADDRESS}`;
 describe('JobAssignmentService', () => {
   let service: JobAssignmentService;
   let exchangeOracleGatewayMock: Partial<ExchangeOracleGateway>;

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -2,7 +2,12 @@ import { JobsDiscoveryService } from '../jobs-discovery.service';
 import { JobsDiscoveryController } from '../jobs-discovery.controller';
 import { Test, TestingModule } from '@nestjs/testing';
 import { jobsDiscoveryServiceMock } from './jobs-discovery.service.mock';
-import { responseFixture } from './jobs-discovery.fixtures';
+import {
+  // jobsDiscoveryParamsCommandFixture,
+  // dtoFixture,
+  // jobDiscoveryToken,
+  responseFixture,
+} from './jobs-discovery.fixtures';
 import { AutomapperModule } from '@automapper/nestjs';
 import { classes } from '@automapper/classes';
 import { JobsDiscoveryProfile } from '../jobs-discovery.mapper.profile';
@@ -13,6 +18,7 @@ import { EnvironmentConfigService } from '../../../common/config/environment-con
 
 describe('JobsDiscoveryController', () => {
   let controller: JobsDiscoveryController;
+  // let jobsDiscoveryService: JobsDiscoveryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,9 +54,22 @@ describe('JobsDiscoveryController', () => {
       .compile();
 
     controller = module.get<JobsDiscoveryController>(JobsDiscoveryController);
+    // jobsDiscoveryService =
+    //   module.get<JobsDiscoveryService>(JobsDiscoveryService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  // describe('processJobsDiscovery', () => {
+  //   it('should call service processJobsDiscovery method with proper fields set', async () => {
+  //     const dto = dtoFixture;
+  //     const command = jobsDiscoveryParamsCommandFixture;
+  //     await controller.getJobs(dto, jobDiscoveryToken);
+  //     expect(jobsDiscoveryService.processJobsDiscovery).toHaveBeenCalledWith(
+  //       command,
+  //     );
+  //   });
+  // });
 });

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -2,12 +2,7 @@ import { JobsDiscoveryService } from '../jobs-discovery.service';
 import { JobsDiscoveryController } from '../jobs-discovery.controller';
 import { Test, TestingModule } from '@nestjs/testing';
 import { jobsDiscoveryServiceMock } from './jobs-discovery.service.mock';
-import {
-  jobsDiscoveryParamsCommandFixture,
-  dtoFixture,
-  jobDiscoveryToken,
-  responseFixture,
-} from './jobs-discovery.fixtures';
+import { responseFixture } from './jobs-discovery.fixtures';
 import { AutomapperModule } from '@automapper/nestjs';
 import { classes } from '@automapper/classes';
 import { JobsDiscoveryProfile } from '../jobs-discovery.mapper.profile';
@@ -18,7 +13,6 @@ import { EnvironmentConfigService } from '../../../common/config/environment-con
 
 describe('JobsDiscoveryController', () => {
   let controller: JobsDiscoveryController;
-  let jobsDiscoveryService: JobsDiscoveryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -54,22 +48,9 @@ describe('JobsDiscoveryController', () => {
       .compile();
 
     controller = module.get<JobsDiscoveryController>(JobsDiscoveryController);
-    jobsDiscoveryService =
-      module.get<JobsDiscoveryService>(JobsDiscoveryService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
-
-  // describe('processJobsDiscovery', () => {
-  //   it('should call service processJobsDiscovery method with proper fields set', async () => {
-  //     const dto = dtoFixture;
-  //     const command = jobsDiscoveryParamsCommandFixture;
-  //     await controller.getJobs(dto, jobDiscoveryToken);
-  //     expect(jobsDiscoveryService.processJobsDiscovery).toHaveBeenCalledWith(
-  //       command,
-  //     );
-  //   });
-  // });
 });

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -4,12 +4,6 @@ import { classes } from '@automapper/classes';
 import { OracleDiscoveryController } from '../oracle-discovery.controller';
 import { OracleDiscoveryService } from '../oracle-discovery.service';
 import { oracleDiscoveryServiceMock } from './oracle-discovery.service.mock';
-import {
-  OracleDiscoveryCommand,
-  OracleDiscoveryDto,
-  OracleDiscoveryResponse,
-} from '../model/oracle-discovery.model';
-import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
 import { CommonConfigModule } from '../../../common/config/common-config.module';
@@ -17,7 +11,6 @@ import { ConfigModule } from '@nestjs/config';
 
 describe('OracleDiscoveryController', () => {
   let controller: OracleDiscoveryController;
-  let serviceMock: OracleDiscoveryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -45,28 +38,9 @@ describe('OracleDiscoveryController', () => {
     controller = module.get<OracleDiscoveryController>(
       OracleDiscoveryController,
     );
-    serviceMock = module.get<OracleDiscoveryService>(OracleDiscoveryService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
-
-  // describe('oracle discovery', () => {
-  //   it('oracle discovery should be return OracleDiscoveryData', async () => {
-  //     const dtoFixture = {
-  //       selected_job_types: ['job-type-1', 'job-type-2'],
-  //     } as OracleDiscoveryDto;
-  //     const commandFixture = {
-  //       selectedJobTypes: ['job-type-1', 'job-type-2'],
-  //     } as OracleDiscoveryCommand;
-  //     const result: OracleDiscoveryResponse[] =
-  //       await controller.getOracles(dtoFixture);
-  //     const expectedResponse = generateOracleDiscoveryResponseBody();
-  //     expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(
-  //       commandFixture,
-  //     );
-  //     expect(result).toEqual(expectedResponse);
-  //   });
-  // });
 });

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -4,6 +4,12 @@ import { classes } from '@automapper/classes';
 import { OracleDiscoveryController } from '../oracle-discovery.controller';
 import { OracleDiscoveryService } from '../oracle-discovery.service';
 import { oracleDiscoveryServiceMock } from './oracle-discovery.service.mock';
+// import {
+//   OracleDiscoveryCommand,
+//   OracleDiscoveryDto,
+//   OracleDiscoveryResponse,
+// } from '../model/oracle-discovery.model';
+// import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
 import { CommonConfigModule } from '../../../common/config/common-config.module';
@@ -11,6 +17,7 @@ import { ConfigModule } from '@nestjs/config';
 
 describe('OracleDiscoveryController', () => {
   let controller: OracleDiscoveryController;
+  // let serviceMock: OracleDiscoveryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -38,9 +45,28 @@ describe('OracleDiscoveryController', () => {
     controller = module.get<OracleDiscoveryController>(
       OracleDiscoveryController,
     );
+    // serviceMock = module.get<OracleDiscoveryService>(OracleDiscoveryService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  // describe('oracle discovery', () => {
+  //   it('oracle discovery should be return OracleDiscoveryData', async () => {
+  //     const dtoFixture = {
+  //       selected_job_types: ['job-type-1', 'job-type-2'],
+  //     } as OracleDiscoveryDto;
+  //     const commandFixture = {
+  //       selectedJobTypes: ['job-type-1', 'job-type-2'],
+  //     } as OracleDiscoveryCommand;
+  //     const result: OracleDiscoveryResponse[] =
+  //       await controller.getOracles(dtoFixture);
+  //     const expectedResponse = generateOracleDiscoveryResponseBody();
+  //     expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(
+  //       commandFixture,
+  //     );
+  //     expect(result).toEqual(expectedResponse);
+  //   });
+  // });
 });

--- a/packages/apps/human-app/server/src/modules/user-worker/spec/worker.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/user-worker/spec/worker.service.spec.ts
@@ -9,7 +9,6 @@ import { exchangeOracleGatewayMock } from '../../../integrations/exchange-oracle
 describe('WorkerService', () => {
   let service: WorkerService;
   let reputationOracleGateway: ReputationOracleGateway;
-  let exchangeOracleGateway: ExchangeOracleGateway;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,9 +27,6 @@ describe('WorkerService', () => {
     service = module.get<WorkerService>(WorkerService);
     reputationOracleGateway = module.get<ReputationOracleGateway>(
       ReputationOracleGateway,
-    );
-    exchangeOracleGateway = module.get<ExchangeOracleGateway>(
-      ExchangeOracleGateway,
     );
   });
 


### PR DESCRIPTION
## Description
Changing the way we store user's job assignments in Redis in order to avoid bloating the cached data up to the limits.

## Summary of changes
1. Use new format of key, including oracle address as well. This will help us to reduce the amount of stored data per item easily w/ no extra effort. Access pattern for "My Jobs" now always includes oracle address, so no extra manipulation needed.
2. Added retention policy for stored job assignments data
   - when updating assignments cache we filter out "expired" assignments and fetch updates from oracle according to retention policy
   - when fetching assignments for the first time (when cache is empty) instead of fetching everything we will fetch only "recent" assignments according to retention policy; it should ease cases when cache is invalidated
   - retention policy is configurable via `CACHE_TTL_JOB_ASSIGNMENTS` env variable with default value of 45 days
3. Fixed `.gitignore` file for local redis_data
4. Updated linter config for `human-app/server` and cleaned up warnings
5. Added basic Joi schema for missing env vars

## How test the changes
- [x] unit test
- [x] set `CACHE_TTL_JOB_ASSIGNMENTS` to some "recent" value (e.g. 1 day), remove existing data from Redis, open "My Jobs" tab and make sure that only assignments up to "recent" date are loaded
- [x] manually update `updated_at` value in cache for some assignment; assign/resign job to trigger cache update, make sure that updated item is no longer in cache

## How to release the changes
1. Deploy new version
2. Cleanup old keys

But taking into account that feature is not released yet, it would be easier to run `FLUSHALL` command on corresponding Redis clusters (stg & prd)

## Related issues
https://github.com/humanprotocol/human-protocol/issues/2574
