### PR TITLE
[CVAT][Exchange Oracle] fix: hmt abbreviation switched back to upper case

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/schemas/exchange.py
+++ b/packages/examples/cvat/exchange-oracle/src/schemas/exchange.py
@@ -7,7 +7,7 @@ from strenum import StrEnum  # added in python 3.11
 from src.core.types import Networks, TaskTypes
 from src.utils.enums import BetterEnumMeta
 
-DEFAULT_TOKEN = "hmt"  # noqa: S105 (it's  not a credential)
+DEFAULT_TOKEN = "HMT"  # noqa: S105 (it's  not a credential)
 
 
 class JobStatuses(StrEnum, metaclass=BetterEnumMeta):

--- a/packages/examples/cvat/exchange-oracle/tests/api/test_exchange_api.py
+++ b/packages/examples/cvat/exchange-oracle/tests/api/test_exchange_api.py
@@ -501,7 +501,7 @@ def test_can_list_jobs_200_check_values(client: TestClient, session: Session) ->
             "status": APIJobStatuses.active,
             "job_description": manifest["annotation"]["description"],
             "reward_amount": manifest["job_bounty"],
-            "reward_token": "hmt",
+            "reward_token": "HMT",
             "created_at": cvat_project.created_at.isoformat().replace("+00:00", "Z"),
             "updated_at": cvat_first_job.task.project.updated_at.isoformat().replace("+00:00", "Z"),
             "qualifications": manifest.get("qualifications", []),


### PR DESCRIPTION
## Description

hmt abbreviation switched back to upper case

