### PR TITLE
[HUMAN App client] Fix oracles discovery tab

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
+++ b/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
@@ -37,21 +37,22 @@ export async function getOracles({
   signal: AbortSignal;
 }) {
   let oracles = [H_CAPTCHA_ORACLE];
-  const queryParams = selected_job_types.length
-    ? `?${stringifyUrlQueryObject({ selected_job_types })}`
-    : '';
+  if (env.VITE_FEATURE_FLAG_JOBS_DISCOVERY) {
+    const queryParams = selected_job_types.length
+      ? `?${stringifyUrlQueryObject({ selected_job_types })}`
+      : '';
 
-  const result = await apiClient(
-    `${apiPaths.worker.oracles.path}${queryParams}`,
-    {
-      successSchema: OraclesSuccessSchema,
-      options: { method: 'GET' },
-    },
-    signal
-  );
+    const result = await apiClient(
+      `${apiPaths.worker.oracles.path}${queryParams}`,
+      {
+        successSchema: OraclesSuccessSchema,
+        options: { method: 'GET' },
+      },
+      signal
+    );
 
-  oracles = oracles.concat(result);
-
+    oracles = oracles.concat(result);
+  }
   return oracles;
 }
 

--- a/packages/apps/human-app/frontend/src/components/layout/drawer-menu-items/drawer-menu-items-worker.tsx
+++ b/packages/apps/human-app/frontend/src/components/layout/drawer-menu-items/drawer-menu-items-worker.tsx
@@ -5,7 +5,6 @@ import type {
 } from '@/components/layout/protected/drawer-navigation';
 import { HelpIcon, UserOutlinedIcon, WorkIcon } from '@/components/ui/icons';
 import { routerPaths } from '@/router/router-paths';
-import { env } from '@/shared/env';
 import { DarkModeSwitch } from '@/components/ui/dark-mode-switch';
 import type { UserData } from '@/auth/auth-context';
 
@@ -13,16 +12,14 @@ export const workerDrawerTopMenuItems = (
   user: UserData | null
 ): TopMenuItem[] => {
   return [
-    ...(env.VITE_FEATURE_FLAG_JOBS_DISCOVERY
-      ? [
-          {
-            label: t('components.DrawerNavigation.jobs'),
-            icon: <WorkIcon />,
-            link: routerPaths.worker.jobsDiscovery,
-            disabled: !user?.wallet_address || user.kyc_status !== 'approved',
-          },
-        ]
-      : []),
+    ...[
+      {
+        label: t('components.DrawerNavigation.jobs'),
+        icon: <WorkIcon />,
+        link: routerPaths.worker.jobsDiscovery,
+        disabled: !user?.wallet_address || user.kyc_status !== 'approved',
+      },
+    ],
   ];
 };
 

--- a/packages/apps/human-app/frontend/src/router/routes.tsx
+++ b/packages/apps/human-app/frontend/src/router/routes.tsx
@@ -90,18 +90,18 @@ export const protectedRoutes: {
       headerText: t('protectedPagesHeaders.profile'),
     },
   },
+  {
+    routerProps: {
+      path: routerPaths.worker.jobsDiscovery,
+      element: <JobsDiscoveryPage />,
+    },
+    pageHeaderProps: {
+      headerIcon: <HomepageWorkIcon />,
+      headerText: t('protectedPagesHeaders.jobsDiscovery'),
+    },
+  },
   ...(env.VITE_FEATURE_FLAG_JOBS_DISCOVERY
     ? [
-        {
-          routerProps: {
-            path: routerPaths.worker.jobsDiscovery,
-            element: <JobsDiscoveryPage />,
-          },
-          pageHeaderProps: {
-            headerIcon: <HomepageWorkIcon />,
-            headerText: t('protectedPagesHeaders.jobsDiscovery'),
-          },
-        },
         {
           routerProps: {
             path: `${routerPaths.worker.jobs}/:address`,


### PR DESCRIPTION
## Issue tracking
The issue was generated when hcaptcha was moved into oracles discovery tab.
Since this change VITE_FEATURE_FLAG_JOBS_DISCOVERY is false, tasks tab is not visible.

## Context behind the change
Tasks menu option will now always be visible and oracles other than hcaptcha will only be shown in case VITE_FEATURE_FLAG_JOBS_DISCOVERY is true

## How has this been tested?
Deployed on render as a hot fix
![image](https://github.com/user-attachments/assets/35d56c3b-b3d8-44e7-bb69-f9aa8f029d8c)


## Release plan
None

## Potential risks; What to monitor; Rollback plan
None