### PR TITLE
[Human App] fix: cache-manager ttl usage

### DIFF
--- a/packages/apps/human-app/server/package.json
+++ b/packages/apps/human-app/server/package.json
@@ -33,7 +33,7 @@
     "@nestjs/swagger": "^7.4.2",
     "@nestjs/terminus": "^10.2.3",
     "cache-manager": "^5.4.0",
-    "cache-manager-redis-store": "^3.0.1",
+    "cache-manager-redis-yet": "^5.1.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "ethers": "^6.12.1",

--- a/packages/apps/human-app/server/src/common/config/cache-factory.config.ts
+++ b/packages/apps/human-app/server/src/common/config/cache-factory.config.ts
@@ -1,8 +1,8 @@
 import { Logger } from '@nestjs/common';
-import { CacheModuleAsyncOptions } from '@nestjs/common/cache';
+import { CacheModuleAsyncOptions } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
 import _ from 'lodash';
-import { redisStore } from 'cache-manager-redis-store';
+import { redisStore } from 'cache-manager-redis-yet';
 
 import { EnvironmentConfigService } from './environment-config.service';
 
@@ -24,8 +24,7 @@ export const CacheFactoryConfig: CacheModuleAsyncOptions = {
       disableOfflineQueue: true,
     });
 
-    const redisClient = store.getClient();
-    redisClient.on('error', throttledRedisErrorLog);
+    store.client.on('error', throttledRedisErrorLog);
 
     return {
       store: () => store,

--- a/packages/apps/human-app/server/src/common/config/environment-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.ts
@@ -95,9 +95,11 @@ export class EnvironmentConfigService {
    * Default: 12 hours
    */
   get cacheTtlOracleStats(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_ORACLE_STATS',
-      DEFAULT_CACHE_TTL_ORACLE_STATS,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_ORACLE_STATS',
+        DEFAULT_CACHE_TTL_ORACLE_STATS,
+      ) * 1000
     );
   }
 
@@ -106,9 +108,11 @@ export class EnvironmentConfigService {
    * Default: 15 minutes
    */
   get cacheTtlUserStats(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_USER_STATS',
-      DEFAULT_CACHE_TTL_USER_STATS,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_USER_STATS',
+        DEFAULT_CACHE_TTL_USER_STATS,
+      ) * 1000
     );
   }
 
@@ -117,9 +121,11 @@ export class EnvironmentConfigService {
    * Default: 24 hours
    */
   get cacheTtlDailyHmtSpent(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_DAILY_HMT_SPENT',
-      DEFAULT_CACHE_TTL_DAILY_HMT_SPENT,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_DAILY_HMT_SPENT',
+        DEFAULT_CACHE_TTL_DAILY_HMT_SPENT,
+      ) * 1000
     );
   }
 
@@ -128,9 +134,11 @@ export class EnvironmentConfigService {
    * Default: 12 hours
    */
   get cacheTtlHCaptchaUserStats(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_HCAPTCHA_USER_STATS',
-      DEFAULT_CACHE_TTL_HCAPTCHA_USER_STATS,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_HCAPTCHA_USER_STATS',
+        DEFAULT_CACHE_TTL_HCAPTCHA_USER_STATS,
+      ) * 1000
     );
   }
 
@@ -139,9 +147,11 @@ export class EnvironmentConfigService {
    * Default: 24 hours
    */
   get cacheTtlOracleDiscovery(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_ORACLE_DISCOVERY',
-      DEFAULT_CACHE_TTL_ORACLE_DISCOVERY,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_ORACLE_DISCOVERY',
+        DEFAULT_CACHE_TTL_ORACLE_DISCOVERY,
+      ) * 1000
     );
   }
 
@@ -150,9 +160,11 @@ export class EnvironmentConfigService {
    * Default: 45 days
    */
   get cacheTtlJobAssignments(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_JOB_ASSIGNMENTS',
-      DEFAULT_CACHE_TTL_JOB_ASSIGNMENTS,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_JOB_ASSIGNMENTS',
+        DEFAULT_CACHE_TTL_JOB_ASSIGNMENTS,
+      ) * 1000
     );
   }
 
