### PR TITLE
[SDK][Typescript] feat!: encryption module now works with binaries

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -347,7 +347,8 @@ export class JobService {
           this.pgpConfigService.passphrase,
         );
 
-        manifest = JSON.parse(await encryption.decrypt(manifestEncrypted));
+        const decryptedData = await encryption.decrypt(manifestEncrypted);
+        manifest = JSON.parse(Buffer.from(decryptedData).toString());
       } catch {
         throw new Error(ErrorJob.ManifestDecryptionFailed);
       }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/storage/storage.service.ts
@@ -57,7 +57,8 @@ export class StorageService {
           this.pgpConfigService.passphrase,
         );
 
-        return JSON.parse(await encryption.decrypt(fileContent)) as ISolution[];
+        const decryptedData = await encryption.decrypt(fileContent);
+        return JSON.parse(Buffer.from(decryptedData).toString()) as ISolution[];
       }
 
       return typeof fileContent == 'string'

--- a/packages/apps/fortune/recording-oracle/src/modules/storage/storage.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/storage/storage.service.ts
@@ -53,7 +53,8 @@ export class StorageService {
             this.pgpConfigService.passphrase,
           );
 
-          return JSON.parse(await encryption.decrypt(fileContent));
+          const decryptedData = await encryption.decrypt(fileContent);
+          return JSON.parse(Buffer.from(decryptedData).toString());
         } catch {
           throw new Error('Unable to decrypt manifest');
         }

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -2650,9 +2650,11 @@ describe('JobService', () => {
       expect(storageService.uploadFile).toHaveBeenCalled();
       expect(
         JSON.parse(
-          await encryption.decrypt(
-            (storageService.uploadFile as any).mock.calls[0][0],
-          ),
+          Buffer.from(
+            await encryption.decrypt(
+              (storageService.uploadFile as any).mock.calls[0][0],
+            ),
+          ).toString(),
         ),
       ).toEqual(fortuneManifestParams);
     });
@@ -2675,9 +2677,11 @@ describe('JobService', () => {
       expect(storageService.uploadFile).toHaveBeenCalled();
       expect(
         JSON.parse(
-          await encryption.decrypt(
-            (storageService.uploadFile as any).mock.calls[0][0],
-          ),
+          Buffer.from(
+            await encryption.decrypt(
+              (storageService.uploadFile as any).mock.calls[0][0],
+            ),
+          ).toString(),
         ),
       ).toEqual(fortuneManifestParams);
     });
@@ -2699,9 +2703,11 @@ describe('JobService', () => {
       expect(storageService.uploadFile).toHaveBeenCalled();
       expect(
         JSON.parse(
-          await encryption.decrypt(
-            (storageService.uploadFile as any).mock.calls[0][0],
-          ),
+          Buffer.from(
+            await encryption.decrypt(
+              (storageService.uploadFile as any).mock.calls[0][0],
+            ),
+          ).toString(),
         ),
       ).toEqual(fortuneManifestParams);
     });
@@ -2768,9 +2774,11 @@ describe('JobService', () => {
       expect(storageService.uploadFile).toHaveBeenCalled();
       expect(
         JSON.parse(
-          await encryption.decrypt(
-            (storageService.uploadFile as any).mock.calls[0][0],
-          ),
+          Buffer.from(
+            await encryption.decrypt(
+              (storageService.uploadFile as any).mock.calls[0][0],
+            ),
+          ).toString(),
         ),
       ).toEqual(manifest);
     });
@@ -2793,9 +2801,11 @@ describe('JobService', () => {
       expect(storageService.uploadFile).toHaveBeenCalled();
       expect(
         JSON.parse(
-          await encryption.decrypt(
-            (storageService.uploadFile as any).mock.calls[0][0],
-          ),
+          Buffer.from(
+            await encryption.decrypt(
+              (storageService.uploadFile as any).mock.calls[0][0],
+            ),
+          ).toString(),
         ),
       ).toEqual(manifest);
     });
