### PR TITLE
Remove RPC endpoints from frontends

### DIFF
--- a/packages/apps/fortune/exchange-oracle/client/src/constants/chains.ts
+++ b/packages/apps/fortune/exchange-oracle/client/src/constants/chains.ts
@@ -23,33 +23,13 @@ switch (import.meta.env.VITE_APP_ENVIRONMENT.toLowerCase()) {
     break;
 }
 
-export const RPC_URLS: Partial<Record<ChainId, string | undefined>> = {
-  [ChainId.MAINNET]: import.meta.env.VITE_APP_RPC_URL_MAINNET || '',
-  [ChainId.SEPOLIA]: import.meta.env.VITE_APP_RPC_URL_SEPOLIA || '',
-  [ChainId.BSC_MAINNET]: import.meta.env.VITE_APP_RPC_URL_BSC_MAINNET || '',
-  [ChainId.BSC_TESTNET]: import.meta.env.VITE_APP_RPC_URL_BSC_TESTNET || '',
-  [ChainId.POLYGON]: import.meta.env.VITE_APP_RPC_URL_POLYGON || '',
-  [ChainId.POLYGON_AMOY]: import.meta.env.VITE_APP_RPC_URL_POLYGON_AMOY || '',
-  [ChainId.MOONBEAM]: import.meta.env.VITE_APP_RPC_URL_MOONBEAM || '',
-  [ChainId.MOONBASE_ALPHA]:
-    import.meta.env.VITE_APP_RPC_URL_MOONBASE_ALPHA || '',
-  [ChainId.AVALANCHE_TESTNET]:
-    import.meta.env.VITE_APP_RPC_URL_AVALANCHE_TESTNET || '',
-  [ChainId.AVALANCHE]: import.meta.env.VITE_APP_RPC_URL_AVALANCHE || '',
-  [ChainId.CELO_ALFAJORES]:
-    import.meta.env.VITE_APP_RPC_URL_CELO_ALFAJORES || '',
-  [ChainId.CELO]: import.meta.env.VITE_APP_RPC_URL_CELO || '',
-  [ChainId.XLAYER]: import.meta.env.VITE_APP_RPC_URL_XLAYER || '',
-  [ChainId.XLAYER_TESTNET]:
-    import.meta.env.VITE_APP_RPC_URL_XLAYER_TESTNET || '',
-  [ChainId.LOCALHOST]: 'http://127.0.0.1:8545',
-};
+const supportedChains =
+  import.meta.env.VITE_APP_SUPPORTED_CHAINS?.split(',') || [];
 
 export const SUPPORTED_CHAIN_IDS: ChainId[] = initialSupportedChainIds.filter(
-  (chainId) => Boolean(RPC_URLS[chainId])
+  (chainId) => supportedChains.includes(chainId.toString())
 );
 
