### PR TITLE
[Job Launcher] Get qualifications issue

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -69,16 +69,18 @@ export const CvatJobRequestForm = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        setQualificationsOptions(await getQualifications());
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching data:', error);
+      if (jobRequest.chainId !== undefined) {
+        try {
+          setQualificationsOptions(await getQualifications(jobRequest.chainId));
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Error fetching data:', error);
+        }
       }
     };
 
     fetchData();
-  }, []);
+  }, [jobRequest.chainId]);
 
   const handleChange =
     (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
@@ -40,16 +40,18 @@ export const FortuneJobRequestForm = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        setQualificationsOptions(await getQualifications());
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching data:', error);
+      if (jobRequest.chainId !== undefined) {
+        try {
+          setQualificationsOptions(await getQualifications(jobRequest.chainId));
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Error fetching data:', error);
+        }
       }
     };
 
     fetchData();
-  }, []);
+  }, [jobRequest.chainId]);
 
   const handleChange =
     (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
@@ -134,17 +134,18 @@ export const HCaptchaJobRequestForm = () => {
       setFieldValue('type', type);
     }
     const fetchData = async () => {
-      try {
-        setQualificationsOptions(await getQualifications());
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching data:', error);
+      if (jobRequest.chainId !== undefined) {
+        try {
+          setQualificationsOptions(await getQualifications(jobRequest.chainId));
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Error fetching data:', error);
+        }
       }
     };
 
     fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [jobRequest.chainId]);
 
   return (
     <Box mt="42px">

--- a/packages/apps/job-launcher/client/src/services/qualification.ts
+++ b/packages/apps/job-launcher/client/src/services/qualification.ts
@@ -1,7 +1,11 @@
+import { ChainId } from '@human-protocol/sdk';
 import { Qualification } from '../types';
 import api from '../utils/api';
 
-export const getQualifications = async () => {
-  const { data } = await api.get<Qualification[]>(`/qualification`);
+export const getQualifications = async (chainId: ChainId) => {
+  const { data } = await api.get<Qualification[]>(`/qualification`, {
+    params: { chainId },
+  });
+
   return data;
 };

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -768,7 +768,7 @@ export class JobService {
 
     if (dto.qualifications) {
       const validQualifications =
-        await this.qualificationService.getQualifications();
+        await this.qualificationService.getQualifications(chainId);
 
       const validQualificationReferences = validQualifications.map(
         (q) => q.reference,

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.controller.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { QualificationController } from './qualification.controller';
 import { QualificationService } from './qualification.service';
 import { QualificationDto } from './qualification.dto';
+import { ChainId } from '@human-protocol/sdk';
 
 describe('QualificationController', () => {
   let qualificationController: QualificationController;
@@ -42,7 +43,9 @@ describe('QualificationController', () => {
         .spyOn(qualificationService, 'getQualifications')
         .mockResolvedValue(result);
 
-      expect(await qualificationController.getQualifications()).toBe(result);
+      expect(
+        await qualificationController.getQualifications(ChainId.LOCALHOST),
+      ).toBe(result);
       expect(qualificationService.getQualifications).toHaveBeenCalled();
     });
   });

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.controller.ts
@@ -1,13 +1,15 @@
-import { Controller, Get, HttpCode, UseGuards } from '@nestjs/common';
+import { Controller, Get, HttpCode, Query, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiTags,
   ApiOperation,
   ApiResponse,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { QualificationService } from './qualification.service';
 import { QualificationDto } from './qualification.dto';
 import { JwtAuthGuard } from '../../common/guards';
+import { ChainId } from '@human-protocol/sdk';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -21,8 +23,20 @@ export class QualificationController {
   @ApiOperation({
     summary: 'Get list of qualifications from Reputation Oracle',
   })
-  @ApiResponse({ status: 200, description: 'List of qualifications' })
-  getQualifications(): Promise<QualificationDto[]> {
-    return this.qualificationService.getQualifications();
+  @ApiResponse({
+    status: 200,
+    description: 'List of qualifications',
+    type: [QualificationDto],
+  })
+  @ApiQuery({
+    name: 'chainId',
+    required: true,
+    type: String,
+    description: 'The chain ID to get qualifications',
+  })
+  getQualifications(
+    @Query('chainId') chainId: ChainId,
+  ): Promise<QualificationDto[]> {
+    return this.qualificationService.getQualifications(chainId);
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.dto.ts
@@ -1,6 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class QualificationDto {
+  @ApiProperty({
+    type: String,
+  })
   public reference: string;
+
+  @ApiProperty({
+    type: String,
+  })
   public title: string;
+
+  @ApiProperty({
+    type: String,
+  })
   public description: string;
+
+  @ApiProperty({
+    type: Date,
+  })
   public expiresAt?: Date | null;
 }

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.spec.ts
@@ -88,7 +88,9 @@ describe.only('QualificationService', () => {
           }) as any,
       );
 
-      const result = await qualificationService.getQualifications();
+      const result = await qualificationService.getQualifications(
+        ChainId.LOCALHOST,
+      );
 
       expect(result).toEqual(qualifications);
     });
@@ -96,7 +98,9 @@ describe.only('QualificationService', () => {
     it('should throw a ControlledError when KVStoreUtils.get fails', async () => {
       (KVStoreUtils.get as any).mockRejectedValue(new Error('KV store error'));
 
-      await expect(qualificationService.getQualifications()).rejects.toThrow(
+      await expect(
+        qualificationService.getQualifications(ChainId.LOCALHOST),
+      ).rejects.toThrow(
         new ControlledError(
           ErrorWeb3.ReputationOracleUrlNotSet,
           HttpStatus.BAD_REQUEST,
@@ -111,7 +115,9 @@ describe.only('QualificationService', () => {
         .spyOn(httpService, 'get')
         .mockImplementation(() => throwError(new Error('HTTP error')) as any);
 
-      await expect(qualificationService.getQualifications()).rejects.toThrow(
+      await expect(
+        qualificationService.getQualifications(ChainId.LOCALHOST),
+      ).rejects.toThrow(
         new ControlledError(
           ErrorQualification.FailedToFetchQualifications,
           HttpStatus.BAD_REQUEST,

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.spec.ts
@@ -14,6 +14,7 @@ import { ControlledError } from '../../common/errors/controlled';
 import { ErrorQualification, ErrorWeb3 } from '../../common/constants/errors';
 import { HttpStatus } from '@nestjs/common';
 import { NetworkConfigService } from '../../common/config/network-config.service';
+import { Web3Service } from '../web3/web3.service';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -42,6 +43,7 @@ describe.only('QualificationService', () => {
         },
         QualificationService,
         Web3ConfigService,
+        Web3Service,
         NetworkConfigService,
         {
           provide: HttpService,
@@ -122,6 +124,20 @@ describe.only('QualificationService', () => {
           ErrorQualification.FailedToFetchQualifications,
           HttpStatus.BAD_REQUEST,
         ),
+      );
+    });
+
+    it('should throw a ControlledError when invalid chainId', async () => {
+      (KVStoreUtils.get as any).mockResolvedValue(MOCK_REPUTATION_ORACLE_URL);
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementation(() => throwError(new Error('HTTP error')) as any);
+
+      await expect(
+        qualificationService.getQualifications(ChainId.MAINNET),
+      ).rejects.toThrow(
+        new ControlledError(ErrorWeb3.InvalidChainId, HttpStatus.BAD_REQUEST),
       );
     });
   });

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.ts
@@ -6,6 +6,7 @@ import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ControlledError } from '../../common/errors/controlled';
 import { ErrorQualification, ErrorWeb3 } from '../../common/constants/errors';
 import { ChainId, KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
+import { Web3Service } from '../web3/web3.service';
 
 @Injectable()
 export class QualificationService {
@@ -14,6 +15,7 @@ export class QualificationService {
   constructor(
     private httpService: HttpService,
     private readonly web3ConfigService: Web3ConfigService,
+    private readonly web3Service: Web3Service,
   ) {}
 
   public async getQualifications(
@@ -21,6 +23,8 @@ export class QualificationService {
   ): Promise<QualificationDto[]> {
     try {
       let reputationOracleUrl = '';
+
+      this.web3Service.validateChainId(chainId);
 
       try {
         reputationOracleUrl = await KVStoreUtils.get(

--- a/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/qualification/qualification.service.ts
@@ -5,8 +5,7 @@ import { HttpService } from '@nestjs/axios';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ControlledError } from '../../common/errors/controlled';
 import { ErrorQualification, ErrorWeb3 } from '../../common/constants/errors';
-import { KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
-import { NetworkConfigService } from '../../common/config/network-config.service';
+import { ChainId, KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
 
 @Injectable()
 export class QualificationService {
@@ -15,16 +14,17 @@ export class QualificationService {
   constructor(
     private httpService: HttpService,
     private readonly web3ConfigService: Web3ConfigService,
-    private readonly networkConfigService: NetworkConfigService,
   ) {}
 
-  public async getQualifications(): Promise<QualificationDto[]> {
+  public async getQualifications(
+    chainId: ChainId,
+  ): Promise<QualificationDto[]> {
     try {
       let reputationOracleUrl = '';
 
       try {
         reputationOracleUrl = await KVStoreUtils.get(
-          this.networkConfigService.networks[0].chainId,
+          chainId,
           this.web3ConfigService.reputationOracleAddress,
           KVStoreKeys.url,
         );


### PR DESCRIPTION
## Description

Get the qualifications using the chain id selected to create the escrow.
The endpoint in frontend should be loaded after selecting the network.

## Summary of changes

Added chainId to getQualifications methods
Modify frontend to load values after selecting the network

## How test the changes

Try to create a new job. Qualifications should be loaded after selecting the network

## Related issues
#2593
