### PR TITLE
[Human App] Converted all chainIds values ​​to type ChainId

### DIFF
--- a/packages/apps/human-app/server/src/common/config/environment-config.service.spec.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.spec.ts
@@ -1,0 +1,50 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { EnvironmentConfigService } from './environment-config.service';
+import { ChainId } from '@human-protocol/sdk';
+
+describe('EnvironmentConfigService', () => {
+  let service: EnvironmentConfigService;
+  let configService: ConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EnvironmentConfigService,
+        {
+          provide: ConfigService,
+          useValue: {
+            getOrThrow: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<EnvironmentConfigService>(EnvironmentConfigService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  it('should return an array of valid ChainIds when CHAIN_IDS_ENABLED is valid', () => {
+    (configService.getOrThrow as jest.Mock).mockReturnValue('1, 4, 80002');
+
+    const result = service.chainIdsEnabled;
+
+    expect(result).toEqual([ChainId.MAINNET, ChainId.RINKEBY, ChainId.POLYGON_AMOY]);
+  });
+
+  it('should ignore invalid chain IDs and only return valid ChainIds', () => {
+    (configService.getOrThrow as jest.Mock).mockReturnValue('1, 4, 99999, 80002');
+
+    const result = service.chainIdsEnabled;
+
+    expect(result).toEqual([ChainId.MAINNET, ChainId.RINKEBY, ChainId.POLYGON_AMOY]);
+  });
+
+  it('should return an empty array if CHAIN_IDS_ENABLED is empty', () => {
+    (configService.getOrThrow as jest.Mock).mockReturnValue('');
+
+    const result = service.chainIdsEnabled;
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/apps/human-app/server/src/common/config/environment-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
+import { ChainId } from '@human-protocol/sdk';
 
 const DEFAULT_CACHE_TTL_HCAPTCHA_USER_STATS = 12 * 60 * 60;
 const DEFAULT_CACHE_TTL_ORACLE_STATS = 12 * 60 * 60;
@@ -255,9 +256,12 @@ export class EnvironmentConfigService {
    * The list of enabled chain IDs.
    * Required
    */
-  get chainIdsEnabled(): string[] {
+  get chainIdsEnabled(): ChainId[] {
     const chainIds = this.configService.getOrThrow<string>('CHAIN_IDS_ENABLED');
-    return chainIds.split(',').map((id) => id.trim());
+    return chainIds
+      .split(',')
+      .map((id) => parseInt(id.trim(), 10))
+      .filter((id): id is ChainId => !isNaN(id) && Object.values(ChainId).includes(id));
   }
 
   /**

--- a/packages/apps/human-app/server/src/integrations/kv-store/kv-store.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/kv-store/kv-store.gateway.ts
@@ -50,7 +50,7 @@ export class KvStoreGateway {
     }
   }
 
-  async getJobTypesByAddress(address: string): Promise<string | void> {
+  async getJobTypesByAddress(chainId: ChainId, address: string): Promise<string | void> {
     const key = `jobTypes:${address}`;
     const cachedData: string | undefined = await this.cacheManager.get(key);
     if (cachedData) {
@@ -59,10 +59,6 @@ export class KvStoreGateway {
 
     let jobTypes: string;
     try {
-      const runner = new ethers.JsonRpcProvider(this.configService.rpcUrl);
-      const network = await runner.provider?.getNetwork();
-      const chainId: ChainId = Number(network?.chainId);
-
       jobTypes = await KVStoreUtils.get(chainId, address, KVStoreKeys.jobTypes);
     } catch (e) {
       if (e.toString().includes('Error: Invalid address')) {

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -125,7 +125,7 @@ export class CronJobService {
   private async resetRetriesCount(oracleData: OracleDiscoveryResponse) {
     oracleData.retriesCount = 0;
 
-    const chainId = oracleData.chainId;
+    const chainId = oracleData.chainId.toString();
     const cachedOracles =
       await this.cacheManager.get<OracleDiscoveryResponse[]>(chainId);
 
@@ -142,7 +142,7 @@ export class CronJobService {
   }
 
   private async handleJobListError(oracleData: OracleDiscoveryResponse) {
-    const chainId = oracleData.chainId;
+    const chainId = oracleData.chainId?.toString();
     const cachedOracles =
       await this.cacheManager.get<OracleDiscoveryResponse[]>(chainId);
 

--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -13,6 +13,7 @@ import { JOB_DISCOVERY_CACHE_KEY } from '../../../common/constants/cache';
 import { JobStatus } from '../../../common/enums/global-common';
 import { OracleDiscoveryResponse } from '../../../modules/oracle-discovery/model/oracle-discovery.model';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { ChainId } from '@human-protocol/sdk';
 
 jest.mock('cron', () => {
   return {
@@ -52,7 +53,7 @@ describe('CronJobService', () => {
       email: 'human-app@hmt.ai',
       password: 'Test1234*',
       cacheTtlOracleDiscovery: 600,
-      chainIdsEnabled: ['137', '1'],
+      chainIdsEnabled: [ChainId.POLYGON, ChainId.MAINNET],
       jobsDiscoveryFlag: false,
     };
 
@@ -166,7 +167,7 @@ describe('CronJobService', () => {
       const oracle: OracleDiscoveryResponse = {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '137',
+        chainId: ChainId.POLYGON,
         retriesCount: 0,
       };
       const token = 'Bearer token';
@@ -193,7 +194,7 @@ describe('CronJobService', () => {
       const oracle: OracleDiscoveryResponse = {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '137',
+        chainId: ChainId.POLYGON,
         retriesCount: 0,
       };
       const token = 'Bearer token';
@@ -218,7 +219,7 @@ describe('CronJobService', () => {
       const oracle: OracleDiscoveryResponse = {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '137',
+        chainId: ChainId.POLYGON,
         retriesCount: 3,
       };
       const token = 'Bearer token';
@@ -314,7 +315,7 @@ describe('CronJobService', () => {
       const oracleData: OracleDiscoveryResponse = {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '137',
+        chainId: ChainId.POLYGON,
         retriesCount: 5,
       };
 
@@ -324,7 +325,7 @@ describe('CronJobService', () => {
 
       expect(oracleData.retriesCount).toBe(0);
       expect(cacheManagerMock.set).toHaveBeenCalledWith(
-        oracleData.chainId,
+        oracleData.chainId.toString(),
         [oracleData],
         configServiceMock.cacheTtlOracleDiscovery,
       );
@@ -336,7 +337,7 @@ describe('CronJobService', () => {
       const oracleData: OracleDiscoveryResponse = {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '137',
+        chainId: ChainId.POLYGON,
         retriesCount: 4,
       };
 
@@ -346,7 +347,7 @@ describe('CronJobService', () => {
 
       expect(oracleData.retriesCount).toBe(5);
       expect(cacheManagerMock.set).toHaveBeenCalledWith(
-        oracleData.chainId,
+        oracleData.chainId.toString(),
         [oracleData],
         configServiceMock.cacheTtlOracleDiscovery,
       );
@@ -356,7 +357,7 @@ describe('CronJobService', () => {
       const oracleData: OracleDiscoveryResponse = {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '137',
+        chainId: ChainId.POLYGON,
         retriesCount: 2,
       };
 
@@ -366,7 +367,7 @@ describe('CronJobService', () => {
 
       expect(oracleData.retriesCount).toBe(3);
       expect(cacheManagerMock.set).toHaveBeenCalledWith(
-        oracleData.chainId,
+        oracleData.chainId.toString(),
         [oracleData],
         configServiceMock.cacheTtlOracleDiscovery,
       );

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.controller.spec.ts
@@ -16,6 +16,7 @@ import { CommonConfigModule } from '../../../common/config/common-config.module'
 import { ConfigModule } from '@nestjs/config';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { ChainId } from '@human-protocol/sdk';
 
 describe('JobsDiscoveryController', () => {
   let controller: JobsDiscoveryController;
@@ -24,7 +25,7 @@ describe('JobsDiscoveryController', () => {
     email: 'human-app@hmt.ai',
     password: 'Test1234*',
     cacheTtlOracleDiscovery: 600,
-    chainIdsEnabled: ['137', '1'],
+    chainIdsEnabled: [ChainId.POLYGON, ChainId.MAINNET],
     jobsDiscoveryFlag: true,
   };
 

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
@@ -1,4 +1,4 @@
-import { IOperator } from '@human-protocol/sdk';
+import { ChainId, IOperator } from '@human-protocol/sdk';
 import { AutoMap } from '@automapper/classes';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsArray, IsOptional } from 'class-validator';
@@ -6,7 +6,7 @@ import { Transform } from 'class-transformer';
 
 export class OracleDiscoveryResponse implements IOperator {
   address: string;
-  chainId: string;
+  chainId: ChainId;
   role?: string;
   url?: string;
   jobTypes?: string[];
@@ -15,7 +15,7 @@ export class OracleDiscoveryResponse implements IOperator {
   retriesCount = 0;
   constructor(
     address: string,
-    chainId: string,
+    chainId: ChainId,
     role?: string,
     url?: string,
     jobTypes?: string[],

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -15,6 +15,7 @@ import { EnvironmentConfigService } from '../../../common/config/environment-con
 import { CommonConfigModule } from '../../../common/config/common-config.module';
 import { ConfigModule } from '@nestjs/config';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { ChainId } from '@human-protocol/sdk';
 
 describe('OracleDiscoveryController', () => {
   let controller: OracleDiscoveryController;
@@ -23,7 +24,7 @@ describe('OracleDiscoveryController', () => {
     email: 'human-app@hmt.ai',
     password: 'Test1234*',
     cacheTtlOracleDiscovery: 600,
-    chainIdsEnabled: ['137', '1'],
+    chainIdsEnabled: [ChainId.POLYGON, ChainId.MAINNET],
     jobsDiscoveryFlag: true,
   };
 

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@human-protocol/sdk';
 import {
   OracleDiscoveryCommand,
   OracleDiscoveryResponse,
@@ -6,7 +7,7 @@ import {
 export function generateOracleDiscoveryResponseBody() {
   const response1: OracleDiscoveryResponse = {
     address: '0xd06eac24a0c47c776Ce6826A93162c4AfC029047',
-    chainId: '4200',
+    chainId: ChainId.POLYGON_AMOY,
     role: 'role1',
     url: 'common-url',
     jobTypes: ['job-type-3'],
@@ -14,7 +15,7 @@ export function generateOracleDiscoveryResponseBody() {
   };
   const response2: OracleDiscoveryResponse = {
     address: '0xd10c3402155c058D78e4D5fB5f50E125F06eb39d',
-    chainId: '4200',
+    chainId: ChainId.POLYGON_AMOY,
     role: 'role2',
     url: 'common-url',
     jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
@@ -22,7 +23,7 @@ export function generateOracleDiscoveryResponseBody() {
   };
   const response3: OracleDiscoveryResponse = {
     address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
-    chainId: '4200',
+    chainId: ChainId.POLYGON_AMOY,
     role: 'role3',
     url: 'common-url',
     jobTypes: ['job-type-2'],
@@ -30,7 +31,7 @@ export function generateOracleDiscoveryResponseBody() {
   };
   const response4: OracleDiscoveryResponse = {
     address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
-    chainId: '4200',
+    chainId: ChainId.POLYGON_AMOY,
     role: 'role3',
     jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
     retriesCount: 0,

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
@@ -1,4 +1,4 @@
-import { OperatorUtils } from '@human-protocol/sdk';
+import { ChainId, OperatorUtils } from '@human-protocol/sdk';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
@@ -28,7 +28,7 @@ jest.mock('@human-protocol/sdk', () => {
 
 describe('OracleDiscoveryService', () => {
   const EXCHANGE_ORACLE = 'Exchange Oracle';
-  const EXPECTED_CHAIN_IDS = ['4200'];
+  const EXPECTED_CHAIN_IDS = [ChainId.POLYGON_AMOY];
   const REPUTATION_ORACLE_ADDRESS = 'the_oracle';
   const TTL = '300';
   const JOB_TYPES = 'job-type-1, job-type-2, job-type-3';
@@ -91,13 +91,13 @@ describe('OracleDiscoveryService', () => {
       {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 0,
       },
       {
         address: 'mockAddress2',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 0,
       },
     ];
@@ -116,14 +116,14 @@ describe('OracleDiscoveryService', () => {
         address: 'mockAddress1',
         role: 'validator',
         url: 'url1',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 0,
         jobTypes: ['job-type-1'],
       },
       {
         address: 'mockAddress2',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 0,
         jobTypes: ['job-type-2'],
       },
@@ -139,9 +139,9 @@ describe('OracleDiscoveryService', () => {
 
     expect(result).toEqual([mockData[0]]);
     EXPECTED_CHAIN_IDS.forEach((chainId) => {
-      expect(cacheManager.get).toHaveBeenCalledWith(chainId);
+      expect(cacheManager.get).toHaveBeenCalledWith(chainId.toString());
       expect(cacheManager.set).toHaveBeenCalledWith(
-        chainId,
+        chainId.toString(),
         [mockData[0]],
         TTL,
       );
@@ -217,7 +217,7 @@ describe('OracleDiscoveryService', () => {
 
     expect(result).toEqual([]);
     expect(loggerErrorSpy).toHaveBeenCalledWith(
-      `Error processing chainId 4200:`,
+      `Error processing chainId ${ChainId.POLYGON_AMOY}:`,
       error,
     );
   });
@@ -233,7 +233,7 @@ describe('OracleDiscoveryService', () => {
 
     expect(result).toEqual([]);
     EXPECTED_CHAIN_IDS.forEach((chainId) => {
-      expect(cacheManager.get).toHaveBeenCalledWith(chainId);
+      expect(cacheManager.get).toHaveBeenCalledWith(chainId.toString());
     });
   });
 
@@ -242,13 +242,13 @@ describe('OracleDiscoveryService', () => {
       {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 5,
       },
       {
         address: 'mockAddress2',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 0,
       },
     ];
@@ -266,13 +266,13 @@ describe('OracleDiscoveryService', () => {
       {
         address: 'mockAddress1',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 5,
       },
       {
         address: 'mockAddress2',
         role: 'validator',
-        chainId: '4200',
+        chainId: ChainId.POLYGON_AMOY,
         retriesCount: 5,
       },
     ];


### PR DESCRIPTION
## Issue tracking
[Human App] Convert all chainIds values ​​to type ChainId
[#2725](https://github.com/humanprotocol/human-protocol/issues/2725)

## Context behind the change
This update aims to improve type safety by changing `chainId` values from `string` to a `ChainId` type. Key updates include modifying the `chainIdsEnabled` method in `environment-config.service.ts` to return `ChainId[]` and updating functions in `KvStoreGateway` to accept a `ChainId` type.

## How has this been tested?
The changes were tested as follows:
1. Updated unit tests to validate the correct type and usage of `ChainId` in affected methods.
2. Verified app functionality in key areas relying on chain ID logic, particularly focusing on `environment-config.service.ts` and `KvStoreGateway`.
3. Conducted unit tests.

### Rollback plan
If issues arise, revert the `ChainId` type casting changes and roll back to using string-based `chainId` values.