@@ -2816,9 +2826,11 @@ describe('JobService', () => {
       expect(storageService.uploadFile).toHaveBeenCalled();
       expect(
         JSON.parse(
-          await encryption.decrypt(
-            (storageService.uploadFile as any).mock.calls[0][0],
-          ),
+          Buffer.from(
+            await encryption.decrypt(
+              (storageService.uploadFile as any).mock.calls[0][0],
+            ),
+          ).toString(),
         ),
       ).toEqual(manifest);
     });

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1013,7 +1013,9 @@ export class JobService {
 
     let manifest = await this.storageService.download(jobEntity.manifestUrl);
     if (typeof manifest === 'string' && isPGPMessage(manifest)) {
-      manifest = await this.encryption.decrypt(manifest as any);
+      manifest = Buffer.from(
+        await this.encryption.decrypt(manifest),
+      ).toString();
     }
 
     if (isValidJSON(manifest)) {
@@ -1496,7 +1498,9 @@ export class JobService {
 
     let manifest;
     if (typeof manifestData === 'string' && isPGPMessage(manifestData)) {
-      manifestData = await this.encryption.decrypt(manifestData as any);
+      manifestData = Buffer.from(
+        await this.encryption.decrypt(manifestData),
+      ).toString();
     }
 
     if (isValidJSON(manifestData)) {

--- a/packages/apps/job-launcher/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/storage/storage.service.ts
@@ -41,7 +41,8 @@ export class StorageService {
         typeof fileContent === 'string' &&
         EncryptionUtils.isEncrypted(fileContent)
       ) {
-        return await this.encryption.decrypt(fileContent);
+        const decryptedData = await this.encryption.decrypt(fileContent);
+        return Buffer.from(decryptedData).toString();
       } else {
         return fileContent;
       }

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
@@ -83,10 +83,12 @@ export class StorageService {
         this.pgpConfigService.privateKey!,
         this.pgpConfigService.passphrase,
       );
+      const decryptedData = await encryption.decrypt(fileContent);
+      const content = Buffer.from(decryptedData).toString();
       try {
-        return JSON.parse(await encryption.decrypt(fileContent));
+        return JSON.parse(content);
       } catch {
-        return await encryption.decrypt(fileContent);
+        return content;
       }
     } else {
       return fileContent;

--- a/packages/sdk/typescript/human-protocol-sdk/example/encrypt.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/example/encrypt.ts
@@ -1,0 +1,59 @@
+import { Encryption } from '../src/encryption';
+
+const ExampleKeys = {
+  private: `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+xVgEZyOGRhYJKwYBBAHaRw8BAQdA6soD3CBjRnPfsYIxOGObykL8X8y+dZlf
+IzAI7mk40E4AAQCPRLKy/1n/QxTRk/Ql+Dt2VYADqDmczBxhWELCbz9Wvw/J
+zRxleGFtcGxlIDxzaW1wbGVAZXhhbXBsZS5jb20+wowEEBYKAD4FgmcjhkYE
+CwkHCAmQZ4KBmVeekE0DFQgKBBYAAgECGQECmwMCHgEWIQQkzuPtNIUkzz4M
+CFhngoGZV56QTQAA89oBAKm5Tai1Ynx4BCU6PSLp0QMEE2ImV/LzwHkLMz52
+mzeJAP9NyyNyIMNH1SpSezy309UhEdJVapGoXQwO1eQR4B+LCMddBGcjhkYS
+CisGAQQBl1UBBQEBB0BykPL7zxjKQpZMYuEnIDBz7vshngm4zJMNOsE6pDSH
+NgMBCAcAAP9b+n3/5QKVd0UP/ow3uyH0X44gc2U4fKV8IhZBJLiSEA9ZwngE
+GBYKACoFgmcjhkYJkGeCgZlXnpBNApsMFiEEJM7j7TSFJM8+DAhYZ4KBmVee
+kE0AAE0WAP9FE0I9dHToxLAkMKiM9tTzL43GVl6K8Lvn9nrLJcfLgQEAtFXL
+39GhAUKNbHMpdeEmxukrdF+rXzUfvOsYGPLIgwI=
+=GfVY
+-----END PGP PRIVATE KEY BLOCK-----`,
+  public: `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xjMEZyOGRhYJKwYBBAHaRw8BAQdA6soD3CBjRnPfsYIxOGObykL8X8y+dZlf
+IzAI7mk40E7NHGV4YW1wbGUgPHNpbXBsZUBleGFtcGxlLmNvbT7CjAQQFgoA
+PgWCZyOGRgQLCQcICZBngoGZV56QTQMVCAoEFgACAQIZAQKbAwIeARYhBCTO
+4+00hSTPPgwIWGeCgZlXnpBNAADz2gEAqblNqLVifHgEJTo9IunRAwQTYiZX
+8vPAeQszPnabN4kA/03LI3Igw0fVKlJ7PLfT1SER0lVqkahdDA7V5BHgH4sI
+zjgEZyOGRhIKKwYBBAGXVQEFAQEHQHKQ8vvPGMpClkxi4ScgMHPu+yGeCbjM
+kw06wTqkNIc2AwEIB8J4BBgWCgAqBYJnI4ZGCZBngoGZV56QTQKbDBYhBCTO
+4+00hSTPPgwIWGeCgZlXnpBNAABNFgD/RRNCPXR06MSwJDCojPbU8y+NxlZe
+ivC75/Z6yyXHy4EBALRVy9/RoQFCjWxzKXXhJsbpK3Rfq181H7zrGBjyyIMC
+=wH1v
+-----END PGP PUBLIC KEY BLOCK-----`,
+};
+
+const exampleRound = async () => {
+  const encryption = await Encryption.build(ExampleKeys.private);
+
+  const message = Buffer.from(
+    JSON.stringify(
+      {
+        date: new Date().toISOString(),
+        random: Math.random(),
+        text: 'Hello from example!',
+      },
+      null,
+      2
+    )
+  );
+
+  const encrypted = await encryption.signAndEncrypt(message, [
+    ExampleKeys.public,
+  ]);
+
+  const decrypted = await encryption.decrypt(encrypted, ExampleKeys.public);
+  console.log('Decrypted', JSON.parse(Buffer.from(decrypted).toString()));
+};
+
+(async () => {
+  await exampleRound();
+})();

--- a/packages/sdk/typescript/human-protocol-sdk/test/utils/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/utils/constants.ts
@@ -140,6 +140,12 @@ WXs/I9nhKcx2pAAA5VwA/R6fW20uAR7ItubxVhQa+PLEVSiUKgYOU9jp75av
 };
 
 export const MESSAGE = 'Human Protocol';
+export const BINARY_MESSAGE_CONTENT = {
+  number: 1,
+  boolean: true,
+  null: null,
+  string: MESSAGE,
+} as const;
 
 export const SIGNEDMESSAGE = `-----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA512
@@ -165,6 +171,21 @@ j/DPeNxUq3zrvUJXXbwb6cMf23f66U/mB27Q0tgAFFMyB+iJxEeo1HEt9IYb
 cii1NVsBkAg4xxsZHrjXKqXzHnnhseNGEW5eNYUZWZJZTZLSMGWV031Kwjm1
 1X6Iew8+EcczRCFcgaCZgxRmEeShDbKMEGjKckvEC1A=
 =pawu
+-----END PGP MESSAGE-----`;
+
+export const SIGNEDENCRYPTEDBINARYMESSAGE = `-----BEGIN PGP MESSAGE-----
+
+wV4D62ta7QqCH7ASAQdA1Fu+j1ROzZfOhWFonXU5nqN8SS7lZ9PcOH5R0EsJ
+WwMwVqgc90AQPe6QqHXADnmWRcmlMa60UqZXp6RM117IA61U3eMWZMvZpm8w
+WchAe+/YwV4DM57hZqoRiU8SAQdAjBxr7VwdHExxR16YJRfl6jmS/+jVf7Ed
+a1M134lkWFQwzGk4dbVx/PVlH3QbwzSuwh4EvdTku/5eA6TTAG8SsPnjeYwe
++bOn6blgHitbCyRg0sA4ARd/h3Cv3SPLv8TLLY1+oZKCxj8JixvRJ7pdQFtX
+uQj4/3ebFN3Wz4Bc22og61V0bRwbItkvAkdPytAAohMSdvtmB/afqN5KleH7
+Q+hftw7iUpLxGEhykh4lHy9dt/ylzPFYP1MVAm9aTdNMo0YEeCji8EPbbxl4
+hdPtck+uT1OpewbrhZNxg5Mtzc+t5tf/TfNYllAO6u/XTTWsOBKGcLhsituV
+j7PegOO0npgohXmOxKFMmjJZhJOEbDOwCxTb72lZHwOXP5f95xMuSWoUGFpO
+lk9n7jB3p5HYtUDSriV2YSI+G3NWmqGHG4/XTdodK2DQb8/Hp88=
+=qQI9
 -----END PGP MESSAGE-----`;
 
 export const SIGNEDENCRYPTEDLOCKEDMESSAGE = `-----BEGIN PGP MESSAGE-----


### PR DESCRIPTION
## Description

Encryption module now works with binaries

## Summary of changes

1. Both `signAndEncrypt` and `sign` methods now accept not only `string`, but also `Uint8Array` (or `Buffer`, which is subclass of it), so we can properly works with some small files. In case we need something relatively big (e.g. >10Mb) - we will probably need to start supporting streams. We can see how it goes with performance over time
2. `decrypt` method now always returns `Uint8Array`, so consumer of this API must know what to expect and how to process decrypted value

## How test the changes

- [x] Unit tests
- [x] `/example/encrypt.ts` file added 

## Related issues
Part of the https://github.com/humanprotocol/human-protocol/issues/2717