@@ -198,9 +210,11 @@ export class EnvironmentConfigService {
    * Default: 24 hours
    */
   get cacheTtlExchangeOracleUrl(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_EXCHANGE_ORACLE_URL',
-      DEFAULT_CACHE_TTL_EXCHANGE_ORACLE_URL,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_EXCHANGE_ORACLE_URL',
+        DEFAULT_CACHE_TTL_EXCHANGE_ORACLE_URL,
+      ) * 1000
     );
   }
 
@@ -209,9 +223,11 @@ export class EnvironmentConfigService {
    * Default: 24 hours
    */
   get cacheTtlExchangeOracleRegistrationNeeded(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_EXCHANGE_ORACLE_REGISTRATION_NEEDED',
-      DEFAULT_CACHE_TTL_EXCHANGE_ORACLE_REGISTRATION_NEEDED,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_EXCHANGE_ORACLE_REGISTRATION_NEEDED',
+        DEFAULT_CACHE_TTL_EXCHANGE_ORACLE_REGISTRATION_NEEDED,
+      ) * 1000
     );
   }
 

--- a/packages/apps/human-app/server/src/integrations/kv-store/kv-store.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/kv-store/kv-store.gateway.ts
@@ -43,9 +43,11 @@ export class KvStoreGateway {
         400,
       );
     } else {
-      await this.cacheManager.set(key, fetchedData, {
-        ttl: this.configService.cacheTtlExchangeOracleUrl,
-      } as any);
+      await this.cacheManager.set(
+        key,
+        fetchedData,
+        this.configService.cacheTtlExchangeOracleUrl,
+      );
       return fetchedData;
     }
   }

--- a/packages/apps/human-app/server/src/integrations/kv-store/spec/kv-store.gateway.spec.ts
+++ b/packages/apps/human-app/server/src/integrations/kv-store/spec/kv-store.gateway.spec.ts
@@ -97,9 +97,11 @@ describe('KvStoreGateway', () => {
         KVStoreKeys.url,
       );
 
-      expect(cacheManager.set).toHaveBeenCalledWith(cacheKey, expectedData, {
-        ttl: configService.cacheTtlExchangeOracleUrl,
-      });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        cacheKey,
+        expectedData,
+        configService.cacheTtlExchangeOracleUrl,
+      );
       expect(cacheManager.get).toHaveBeenCalledWith(cacheKey);
       expect(result).toBe(expectedData);
     });

--- a/packages/apps/human-app/server/src/modules/h-captcha/h-captcha.service.ts
+++ b/packages/apps/human-app/server/src/modules/h-captcha/h-captcha.service.ts
@@ -74,9 +74,11 @@ export class HCaptchaService {
     );
     if (!dailyHmtSpent) {
       dailyHmtSpent = await this.hCaptchaLabelingGateway.fetchDailyHmtSpent();
-      await this.cacheManager.set(DAILY_HMT_SPENT_CACHE_KEY, dailyHmtSpent, {
-        ttl: this.configService.cacheTtlDailyHmtSpent,
-      } as any);
+      await this.cacheManager.set(
+        DAILY_HMT_SPENT_CACHE_KEY,
+        dailyHmtSpent,
+        this.configService.cacheTtlDailyHmtSpent,
+      );
     }
     return dailyHmtSpent;
   }
@@ -88,9 +90,11 @@ export class HCaptchaService {
       return stats;
     }
     stats = await this.hCaptchaLabelingGateway.fetchUserStats(command.email);
-    await this.cacheManager.set(command.email, stats, {
-      ttl: this.configService.cacheTtlHCaptchaUserStats,
-    } as any);
+    await this.cacheManager.set(
+      command.email,
+      stats,
+      this.configService.cacheTtlHCaptchaUserStats,
+    );
     return stats;
   }
   private checkIfHcaptchaSitekeyPresent(siteKey: string) {

--- a/packages/apps/human-app/server/src/modules/h-captcha/spec/h-captcha.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/h-captcha/spec/h-captcha.service.spec.ts
@@ -196,7 +196,7 @@ describe('HCaptchaService', () => {
       expect(cacheManager.set).toHaveBeenCalledWith(
         DAILY_HMT_SPENT_CACHE_KEY,
         dailyHmtSpentResponseFixture,
-        { ttl: configService.cacheTtlDailyHmtSpent },
+        configService.cacheTtlDailyHmtSpent,
       );
     });
   });
