### PR TITLE
[Human App] Enable JobDiscovery tests

### DIFF
--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -14,6 +14,14 @@ import { JobStatus } from '../../../common/enums/global-common';
 import { OracleDiscoveryResponse } from '../../../modules/oracle-discovery/model/oracle-discovery.model';
 import { SchedulerRegistry } from '@nestjs/schedule';
 
+jest.mock('cron', () => {
+  return {
+    CronJob: jest.fn().mockImplementation(() => ({
+      start: jest.fn(),
+    })),
+  };
+});
+
 describe('CronJobService', () => {
   let service: CronJobService;
   let exchangeOracleGatewayMock: Partial<ExchangeOracleGateway>;
@@ -68,6 +76,46 @@ describe('CronJobService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('CronJobService - Cron Job Initialization', () => {
+    const schedulerRegistryMock: any = {
+      addCronJob: jest.fn(),
+    };
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should initialize the cron job if jobsDiscoveryFlag is true', () => {
+      (configServiceMock as any).jobsDiscoveryFlag = true;
+
+      service = new CronJobService(
+        exchangeOracleGatewayMock as ExchangeOracleGateway,
+        cacheManagerMock,
+        configServiceMock as any,
+        oracleDiscoveryServiceMock as OracleDiscoveryService,
+        workerServiceMock as WorkerService,
+        schedulerRegistryMock,
+      );
+
+      expect(schedulerRegistryMock.addCronJob).toHaveBeenCalled();
+    });
+
+    it('should not initialize the cron job if jobsDiscoveryFlag is false', () => {
+      (configServiceMock as any).jobsDiscoveryFlag = false;
+
+      service = new CronJobService(
+        exchangeOracleGatewayMock as ExchangeOracleGateway,
+        cacheManagerMock,
+        configServiceMock as any,
+        oracleDiscoveryServiceMock as OracleDiscoveryService,
+        workerServiceMock as WorkerService,
+        schedulerRegistryMock,
+      );
+
+      expect(schedulerRegistryMock.addCronJob).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateJobsListCron', () => {

--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -45,6 +45,7 @@ describe('CronJobService', () => {
       password: 'Test1234*',
       cacheTtlOracleDiscovery: 600,
       chainIdsEnabled: ['137', '1'],
+      jobsDiscoveryFlag: false,
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -15,7 +15,6 @@ import { HttpService } from '@nestjs/axios';
 import { CommonConfigModule } from '../../../common/config/common-config.module';
 import { ConfigModule } from '@nestjs/config';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
-import { JwtUserData } from 'src/common/utils/jwt-token.model';
 
 describe('JobsDiscoveryController', () => {
   let controller: JobsDiscoveryController;

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -88,7 +88,7 @@ describe('JobsDiscoveryController', () => {
     it('should throw an error if jobsDiscoveryFlag is disabled', async () => {
       const dto = dtoFixture;
       (configServiceMock as any).jobsDiscoveryFlag = false;
-      expect(
+      await expect(
         controller.getJobs(
           dto,
           { qualifications: [] } as any,

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -3,9 +3,9 @@ import { JobsDiscoveryController } from '../jobs-discovery.controller';
 import { Test, TestingModule } from '@nestjs/testing';
 import { jobsDiscoveryServiceMock } from './jobs-discovery.service.mock';
 import {
-  // jobsDiscoveryParamsCommandFixture,
-  // dtoFixture,
-  // jobDiscoveryToken,
+  jobsDiscoveryParamsCommandFixture,
+  dtoFixture,
+  jobDiscoveryToken,
   responseFixture,
 } from './jobs-discovery.fixtures';
 import { AutomapperModule } from '@automapper/nestjs';
@@ -15,10 +15,11 @@ import { HttpService } from '@nestjs/axios';
 import { CommonConfigModule } from '../../../common/config/common-config.module';
 import { ConfigModule } from '@nestjs/config';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
+import { JwtUserData } from 'src/common/utils/jwt-token.model';
 
 describe('JobsDiscoveryController', () => {
   let controller: JobsDiscoveryController;
-  // let jobsDiscoveryService: JobsDiscoveryService;
+  let jobsDiscoveryService: JobsDiscoveryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -54,22 +55,27 @@ describe('JobsDiscoveryController', () => {
       .compile();
 
     controller = module.get<JobsDiscoveryController>(JobsDiscoveryController);
-    // jobsDiscoveryService =
-    //   module.get<JobsDiscoveryService>(JobsDiscoveryService);
+    jobsDiscoveryService =
+      module.get<JobsDiscoveryService>(JobsDiscoveryService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
-  // describe('processJobsDiscovery', () => {
-  //   it('should call service processJobsDiscovery method with proper fields set', async () => {
-  //     const dto = dtoFixture;
-  //     const command = jobsDiscoveryParamsCommandFixture;
-  //     await controller.getJobs(dto, jobDiscoveryToken);
-  //     expect(jobsDiscoveryService.processJobsDiscovery).toHaveBeenCalledWith(
-  //       command,
-  //     );
-  //   });
-  // });
+  describe('processJobsDiscovery', () => {
+    it('should call service processJobsDiscovery method with proper fields set', async () => {
+      const dto = dtoFixture;
+      const command = jobsDiscoveryParamsCommandFixture;
+      await controller.getJobs(
+        dto,
+        { qualifications: [] } as any,
+        jobDiscoveryToken,
+      );
+      command.data.qualifications = [];
+      expect(jobsDiscoveryService.processJobsDiscovery).toHaveBeenCalledWith(
+        command,
+      );
+    });
+  });
 });

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
@@ -29,7 +29,7 @@ export class OracleDiscoveryController {
   @Get('/oracles')
   @ApiOperation({ summary: 'Oracles discovery' })
   @UsePipes(new ValidationPipe())
-  public getOracles(
+  public async getOracles(
     @Query() dto: OracleDiscoveryDto,
   ): Promise<OracleDiscoveryResponse[]> {
     if (!this.environmentConfigService.jobsDiscoveryFlag) {

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -4,20 +4,29 @@ import { classes } from '@automapper/classes';
 import { OracleDiscoveryController } from '../oracle-discovery.controller';
 import { OracleDiscoveryService } from '../oracle-discovery.service';
 import { oracleDiscoveryServiceMock } from './oracle-discovery.service.mock';
-// import {
-//   OracleDiscoveryCommand,
-//   OracleDiscoveryDto,
-//   OracleDiscoveryResponse,
-// } from '../model/oracle-discovery.model';
-// import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
+import {
+  OracleDiscoveryCommand,
+  OracleDiscoveryDto,
+  OracleDiscoveryResponse,
+} from '../model/oracle-discovery.model';
+import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
 import { CommonConfigModule } from '../../../common/config/common-config.module';
 import { ConfigModule } from '@nestjs/config';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { any } from 'joi';
 
 describe('OracleDiscoveryController', () => {
   let controller: OracleDiscoveryController;
-  // let serviceMock: OracleDiscoveryService;
+  let serviceMock: OracleDiscoveryService;
+  const configServiceMock: Partial<EnvironmentConfigService> = {
+    email: 'human-app@hmt.ai',
+    password: 'Test1234*',
+    cacheTtlOracleDiscovery: 600,
+    chainIdsEnabled: ['137', '1'],
+    jobsDiscoveryFlag: true,
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -35,7 +44,7 @@ describe('OracleDiscoveryController', () => {
       providers: [
         OracleDiscoveryService,
         OracleDiscoveryProfile,
-        EnvironmentConfigService,
+        { provide: EnvironmentConfigService, useValue: configServiceMock },
       ],
     })
       .overrideProvider(OracleDiscoveryService)
@@ -45,28 +54,43 @@ describe('OracleDiscoveryController', () => {
     controller = module.get<OracleDiscoveryController>(
       OracleDiscoveryController,
     );
-    // serviceMock = module.get<OracleDiscoveryService>(OracleDiscoveryService);
+    serviceMock = module.get<OracleDiscoveryService>(OracleDiscoveryService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
-  // describe('oracle discovery', () => {
-  //   it('oracle discovery should be return OracleDiscoveryData', async () => {
-  //     const dtoFixture = {
-  //       selected_job_types: ['job-type-1', 'job-type-2'],
-  //     } as OracleDiscoveryDto;
-  //     const commandFixture = {
-  //       selectedJobTypes: ['job-type-1', 'job-type-2'],
-  //     } as OracleDiscoveryCommand;
-  //     const result: OracleDiscoveryResponse[] =
-  //       await controller.getOracles(dtoFixture);
-  //     const expectedResponse = generateOracleDiscoveryResponseBody();
-  //     expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(
-  //       commandFixture,
-  //     );
-  //     expect(result).toEqual(expectedResponse);
-  //   });
-  // });
+  describe('oracle discovery', () => {
+    it('oracle discovery should be return OracleDiscoveryData', async () => {
+      const dtoFixture = {
+        selected_job_types: ['job-type-1', 'job-type-2'],
+      } as OracleDiscoveryDto;
+      const commandFixture = {
+        selectedJobTypes: ['job-type-1', 'job-type-2'],
+      } as OracleDiscoveryCommand;
+      const result: OracleDiscoveryResponse[] =
+        await controller.getOracles(dtoFixture);
+      const expectedResponse = generateOracleDiscoveryResponseBody();
+      expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(
+        commandFixture,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('should throw an error if jobsDiscoveryFlag is disabled', async () => {
+      const dtoFixture = {
+        selected_job_types: ['job-type-1', 'job-type-2'],
+      } as OracleDiscoveryDto;
+
+      (configServiceMock as any).jobsDiscoveryFlag = false;
+
+      await expect(controller.getOracles(dtoFixture)).rejects.toThrow(
+        new HttpException(
+          'Oracles discovery is disabled',
+          HttpStatus.FORBIDDEN,
+        ),
+      );
+    });
+  });
 });

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -15,7 +15,6 @@ import { EnvironmentConfigService } from '../../../common/config/environment-con
 import { CommonConfigModule } from '../../../common/config/common-config.module';
 import { ConfigModule } from '@nestjs/config';
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { any } from 'joi';
 
 describe('OracleDiscoveryController', () => {
   let controller: OracleDiscoveryController;


### PR DESCRIPTION
## Description

Uncomment tests. These tests were commented because the endpoints were disabled. Now it is enable again

## Summary of changes

- Uncomment `src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts``
- Specify jobsDiscoveryFlag to false to disable asyncronous jobs running in tests

## How test the changes

`yarn test`

## Related issues
#2609