### PR TITLE
[CVAT][Exchange Oracle] Fix handling of projects in validation status

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/services/cvat.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/cvat.py
@@ -203,7 +203,7 @@ def create_escrow_validations(session: Session):
     allowed_statuses = [ProjectStatuses.completed, ProjectStatuses.validation]
     # excluding escrows where all projects are still have `validation` status
     at_least_one_is_completed = (
-        func.count(case((Project.status == ProjectStatuses.completed, 1), else_=0)) > 0
+        func.sum(case((Project.status == ProjectStatuses.completed, 1), else_=0)) > 0
     )
     select_stmt = (
         select(

--- a/packages/examples/cvat/exchange-oracle/tests/integration/cron/state_trackers/test_track_completed_escrows.py
+++ b/packages/examples/cvat/exchange-oracle/tests/integration/cron/state_trackers/test_track_completed_escrows.py
@@ -745,6 +745,8 @@ class ServiceIntegrationTest(unittest.TestCase):
             )
             self.session.add(assignment)
 
+        create_escrow_validations(self.session)
+
         self.session.commit()
         validations = self.session.execute(select(EscrowValidation)).all()
         assert not validations


### PR DESCRIPTION
## Context behind the change
Use correct function to count all of the projects in completed status. Previously count() was used that just counted all records, however the logic requires use of sum() to ignore cases that evaluate to 0.

## How has this been tested?
Fixed previously non-working test case.

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->