-// it no rpc set, throw error
 if (SUPPORTED_CHAIN_IDS.length === 0) {
   throw new Error(
     'No valid RPC URL provided for the supported blockchain environment'

--- a/packages/apps/fortune/exchange-oracle/client/src/providers/WagmiProvider.tsx
+++ b/packages/apps/fortune/exchange-oracle/client/src/providers/WagmiProvider.tsx
@@ -1,11 +1,9 @@
-import { ChainId } from '@human-protocol/sdk';
-
 import { FC, PropsWithChildren } from 'react';
-import { http, createConfig, WagmiProvider as WWagmiProvider } from 'wagmi';
+import { createConfig, WagmiProvider as WWagmiProvider } from 'wagmi';
 import * as wagmiChains from 'wagmi/chains';
 import { coinbaseWallet, walletConnect } from 'wagmi/connectors';
 
-import { RPC_URLS, LOCALHOST } from '../constants/chains';
+import { LOCALHOST } from '../constants/chains';
 
 const projectId = import.meta.env.VITE_APP_WALLETCONNECT_PROJECT_ID;
 
@@ -34,21 +32,6 @@ export const wagmiConfig = createConfig({
       appName: 'human-job-launcher',
     }),
   ],
-  transports: {
-    [wagmiChains.mainnet.id]: http(RPC_URLS[ChainId.MAINNET]),
-    [wagmiChains.sepolia.id]: http(RPC_URLS[ChainId.SEPOLIA]),
-    [wagmiChains.bsc.id]: http(RPC_URLS[ChainId.BSC_MAINNET]),
-    [wagmiChains.bscTestnet.id]: http(RPC_URLS[ChainId.BSC_TESTNET]),
-    [wagmiChains.polygon.id]: http(RPC_URLS[ChainId.POLYGON]),
-    [wagmiChains.polygonAmoy.id]: http(RPC_URLS[ChainId.POLYGON_AMOY]),
-    [wagmiChains.moonbeam.id]: http(RPC_URLS[ChainId.MOONBEAM]),
-    [wagmiChains.moonbaseAlpha.id]: http(RPC_URLS[ChainId.MOONBASE_ALPHA]),
-    [wagmiChains.avalanche.id]: http(RPC_URLS[ChainId.AVALANCHE]),
-    [wagmiChains.avalancheFuji.id]: http(RPC_URLS[ChainId.AVALANCHE_TESTNET]),
-    [wagmiChains.xLayer.id]: http(RPC_URLS[ChainId.XLAYER]),
-    [wagmiChains.xLayerTestnet.id]: http(RPC_URLS[ChainId.XLAYER_TESTNET]),
-    [LOCALHOST.id]: http(RPC_URLS[ChainId.LOCALHOST]),
-  },
 });
 
 export const WagmiProvider: FC<PropsWithChildren> = ({ children }) => {

--- a/packages/apps/job-launcher/client/src/constants/chains.ts
+++ b/packages/apps/job-launcher/client/src/constants/chains.ts
@@ -24,33 +24,13 @@ switch (import.meta.env.VITE_APP_ENVIRONMENT.toLowerCase()) {
     break;
 }
 
-export const RPC_URLS: Partial<Record<ChainId, string | undefined>> = {
-  [ChainId.MAINNET]: import.meta.env.VITE_APP_RPC_URL_MAINNET || '',
-  [ChainId.SEPOLIA]: import.meta.env.VITE_APP_RPC_URL_SEPOLIA || '',
-  [ChainId.BSC_MAINNET]: import.meta.env.VITE_APP_RPC_URL_BSC_MAINNET || '',
-  [ChainId.BSC_TESTNET]: import.meta.env.VITE_APP_RPC_URL_BSC_TESTNET || '',
-  [ChainId.POLYGON]: import.meta.env.VITE_APP_RPC_URL_POLYGON || '',
-  [ChainId.POLYGON_AMOY]: import.meta.env.VITE_APP_RPC_URL_POLYGON_AMOY || '',
-  [ChainId.MOONBEAM]: import.meta.env.VITE_APP_RPC_URL_MOONBEAM || '',
-  [ChainId.MOONBASE_ALPHA]:
-    import.meta.env.VITE_APP_RPC_URL_MOONBASE_ALPHA || '',
-  [ChainId.AVALANCHE_TESTNET]:
-    import.meta.env.VITE_APP_RPC_URL_AVALANCHE_TESTNET || '',
-  [ChainId.AVALANCHE]: import.meta.env.VITE_APP_RPC_URL_AVALANCHE || '',
-  [ChainId.CELO_ALFAJORES]:
-    import.meta.env.VITE_APP_RPC_URL_CELO_ALFAJORES || '',
-  [ChainId.CELO]: import.meta.env.VITE_APP_RPC_URL_CELO || '',
-  [ChainId.XLAYER]: import.meta.env.VITE_APP_RPC_URL_XLAYER || '',
-  [ChainId.XLAYER_TESTNET]:
-    import.meta.env.VITE_APP_RPC_URL_XLAYER_TESTNET || '',
-  [ChainId.LOCALHOST]: 'http://127.0.0.1:8545',
-};
+const supportedChains =
+  import.meta.env.VITE_APP_SUPPORTED_CHAINS?.split(',') || [];
 
 export const SUPPORTED_CHAIN_IDS: ChainId[] = initialSupportedChainIds.filter(
-  (chainId) => Boolean(RPC_URLS[chainId]),
+  (chainId) => supportedChains.includes(chainId.toString()),
 );
 
-// it no rpc set, throw error
 if (SUPPORTED_CHAIN_IDS.length === 0) {
   throw new Error(ERROR_MESSAGES.noRpcUrl);
 }

--- a/packages/apps/job-launcher/client/src/providers/WagmiProvider.tsx
+++ b/packages/apps/job-launcher/client/src/providers/WagmiProvider.tsx
@@ -1,11 +1,9 @@
-import { ChainId } from '@human-protocol/sdk';
-
 import { FC, PropsWithChildren } from 'react';
-import { http, createConfig, WagmiProvider as WWagmiProvider } from 'wagmi';
+import { createConfig, WagmiProvider as WWagmiProvider } from 'wagmi';
 import * as wagmiChains from 'wagmi/chains';
 import { coinbaseWallet, walletConnect } from 'wagmi/connectors';
 
-import { RPC_URLS, LOCALHOST } from '../constants/chains';
+import { LOCALHOST } from '../constants/chains';
 
 const projectId = import.meta.env.VITE_APP_WALLETCONNECT_PROJECT_ID;
 
@@ -34,21 +32,6 @@ export const wagmiConfig = createConfig({
       appName: 'human-job-launcher',
     }),
   ],
-  transports: {
-    [wagmiChains.mainnet.id]: http(RPC_URLS[ChainId.MAINNET]),
-    [wagmiChains.sepolia.id]: http(RPC_URLS[ChainId.SEPOLIA]),
-    [wagmiChains.bsc.id]: http(RPC_URLS[ChainId.BSC_MAINNET]),
-    [wagmiChains.bscTestnet.id]: http(RPC_URLS[ChainId.BSC_TESTNET]),
-    [wagmiChains.polygon.id]: http(RPC_URLS[ChainId.POLYGON]),
-    [wagmiChains.polygonAmoy.id]: http(RPC_URLS[ChainId.POLYGON_AMOY]),
-    [wagmiChains.moonbeam.id]: http(RPC_URLS[ChainId.MOONBEAM]),
-    [wagmiChains.moonbaseAlpha.id]: http(RPC_URLS[ChainId.MOONBASE_ALPHA]),
-    [wagmiChains.avalanche.id]: http(RPC_URLS[ChainId.AVALANCHE]),
-    [wagmiChains.avalancheFuji.id]: http(RPC_URLS[ChainId.AVALANCHE_TESTNET]),
-    [wagmiChains.xLayer.id]: http(RPC_URLS[ChainId.XLAYER]),
-    [wagmiChains.xLayerTestnet.id]: http(RPC_URLS[ChainId.XLAYER_TESTNET]),
-    [LOCALHOST.id]: http(RPC_URLS[ChainId.LOCALHOST]),
-  },
 });
 
 export const WagmiProvider: FC<PropsWithChildren> = ({ children }) => {


### PR DESCRIPTION
## Description

Remove RPC endpoints from frontend apps

## Summary of changes

Remove RPC_URLS from frontends
Introduce a new env variable to define the supported chainIds

## How test the changes

Check if frontend still working without them

## Related issues
#2591