### PR TITLE
[Dasbhoard] refactor: use same redis-store as for human app

### DIFF
--- a/packages/apps/dashboard/server/package.json
+++ b/packages/apps/dashboard/server/package.json
@@ -23,8 +23,10 @@
     "@nestjs/core": "^10.2.8",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.3.10",
-    "cache-manager-redis-store": "^3.0.1",
+    "cache-manager": "^5.4.0",
+    "cache-manager-redis-yet": "^5.1.5",
     "dayjs": "^1.11.12",
+    "lodash": "^4.17.21",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.2.0"
   },

--- a/packages/apps/dashboard/server/src/app.module.ts
+++ b/packages/apps/dashboard/server/src/app.module.ts
@@ -21,8 +21,12 @@ import { StatsModule } from './modules/stats/stats.module';
       validationSchema: Joi.object({
         HOST: Joi.string().required(),
         PORT: Joi.number().port().default(3000),
+        REDIS_HOST: Joi.string(),
+        REDIS_PORT: Joi.number(),
         SUBGRAPH_API_KEY: Joi.string().required(),
         HCAPTCHA_API_KEY: Joi.string().required(),
+        CACHE_HMT_PRICE_TTL: Joi.number(),
+        CACHE_HMT_GENERAL_STATS_TTL: Joi.number(),
       }),
     }),
     CacheModule.registerAsync(CacheFactoryConfig),

--- a/packages/apps/dashboard/server/src/common/config/cache-factory.config.ts
+++ b/packages/apps/dashboard/server/src/common/config/cache-factory.config.ts
@@ -1,7 +1,15 @@
 import { CacheModuleAsyncOptions } from '@nestjs/common/cache';
 import { ConfigModule } from '@nestjs/config';
+import * as _ from 'lodash';
 import { RedisConfigService } from './redis-config.service';
-import { redisStore } from 'cache-manager-redis-store';
+import { redisStore } from 'cache-manager-redis-yet';
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('CacheFactoryRedisStore');
+
+const throttledRedisErrorLog = _.throttle((error) => {
+  logger.error('Redis client network error', error);
+}, 1000 * 5);
 
 export const CacheFactoryConfig: CacheModuleAsyncOptions = {
   isGlobal: true,
@@ -12,7 +20,11 @@ export const CacheFactoryConfig: CacheModuleAsyncOptions = {
         host: configService.redisHost,
         port: configService.redisPort,
       },
+      disableOfflineQueue: true,
     });
+
+    store.client.on('error', throttledRedisErrorLog);
+
     return {
       store: () => store,
     };

--- a/packages/apps/dashboard/server/src/common/config/redis-config.service.ts
+++ b/packages/apps/dashboard/server/src/common/config/redis-config.service.ts
@@ -17,18 +17,22 @@ export class RedisConfigService {
     return this.configService.get<string>('REDIS_HOST', DEFAULT_REDIS_HOST);
   }
   get redisPort(): number {
-    return +this.configService.get<number>('REDIS_PORT', DEFAULT_REDIS_PORT);
+    return this.configService.get<number>('REDIS_PORT', DEFAULT_REDIS_PORT);
   }
   get cacheHmtPriceTTL(): number {
-    return +this.configService.get<number>(
-      'CACHE_HMT_PRICE_TTL',
-      DEFAULT_CACHE_HMT_PRICE_TTL,
+    return (
+      this.configService.get<number>(
+        'CACHE_HMT_PRICE_TTL',
+        DEFAULT_CACHE_HMT_PRICE_TTL,
+      ) * 1000
     );
   }
   get cacheHmtGeneralStatsTTL(): number {
-    return +this.configService.get<number>(
-      'CACHE_HMT_GENERAL_STATS_TTL',
-      DEFAULT_CACHE_HMT_GENERAL_STATS_TTL,
+    return (
+      this.configService.get<number>(
+        'CACHE_HMT_GENERAL_STATS_TTL',
+        DEFAULT_CACHE_HMT_GENERAL_STATS_TTL,
+      ) * 1000
     );
   }
   get hmtPriceCacheKey(): string {

--- a/packages/apps/dashboard/server/src/modules/stats/stats.service.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/stats.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { lastValueFrom } from 'rxjs';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs';
 import { Cron } from '@nestjs/schedule';
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NETWORKS, StatisticsClient } from '@human-protocol/sdk';
@@ -322,7 +322,7 @@ export class StatsService implements OnModuleInit {
     await this.cacheManager.set(
       this.redisConfigService.hmtPriceCacheKey,
       hmtPrice,
-      { ttl: this.redisConfigService.cacheHmtPriceTTL } as any,
+      this.redisConfigService.cacheHmtPriceTTL,
     );
     return hmtPrice;
   }

--- a/packages/apps/dashboard/server/tsconfig.json
+++ b/packages/apps/dashboard/server/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "esModuleInterop": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8583,13 +8583,6 @@ cacache@^18.0.0:
     tar "^6.1.11"
     unique-filename "^3.0.0"
 
-cache-manager-redis-store@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cache-manager-redis-store/-/cache-manager-redis-store-3.0.1.tgz#8eeb211212763d04cef4058666182d624f714299"
-  integrity sha512-o560kw+dFqusC9lQJhcm6L2F2fMKobJ5af+FoR2PdnMVdpQ3f3Bz6qzvObTGyvoazQJxjQNWgMQeChP4vRTuXQ==
-  dependencies:
-    redis "^4.3.1"
-
 cache-manager-redis-yet@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/cache-manager-redis-yet/-/cache-manager-redis-yet-5.1.5.tgz#9175287ca0f7efa9a2d3b76d51b7825a98629f80"
@@ -17955,7 +17948,7 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-redis@^4.3.1, redis@^4.7.0:
+redis@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.7.0.tgz#b401787514d25dd0cfc22406d767937ba3be55d6"
   integrity sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==


### PR DESCRIPTION
## Description
Same as https://github.com/humanprotocol/human-protocol/pull/2742

## Summary of changes
- refactored to use `cache-manager-redis-yet` for dashboard
- added schema validation for some numeric env vars, so we don't have to cast them in the code
- added `esModuleInterop` option to TS config in order to enabled common imports (it required to change the way we import `dayjs`

## How test the changes
- [x] run locally, trigger `stats/hmt-price` endpoint, check `hmt-price` cache key has proper ttl value

## Related issues
Freestyle