### PR TITLE
[Job Launcher][Client] Empty fields in escrow details.

### DIFF
--- a/packages/apps/job-launcher/client/src/pages/Job/JobDetail/index.tsx
+++ b/packages/apps/job-launcher/client/src/pages/Job/JobDetail/index.tsx
@@ -163,13 +163,19 @@ export default function JobDetail() {
                       label="Chain Id"
                       value={data.manifest.chainId}
                     />
-                    <CardTextRow label="Title" value={data.manifest.title} />
+                    {data.manifest.title && (
+                      <CardTextRow label="Title" value={data.manifest.title} />
+                    )}
                     <CardTextRow
                       label="Description"
                       value={data.manifest.description}
                     />
                     <CardTextRow
-                      label="Fortune's request"
+                      label={
+                        data.manifest.requestType === 'FORTUNE'
+                          ? "Fortune's request"
+                          : 'Task size'
+                      }
                       value={data.manifest.submissionsRequired}
                     />
                     <CardTextRow

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1511,6 +1511,7 @@ export class JobService {
       manifest = manifestData as CvatManifestDto;
     }
 
+    console.log(manifest);
     const baseManifestDetails = {
       chainId,
       tokenAddress: escrow ? escrow.token : ethers.ZeroAddress,
@@ -1551,9 +1552,10 @@ export class JobService {
       specificManifestDetails = {
         requestType: manifest.annotation?.type,
         submissionsRequired: manifest.annotation?.job_size,
-        ...(manifest.annotation.qualifications &&
-          manifest.annotation.qualifications?.length > 0 && {
-            qualifications: manifest.annotation.qualifications,
+        description: manifest.annotation?.description,
+        ...(manifest.annotation?.qualifications &&
+          manifest.annotation?.qualifications?.length > 0 && {
+            qualifications: manifest.annotation?.qualifications,
           }),
       };
     }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1511,7 +1511,6 @@ export class JobService {
       manifest = manifestData as CvatManifestDto;
     }
 
-    console.log(manifest);
     const baseManifestDetails = {
       chainId,
       tokenAddress: escrow ? escrow.token : ethers.ZeroAddress,


### PR DESCRIPTION
## Description

Empty fields while showing manifest details.
Also, Fortune's request should be a thing for CVAT jobs.

## Summary of changes

Fix empty description for CVAT jobs and change `Fortune's request` to `Task size` for non-fortune jobs

## How test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
#2643
