### PR TITLE
[Reputation Oracle] Verification message updates with every decision

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
@@ -89,7 +89,7 @@ export class KycService {
   }
 
   public async updateKycStatus(data: KycStatusDto): Promise<void> {
-    const { status, id: sessionId } = data.verification;
+    const { status, reason, id: sessionId } = data.verification;
     const { country } = data.verification.document;
 
     const kycEntity = await this.kycRepository.findOneBySessionId(sessionId);
@@ -101,13 +101,9 @@ export class KycService {
       throw new ControlledError(ErrorKyc.CountryNotSet, HttpStatus.BAD_REQUEST);
     }
 
-    if (status === KycStatus.APPROVED) {
-      kycEntity.status = status;
-      kycEntity.country = country;
-    } else {
-      kycEntity.status = data.verification.status;
-      kycEntity.message = data.verification.reason;
-    }
+    kycEntity.status = status;
+    kycEntity.country = country;
+    kycEntity.message = reason;
 
     await this.kycRepository.updateOne(kycEntity);
   }


### PR DESCRIPTION
## Description

Verification message updates with every decision sent from Veriff

## Summary of changes

Previously we didn't change a message with every webhook sent from Veriff so we could have an `approved` status but with message like `Document type is not supported` due to the resubmission.

## Related issues
To close #2599 
