### PR TITLE
[HUMAN App] Fixed job type filter 

### DIFF
--- a/packages/apps/human-app/frontend/.env.example
+++ b/packages/apps/human-app/frontend/.env.example
@@ -36,6 +36,8 @@ VITE_DAPP_META_DESCRIPTION= #string
 VITE_DAPP_META_URL= #string 
 # Dapp icons for wallet connect 
 VITE_DAPP_ICONS= #string => lists of icons eg.: icon1,icon2...
+# Feature flag to enable or disable jobs discovery functionality
+VITE_FEATURE_FLAG_JOBS_DISCOVERY= #boolean (true/false)
 
 # network if network is equl to 'testnet' app will use first tesntet chain from .src/smart-contracts/chains.ts
 # and first mainnet chain for 'mainnet'

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
@@ -126,9 +126,10 @@ describe('OracleDiscoveryService', () => {
 
     expect(result).toEqual([mockData[0]]);
     EXPECTED_CHAIN_IDS.forEach((chainId) => {
-      expect(cacheManager.get).toHaveBeenCalledWith(chainId);
+      const cacheKey = `${chainId}-all`;
+      expect(cacheManager.get).toHaveBeenCalledWith(cacheKey);
       expect(cacheManager.set).toHaveBeenCalledWith(
-        chainId,
+        cacheKey,
         [mockData[0]],
         TTL,
       );
@@ -188,7 +189,8 @@ describe('OracleDiscoveryService', () => {
 
     expect(result).toEqual([]);
     EXPECTED_CHAIN_IDS.forEach((chainId) => {
-      expect(cacheManager.get).toHaveBeenCalledWith(chainId);
+      const cacheKey = `${chainId}-all`;
+      expect(cacheManager.get).toHaveBeenCalledWith(cacheKey);
     });
   });
 


### PR DESCRIPTION
## Description
The issue is due to the fact that the cache stores the entire list of oracles without considering the `selectedJobTypes`. When we change the filter (`selectedJobTypes`), it still returns the cached result, which doesn't account for the new filter. To fix this, I have been included `selectedJobTypes` as part of the cache key.

## Summary of changes
- Modified the cache key to include the `selectedJobTypes` in addition to the chainId. This way, each combination of chainId and `selectedJobTypes` cached separately.
- Updated `findOraclesByChainId`.
- Update unit tests

## How test the changes
`yarn test`
```bash
curl -X 'GET' \
  'http://127.0.0.1:5000/oracles?selected_job_types=fortune' \
  -H 'accept: */*'
```

## Related issues
[HUMAN App] Job type filter not working
[#2556](https://github.com/humanprotocol/human-protocol/issues/2556)
