### PR TITLE
fix build error in job launcher server

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -171,3 +171,10 @@ export enum ErrorQualification {
   FailedToFetchQualifications = 'Failed to fetch qualifications',
   InvalidQualification = `Invalid qualification`,
 }
+
+/**
+ * Represents error messages associated with encryption.
+ */
+export enum ErrorEncryption {
+  MissingPrivateKey = 'Encryption private key cannot be empty, when it is enabled',
+}


### PR DESCRIPTION
## Description

Nullable value cannot be used as private key

## Summary of changes

Handle error of possible private key empty when encryption is enabled

