### PR TITLE
[Reputation Oracle] Remove `forbidNonWhitelisted: true` option from `HttpValidationPipe`

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/reputation-oracle/server/src/common/pipes/validation.ts
@@ -25,7 +25,6 @@ export class HttpValidationPipe extends ValidationPipe {
       },
       transform: true,
       whitelist: true,
-      forbidNonWhitelisted: true,
       forbidUnknownValues: true,
       ...options,
     });


### PR DESCRIPTION
## Description

Removed `forbidNonWhitelisted: true` option from `HttpValidationPipe`

## Summary of changes

`forbidNonWhitelisted: true` is removed to avoid situations where 3rd party tool (e.g. Veriff) adds some fields to the request and we throw a validation error when it's completely fine and we don't use this field.

## Related issues
To close #2598 