@@ -225,7 +225,7 @@ describe('HCaptchaService', () => {
       expect(cacheManager.set).toHaveBeenCalledWith(
         command.email,
         userStatsResponseFixture,
-        { ttl: configService.cacheTtlHCaptchaUserStats },
+        configService.cacheTtlHCaptchaUserStats,
       );
     });
   });

--- a/packages/apps/human-app/server/src/modules/health/health.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/health/health.controller.spec.ts
@@ -13,7 +13,7 @@ const redisClientMock = {
 
 const cacheManagerMock = {
   store: {
-    getClient: () => redisClientMock,
+    client: redisClientMock,
   },
 };
 

--- a/packages/apps/human-app/server/src/modules/health/health.controller.ts
+++ b/packages/apps/human-app/server/src/modules/health/health.controller.ts
@@ -1,8 +1,7 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Controller, Get, Inject } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Cache } from 'cache-manager';
-import type { RedisStore } from 'cache-manager-redis-yet';
+import type { Cache } from 'cache-manager';
 
 import {
   HealthCheck,
@@ -13,7 +12,7 @@ import {
 import packageJson from '../../../package.json';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 import { PingResponseDto } from './dto/ping-response.dto';
-import { RedisHealthIndicator } from './indicators/redis.health';
+import { CacheManagerHealthIndicator } from './indicators/cache-manager.health';
 
 @ApiTags('Health')
 @Controller('health')
@@ -22,7 +21,7 @@ export class HealthController {
     private readonly environmentConfigService: EnvironmentConfigService,
     private readonly healthCheckService: HealthCheckService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-    private readonly redisHealthIndicator: RedisHealthIndicator,
+    private readonly cacheManagerHealthIndicator: CacheManagerHealthIndicator,
   ) {}
 
   @ApiOperation({
@@ -56,9 +55,9 @@ export class HealthController {
   async check(): Promise<HealthCheckResult> {
     return this.healthCheckService.check([
       () =>
-        this.redisHealthIndicator.isHealthy(
-          'cache-manager-redis',
-          (this.cacheManager.store as RedisStore).client,
+        this.cacheManagerHealthIndicator.isHealthy(
+          'cache-manager',
+          this.cacheManager,
         ),
     ]);
   }

--- a/packages/apps/human-app/server/src/modules/health/health.controller.ts
+++ b/packages/apps/human-app/server/src/modules/health/health.controller.ts
@@ -2,7 +2,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Controller, Get, Inject } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Cache } from 'cache-manager';
-import type { RedisStore } from 'cache-manager-redis-store';
+import type { RedisStore } from 'cache-manager-redis-yet';
 
 import {
   HealthCheck,
@@ -58,7 +58,7 @@ export class HealthController {
       () =>
         this.redisHealthIndicator.isHealthy(
           'cache-manager-redis',
-          (this.cacheManager.store as unknown as RedisStore).getClient(),
+          (this.cacheManager.store as RedisStore).client,
         ),
     ]);
   }

--- a/packages/apps/human-app/server/src/modules/health/health.module.ts
+++ b/packages/apps/human-app/server/src/modules/health/health.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
-import { RedisHealthIndicator } from './indicators/redis.health';
+import { CacheManagerHealthIndicator } from './indicators/cache-manager.health';
 
 @Module({
   controllers: [HealthController],
   imports: [TerminusModule],
-  providers: [RedisHealthIndicator],
+  providers: [CacheManagerHealthIndicator],
 })
 export class HealthModule {}

--- a/packages/apps/human-app/server/src/modules/health/indicators/cache-manager.health.spec.ts
+++ b/packages/apps/human-app/server/src/modules/health/indicators/cache-manager.health.spec.ts
@@ -1,0 +1,54 @@
+import { HealthCheckError } from '@nestjs/terminus';
+import type { Cache } from 'cache-manager';
+import { CacheManagerHealthIndicator } from './cache-manager.health';
+
+describe('CacheManagerHealthIndicator', () => {
+  const cacheManagerMock = {
+    get: jest.fn(),
+  };
+
+  const cacheManagerHealthIndicator = new CacheManagerHealthIndicator();
+
+  afterEach(() => {
+    cacheManagerMock.get.mockReset();
+  });
+
+  describe('isHealty', () => {
+    it('should return healthy status if can ping', async () => {
+      cacheManagerMock.get.mockResolvedValueOnce(null);
+
+      const testKey = 'test-key-1';
+
+      const healthIndicatorResult = await cacheManagerHealthIndicator.isHealthy(
+        testKey,
+        cacheManagerMock as unknown as Cache,
+      );
+
+      expect(healthIndicatorResult).toEqual({
+        [testKey]: { status: 'up' },
+      });
+    });
+
+    it(`should throw with unhealthy status if can't ping`, async () => {
+      const mockNetworkError = new Error('Ooops! Redis network error');
+      cacheManagerMock.get.mockRejectedValueOnce(mockNetworkError);
+
+      const testKey = 'test-key-2';
+
+      let thrownError;
+      try {
+        await cacheManagerHealthIndicator.isHealthy(
+          testKey,
+          cacheManagerMock as unknown as Cache,
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(HealthCheckError);
+      expect(thrownError.causes).toEqual({
+        [testKey]: { status: 'down' },
+      });
+    });
+  });
+});

--- a/packages/apps/human-app/server/src/modules/health/indicators/cache-manager.health.ts
+++ b/packages/apps/human-app/server/src/modules/health/indicators/cache-manager.health.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import type { Cache } from 'cache-manager';
+
+@Injectable()
+export class CacheManagerHealthIndicator extends HealthIndicator {
+  async isHealthy(
+    key: string,
+    cacheManager: Cache,
+  ): Promise<HealthIndicatorResult> {
+    let isHealthy = false;
+    try {
+      await cacheManager.get(`health-indicator-synthetic-key`);
+      isHealthy = true;
+    } catch (_noop) {}
+
+    const result = this.getStatus(key, isHealthy);
+
+    if (isHealthy) {
+      return result;
+    }
+
+    throw new HealthCheckError('Cache manager check failed', result);
+  }
+}

--- a/packages/apps/human-app/server/src/modules/job-assignment/job-assignment.service.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/job-assignment.service.ts
@@ -39,9 +39,9 @@ export class JobAssignmentService {
   }
 
   private getCacheRetentionDate(): string {
-    const ttlMs = this.configService.cacheTtlJobAssignments * 1000;
-
-    return new Date(Date.now() - ttlMs).toISOString();
+    return new Date(
+      Date.now() - this.configService.cacheTtlJobAssignments,
+    ).toISOString();
   }
 
   async processJobAssignment(

--- a/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.service.spec.ts
@@ -14,7 +14,7 @@ import { EscrowUtilsGateway } from '../../../integrations/escrow/escrow-utils-ga
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ResignJobCommand } from '../model/job-assignment.model';
 
-const TEST_RETENTION_TTL = 60 * 60 * 24;
+const TEST_RETENTION_TTL = 1000 * 60 * 60 * 24;
 const cacheKey = `jobs:assigned:${USER_ADDRESS}:${EXCHANGE_ORACLE_ADDRESS}`;
 
 describe('JobAssignmentService', () => {
@@ -110,7 +110,7 @@ describe('JobAssignmentService', () => {
         command,
       );
       expect(command.data.updatedAfter).toBe(
-        new Date(now - TEST_RETENTION_TTL * 1000).toISOString(),
+        new Date(now - TEST_RETENTION_TTL).toISOString(),
       );
 
       expect(cacheManagerMock.set).toHaveBeenCalledWith(

--- a/packages/apps/human-app/server/src/modules/statistics/spec/statistics.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/statistics/spec/statistics.service.spec.ts
@@ -78,9 +78,11 @@ describe('StatisticsService', () => {
       expect(exchangeGateway.fetchOracleStatistics).toHaveBeenCalledWith(
         command,
       );
-      expect(cacheManager.set).toHaveBeenCalledWith(cacheKey, newData, {
-        ttl: configService.cacheTtlOracleStats,
-      });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        cacheKey,
+        newData,
+        configService.cacheTtlOracleStats,
+      );
 
       expect(result).toEqual(newData);
     });
@@ -117,9 +119,11 @@ describe('StatisticsService', () => {
       const result = await service.getUserStats(command);
       expect(cacheManager.get).toHaveBeenCalledWith(userCacheKey);
       expect(exchangeGateway.fetchUserStatistics).toHaveBeenCalledWith(command);
-      expect(cacheManager.set).toHaveBeenCalledWith(userCacheKey, newData, {
-        ttl: configService.cacheTtlUserStats,
-      });
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        userCacheKey,
+        newData,
+        configService.cacheTtlUserStats,
+      );
       expect(result).toEqual(newData);
     });
   });

--- a/packages/apps/human-app/server/src/modules/statistics/statistics.service.ts
+++ b/packages/apps/human-app/server/src/modules/statistics/statistics.service.ts
@@ -35,9 +35,11 @@ export class StatisticsService {
     }
     const response: OracleStatisticsResponse =
       await this.exchangeOracleGateway.fetchOracleStatistics(command);
-    await this.cacheManager.set(key, response, {
-      ttl: this.configService.cacheTtlOracleStats,
-    } as any);
+    await this.cacheManager.set(
+      key,
+      response,
+      this.configService.cacheTtlOracleStats,
+    );
     return response;
   }
   async getUserStats(
@@ -53,9 +55,11 @@ export class StatisticsService {
       await this.exchangeOracleGateway.fetchUserStatistics(command);
     response.last_updated = new Date().toISOString();
 
-    await this.cacheManager.set(userCacheKey, response, {
-      ttl: this.configService.cacheTtlUserStats,
-    } as any);
+    await this.cacheManager.set(
+      userCacheKey,
+      response,
+      this.configService.cacheTtlUserStats,
+    );
     return response;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,11 +1998,6 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@fastify/busboy@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
-  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
-
 "@float-capital/float-subgraph-uncrashable@^0.0.0-alpha.4":
   version "0.0.0-internal-testing.5"
   resolved "https://registry.yarnpkg.com/@float-capital/float-subgraph-uncrashable/-/float-subgraph-uncrashable-0.0.0-internal-testing.5.tgz#060f98440f6e410812766c5b040952d2d02e2b73"
@@ -10250,14 +10245,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
-  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
-  dependencies:
-    jake "^10.8.5"
-
-ejs@^3.0.0, ejs@^3.1.10, ejs@^3.1.8:
+ejs@3.1.8, ejs@^3.0.0, ejs@^3.1.10, ejs@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
@@ -10322,7 +10310,7 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-encode-utf8@^1.0.2, encode-utf8@^1.0.3:
+encode-utf8@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
   integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
@@ -11584,7 +11572,7 @@ fast-url-parser@^1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@^4.2.2:
+fast-xml-parser@4.4.1, fast-xml-parser@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
   integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
@@ -12299,10 +12287,10 @@ globule@^1.0.0:
     lodash "^4.17.21"
     minimatch "~3.0.2"
 
-gluegun@5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-5.1.6.tgz#74ec13193913dc610f5c1a4039972c70c96a7bad"
-  integrity sha512-9zbi4EQWIVvSOftJWquWzr9gLX2kaDgPkNR5dYWbM53eVvCI3iKuxLlnKoHC0v4uPoq+Kr/+F569tjoFbA4DSA==
+gluegun@5.1.6, gluegun@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-5.2.0.tgz#88ba1f76f20e68a135557a4a4c8ea283291a7491"
+  integrity sha512-jSUM5xUy2ztYFQANne17OUm/oAd7qSX7EBksS9bQDt9UvLPqcEkeWUebmaposb8Tx7eTTD8uJVWGRe6PYSsYkg==
   dependencies:
     apisauce "^2.1.5"
     app-module-path "^2.2.0"
@@ -16134,21 +16122,14 @@ node-fetch-native@^1.6.4:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.4.tgz#679fc8fd8111266d47d7e72c379f1bed9acff06e"
   integrity sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==
 
-node-fetch@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
-  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.8, node-fetch@^2.6.9, node-fetch@^2.7.0:
+node-fetch@2.6.9, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.8, node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1.3.1:
+node-forge@^1.0.0, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
@@ -17521,13 +17502,12 @@ qrcode-terminal-nooctal@^0.12.1:
   resolved "https://registry.yarnpkg.com/qrcode-terminal-nooctal/-/qrcode-terminal-nooctal-0.12.1.tgz#45016aca0d82b2818de7af0a06d072ad671fbe2e"
   integrity sha512-jy/kkD0iIMDjTucB+5T6KBsnirlhegDH47vHgrj5MejchSQmi/EAMM0xMFeePgV9CJkkAapNakpVUWYgHvtdKg==
 
-qrcode@1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.3.tgz#03afa80912c0dccf12bc93f615a535aad1066170"
-  integrity sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==
+qrcode@1.5.3, qrcode@^1.5.0:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.4.tgz#5cb81d86eb57c675febb08cf007fff963405da88"
+  integrity sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==
   dependencies:
     dijkstrajs "^1.0.1"
-    encode-utf8 "^1.0.3"
     pngjs "^5.0.0"
     yargs "^15.3.1"
 
@@ -18521,31 +18501,7 @@ secp256k1@^5.0.0:
     node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
-semver@7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.4.0.tgz#8481c92feffc531ab1e012a8ffc15bdd3a0f4318"
-  integrity sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
+"semver@2 || 3 || 4 || 5", semver@7.3.5, semver@7.4.0, semver@^5.5.0, semver@^6.0.0, semver@^6.3.0, semver@^6.3.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -20426,14 +20382,7 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici@5.28.4, undici@^5.14.0:
-  version "5.28.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
-  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
-
-undici@^6.11.1:
+undici@5.28.4, undici@^5.14.0, undici@^6.11.1:
   version "6.20.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.20.1.tgz#fbb87b1e2b69d963ff2d5410a40ffb4c9e81b621"
   integrity sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==
@@ -21543,30 +21492,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@7.4.6:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
-
-ws@8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
-
-ws@8.17.1, ws@~8.17.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
-
-ws@8.18.0, ws@^8.11.0, ws@^8.12.0, ws@^8.17.1, ws@^8.18.0:
+ws@7.4.6, ws@8.13.0, ws@8.17.1, ws@8.18.0, ws@^7.4.5, ws@^7.4.6, ws@^7.5.1, ws@^8.11.0, ws@^8.12.0, ws@^8.17.1, ws@^8.18.0, ws@~8.17.1:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
-
-ws@^7.4.5, ws@^7.4.6, ws@^7.5.1:
-  version "7.5.10"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 xdeployer@3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,6 +1998,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
+
 "@float-capital/float-subgraph-uncrashable@^0.0.0-alpha.4":
   version "0.0.0-internal-testing.5"
   resolved "https://registry.yarnpkg.com/@float-capital/float-subgraph-uncrashable/-/float-subgraph-uncrashable-0.0.0-internal-testing.5.tgz#060f98440f6e410812766c5b040952d2d02e2b73"
@@ -4105,12 +4110,12 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@redis/bloom@1.2.0":
+"@redis/bloom@1.2.0", "@redis/bloom@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
   integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
 
-"@redis/client@1.6.0":
+"@redis/client@1.6.0", "@redis/client@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.6.0.tgz#dcf4ae1319763db6fdddd6de7f0af68a352c30ea"
   integrity sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==
@@ -4119,22 +4124,22 @@
     generic-pool "3.9.0"
     yallist "4.0.0"
 
-"@redis/graph@1.1.1":
+"@redis/graph@1.1.1", "@redis/graph@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.1.tgz#8c10df2df7f7d02741866751764031a957a170ea"
   integrity sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==
 
-"@redis/json@1.0.7":
+"@redis/json@1.0.7", "@redis/json@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.7.tgz#016257fcd933c4cbcb9c49cde8a0961375c6893b"
   integrity sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==
 
-"@redis/search@1.2.0":
+"@redis/search@1.2.0", "@redis/search@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.2.0.tgz#50976fd3f31168f585666f7922dde111c74567b8"
   integrity sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==
 
-"@redis/time-series@1.1.0":
+"@redis/time-series@1.1.0", "@redis/time-series@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.1.0.tgz#cba454c05ec201bd5547aaf55286d44682ac8eb5"
   integrity sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==
@@ -8590,7 +8595,21 @@ cache-manager-redis-store@^3.0.1:
   dependencies:
     redis "^4.3.1"
 
-cache-manager@^5.4.0:
+cache-manager-redis-yet@^5.1.5:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/cache-manager-redis-yet/-/cache-manager-redis-yet-5.1.5.tgz#9175287ca0f7efa9a2d3b76d51b7825a98629f80"
+  integrity sha512-NYDxrWBoLXxxVPw4JuBriJW0f45+BVOAsgLiozRo4GoJQyoKPbueQWYStWqmO73/AeHJeWrV7Hzvk6vhCGHlqA==
+  dependencies:
+    "@redis/bloom" "^1.2.0"
+    "@redis/client" "^1.6.0"
+    "@redis/graph" "^1.1.1"
+    "@redis/json" "^1.0.7"
+    "@redis/search" "^1.2.0"
+    "@redis/time-series" "^1.1.0"
+    cache-manager "^5.7.6"
+    redis "^4.7.0"
+
+cache-manager@^5.4.0, cache-manager@^5.7.6:
   version "5.7.6"
   resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-5.7.6.tgz#bdd8a154c73e5233824aa09ceb359ed225d37b7e"
   integrity sha512-wBxnBHjDxF1RXpHCBD6HGvKER003Ts7IIm0CHpggliHzN1RZditb7rXoduE1rplc2DEFYKxhLKgFuchXMJje9w==
@@ -10231,7 +10250,14 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@3.1.8, ejs@^3.0.0, ejs@^3.1.10, ejs@^3.1.8:
+ejs@3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
+
+ejs@^3.0.0, ejs@^3.1.10, ejs@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
@@ -10296,7 +10322,7 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-encode-utf8@^1.0.2:
+encode-utf8@^1.0.2, encode-utf8@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
   integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
@@ -11558,7 +11584,7 @@ fast-url-parser@^1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@4.4.1, fast-xml-parser@^4.2.2:
+fast-xml-parser@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
   integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
@@ -12273,10 +12299,10 @@ globule@^1.0.0:
     lodash "^4.17.21"
     minimatch "~3.0.2"
 
-gluegun@5.1.6, gluegun@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-5.2.0.tgz#88ba1f76f20e68a135557a4a4c8ea283291a7491"
-  integrity sha512-jSUM5xUy2ztYFQANne17OUm/oAd7qSX7EBksS9bQDt9UvLPqcEkeWUebmaposb8Tx7eTTD8uJVWGRe6PYSsYkg==
+gluegun@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-5.1.6.tgz#74ec13193913dc610f5c1a4039972c70c96a7bad"
+  integrity sha512-9zbi4EQWIVvSOftJWquWzr9gLX2kaDgPkNR5dYWbM53eVvCI3iKuxLlnKoHC0v4uPoq+Kr/+F569tjoFbA4DSA==
   dependencies:
     apisauce "^2.1.5"
     app-module-path "^2.2.0"
@@ -16108,14 +16134,21 @@ node-fetch-native@^1.6.4:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.4.tgz#679fc8fd8111266d47d7e72c379f1bed9acff06e"
   integrity sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==
 
-node-fetch@2.6.9, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.8, node-fetch@^2.6.9, node-fetch@^2.7.0:
+node-fetch@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.8, node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1.0.0, node-forge@^1.3.1:
+node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
@@ -17488,12 +17521,13 @@ qrcode-terminal-nooctal@^0.12.1:
   resolved "https://registry.yarnpkg.com/qrcode-terminal-nooctal/-/qrcode-terminal-nooctal-0.12.1.tgz#45016aca0d82b2818de7af0a06d072ad671fbe2e"
   integrity sha512-jy/kkD0iIMDjTucB+5T6KBsnirlhegDH47vHgrj5MejchSQmi/EAMM0xMFeePgV9CJkkAapNakpVUWYgHvtdKg==
 
-qrcode@1.5.3, qrcode@^1.5.0:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.4.tgz#5cb81d86eb57c675febb08cf007fff963405da88"
-  integrity sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==
+qrcode@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.3.tgz#03afa80912c0dccf12bc93f615a535aad1066170"
+  integrity sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==
   dependencies:
     dijkstrajs "^1.0.1"
+    encode-utf8 "^1.0.3"
     pngjs "^5.0.0"
     yargs "^15.3.1"
 
@@ -17941,7 +17975,7 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-redis@^4.3.1:
+redis@^4.3.1, redis@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.7.0.tgz#b401787514d25dd0cfc22406d767937ba3be55d6"
   integrity sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==
@@ -18487,7 +18521,31 @@ secp256k1@^5.0.0:
     node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
-"semver@2 || 3 || 4 || 5", semver@7.3.5, semver@7.4.0, semver@^5.5.0, semver@^6.0.0, semver@^6.3.0, semver@^6.3.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+semver@7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.4.0.tgz#8481c92feffc531ab1e012a8ffc15bdd3a0f4318"
+  integrity sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -19161,16 +19219,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19287,7 +19336,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19300,13 +19349,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -20384,7 +20426,14 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici@5.28.4, undici@^5.14.0, undici@^6.11.1:
+undici@5.28.4, undici@^5.14.0:
+  version "5.28.4"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
+  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
+
+undici@^6.11.1:
   version "6.20.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.20.1.tgz#fbb87b1e2b69d963ff2d5410a40ffb4c9e81b621"
   integrity sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==
@@ -21445,7 +21494,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21458,15 +21507,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -21503,10 +21543,30 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@7.4.6, ws@8.13.0, ws@8.17.1, ws@8.18.0, ws@^7.4.5, ws@^7.4.6, ws@^7.5.1, ws@^8.11.0, ws@^8.12.0, ws@^8.17.1, ws@^8.18.0, ws@~8.17.1:
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
+  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+
+ws@8.17.1, ws@~8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
+ws@8.18.0, ws@^8.11.0, ws@^8.12.0, ws@^8.17.1, ws@^8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+ws@^7.4.5, ws@^7.4.6, ws@^7.5.1:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 xdeployer@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description
Fixing invalid usage of cache-manager `ttl` value.

## Summary of changes
We use `@nestjs/cache-manager@2.2.1` that under the hood just creates instance of `cache-manager` package ([ref](https://github.com/nestjs/cache-manager/blob/2.2.1/lib/cache.providers.ts#L29-L51)) that is being installed in the project (5.4.0 in our case). When we import `Cache` type for it - we see that `ttl` is just a third argument and is in milliseconds. Under the hood `cache-manager` calls the `set` method of the store ([ref](https://github.com/jaredwray/cacheable/blob/5.1.4/src/caching.ts#L89)) in the same fashion. However, when we register cache module, we create a redis store based on `cache-manager-redis-store`, that accepts ttl in `options` argument ([ref](https://github.com/dabroek/node-cache-manager-redis-store/blob/v3.0.1/index.js)), so it's not compatible with the used version of `cache-manager`, so in order to fix that we have two options:
- downgrade `cache-manager` to v4, that used same signature ([ref](https://github.com/jaredwray/cacheable/blob/4.0.0/lib/caching.js#L90))
- use different store, e.g. `cache-manager-redis-yet` that is compatible with v5 ([ref](https://github.com/jaredwray/cache-manager-stores/blob/6b3f4e65dca31edd6cde1982f75e6296ede63342/packages/cache-manager-redis-yet/src/index.ts#L81))

I decided to go with the second option due to next reasons:
- using this store is mentioned in `nestjs` docs, so it's not surprising
- downgrading to v4 might introduce some bugs/regressions
- even though `cache-manager-redis-yet` is deprecated, it can be removed from npm due to dependencies and number of downloads; and at the same time `nestjs/cache-manager` should introduce support for the `cache-manager/v6` soone that should eliminate such dep ([ref](https://github.com/nestjs/cache-manager/issues/516#issuecomment-2422371991)); once it's there - we will upgrade and also get back to using seconds

Also refactored healthcheck for `cache-manager`: under the hood it can be any storage (Redis, Memcached, Mongo, etc.) and in case if health indicator depends on store's API we can miss updating our healthcheck if we change the store

## How test the changes
- [x] simply run the app and use `TTL` command to check that values are set on all necessary keys
- [x] existing unit tests pass 

## Related issues
To close #2671, #2672 