### PR TITLE
[Reputation Oracle] feat: get rid of sdk's storage module

### DIFF
--- a/packages/apps/job-launcher/server/tsconfig.json
+++ b/packages/apps/job-launcher/server/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
-    "target": "ES2020",
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/apps/reputation-oracle/server/docker-compose.yml
+++ b/packages/apps/reputation-oracle/server/docker-compose.yml
@@ -26,12 +26,9 @@ services:
     ports:
       - 9001:9001
       - 9000:9000
-    environment:
-      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
-      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
     entrypoint: 'sh'
     command:
-      -c "mkdir -p /data/reputation && minio server /data --console-address ':9001'"
+      -c "minio server /data --console-address ':9001'"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
@@ -45,7 +42,7 @@ services:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc config host add myminio http://minio:9000 ${S3_ACCESS_KEY} ${S3_SECRET_KEY};
+      /usr/bin/mc config host add myminio http://minio:9000 minioadmin minioadmin;
       /usr/bin/mc mb myminio/reputation;
       /usr/bin/mc anonymous set public myminio/reputation;
       "

--- a/packages/apps/reputation-oracle/server/src/common/errors/base.ts
+++ b/packages/apps/reputation-oracle/server/src/common/errors/base.ts
@@ -1,0 +1,11 @@
+export class BaseError extends Error {
+  constructor(message: string, cause?: unknown) {
+    const errorOptions: ErrorOptions = {};
+    if (cause) {
+      errorOptions.cause = cause;
+    }
+
+    super(message, errorOptions);
+    this.name = this.constructor.name;
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
@@ -142,7 +142,9 @@ describe('PayoutService', () => {
         job_bounty: '10',
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue(manifest);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(manifest);
 
       const escrowAddress = MOCK_ADDRESS;
       const chainId = ChainId.LOCALHOST;
@@ -160,7 +162,9 @@ describe('PayoutService', () => {
         requestType: JobRequestType.FORTUNE,
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue(manifest);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(manifest);
 
       const results: SaveResultDto = {
         url: MOCK_FILE_URL,
@@ -236,7 +240,9 @@ describe('PayoutService', () => {
         job_bounty: '10',
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue(manifest);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(manifest);
 
       const escrowAddress = MOCK_ADDRESS;
       const chainId = ChainId.LOCALHOST;
@@ -261,7 +267,9 @@ describe('PayoutService', () => {
         requestType: JobRequestType.FORTUNE,
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue(manifest);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(manifest);
 
       const results: PayoutsDataDto = {
         recipients: [MOCK_ADDRESS],
@@ -332,7 +340,7 @@ describe('PayoutService', () => {
       ];
 
       jest
-        .spyOn(storageService, 'download')
+        .spyOn(storageService, 'downloadJsonLikeData')
         .mockResolvedValue(intermediateResults);
 
       jest.spyOn(storageService, 'uploadJobSolutions').mockResolvedValue({
@@ -361,7 +369,9 @@ describe('PayoutService', () => {
         requestType: JobRequestType.FORTUNE,
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue([] as any);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue([] as any);
 
       await expect(
         payoutService.saveResultsFortune(manifest, chainId, escrowAddress),
@@ -393,7 +403,7 @@ describe('PayoutService', () => {
       ];
 
       jest
-        .spyOn(storageService, 'download')
+        .spyOn(storageService, 'downloadJsonLikeData')
         .mockResolvedValue(intermediateResults);
 
       await expect(
@@ -425,7 +435,7 @@ describe('PayoutService', () => {
       ];
 
       jest
-        .spyOn(storageService, 'download')
+        .spyOn(storageService, 'downloadJsonLikeData')
         .mockResolvedValue(intermediateResults);
 
       const result = await payoutService.calculatePayoutsFortune(
@@ -475,7 +485,9 @@ describe('PayoutService', () => {
         url: MOCK_FILE_URL,
         hash: MOCK_FILE_HASH,
       });
-      jest.spyOn(storageService, 'download').mockResolvedValue(results);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(results);
 
       const result = await payoutService.saveResultsCvat(
         chainId,
@@ -539,7 +551,9 @@ describe('PayoutService', () => {
         ],
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue(results);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(results);
 
       const result = await payoutService.calculatePayoutsCvat(
         manifest as any,
@@ -563,7 +577,9 @@ describe('PayoutService', () => {
         results: [],
       };
 
-      jest.spyOn(storageService, 'download').mockResolvedValue(results);
+      jest
+        .spyOn(storageService, 'downloadJsonLikeData')
+        .mockResolvedValue(results);
 
       await expect(
         payoutService.calculatePayoutsCvat(

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
@@ -60,7 +60,8 @@ export class PayoutService {
       );
     }
 
-    const manifest = await this.storageService.download(manifestUrl);
+    const manifest =
+      await this.storageService.downloadJsonLikeData(manifestUrl);
 
     const requestType = getRequestType(manifest);
 
@@ -102,7 +103,8 @@ export class PayoutService {
       );
     }
 
-    const manifest = await this.storageService.download(manifestUrl);
+    const manifest =
+      await this.storageService.downloadJsonLikeData(manifestUrl);
 
     const requestType = getRequestType(manifest);
 
@@ -209,7 +211,7 @@ export class PayoutService {
     const intermediateResultsUrl =
       await escrowClient.getIntermediateResultsUrl(escrowAddress);
 
-    const intermediateResults = (await this.storageService.download(
+    const intermediateResults = (await this.storageService.downloadJsonLikeData(
       intermediateResultsUrl,
     )) as FortuneFinalResult[];
 
@@ -279,7 +281,7 @@ export class PayoutService {
     manifest: FortuneManifestDto,
     finalResultsUrl: string,
   ): Promise<PayoutsDataDto> {
-    const finalResults = (await this.storageService.download(
+    const finalResults = (await this.storageService.downloadJsonLikeData(
       finalResultsUrl,
     )) as FortuneFinalResult[];
 
@@ -315,9 +317,10 @@ export class PayoutService {
     const intermediateResultsUrl =
       await escrowClient.getIntermediateResultsUrl(escrowAddress);
 
-    const annotations: CvatAnnotationMeta = await this.storageService.download(
-      `${intermediateResultsUrl}/${CVAT_VALIDATION_META_FILENAME}`,
-    );
+    const annotations: CvatAnnotationMeta =
+      await this.storageService.downloadJsonLikeData(
+        `${intermediateResultsUrl}/${CVAT_VALIDATION_META_FILENAME}`,
+      );
 
     // If annotation meta results does not exist
     if (

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
@@ -137,7 +137,7 @@ describe('ReputationService', () => {
         };
 
         jest
-          .spyOn(storageService, 'download')
+          .spyOn(storageService, 'downloadJsonLikeData')
           .mockResolvedValueOnce(manifest) // Mock manifest
           .mockResolvedValueOnce([]); // Mock final results
 
@@ -165,7 +165,7 @@ describe('ReputationService', () => {
         ];
 
         jest
-          .spyOn(storageService, 'download')
+          .spyOn(storageService, 'downloadJsonLikeData')
           .mockResolvedValueOnce(manifest)
           .mockResolvedValueOnce(finalResults);
 
@@ -238,7 +238,7 @@ describe('ReputationService', () => {
         }));
 
         jest
-          .spyOn(storageService, 'download')
+          .spyOn(storageService, 'downloadJsonLikeData')
           .mockResolvedValueOnce(manifest) // Mock manifest
           .mockResolvedValueOnce([]); // Mock final results
 
@@ -289,7 +289,7 @@ describe('ReputationService', () => {
         };
 
         jest
-          .spyOn(storageService, 'download')
+          .spyOn(storageService, 'downloadJsonLikeData')
           .mockResolvedValueOnce(manifest)
           .mockResolvedValueOnce(annotationMeta);
 

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -65,7 +65,8 @@ export class ReputationService {
       );
     }
 
-    const manifest = await this.storageService.download(manifestUrl);
+    const manifest =
+      await this.storageService.downloadJsonLikeData(manifestUrl);
 
     const requestType = getRequestType(manifest);
 
@@ -160,7 +161,8 @@ export class ReputationService {
     const escrowClient = await EscrowClient.build(signer);
 
     const finalResultsUrl = await escrowClient.getResultsUrl(escrowAddress);
-    const finalResults = await this.storageService.download(finalResultsUrl);
+    const finalResults =
+      await this.storageService.downloadJsonLikeData(finalResultsUrl);
 
     if (finalResults.length === 0) {
       throw new ControlledError(
@@ -202,9 +204,10 @@ export class ReputationService {
     const intermediateResultsUrl =
       await escrowClient.getIntermediateResultsUrl(escrowAddress);
 
-    const annotations: CvatAnnotationMeta = await this.storageService.download(
-      `${intermediateResultsUrl}/${CVAT_VALIDATION_META_FILENAME}`,
-    );
+    const annotations: CvatAnnotationMeta =
+      await this.storageService.downloadJsonLikeData(
+        `${intermediateResultsUrl}/${CVAT_VALIDATION_META_FILENAME}`,
+      );
 
     // If annotation meta does not exist
     if (annotations && Array.isArray(annotations) && annotations.length === 0) {

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.errors.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.errors.ts
@@ -1,0 +1,25 @@
+import { BaseError } from '../../common/errors/base';
+
+export class FileDownloadError extends BaseError {
+  public readonly location: string;
+
+  constructor(location: string, cause?: unknown) {
+    super('Failed to download file', cause);
+
+    this.location = location;
+  }
+}
+
+export class InvalidFileUrl extends FileDownloadError {
+  constructor(url: string) {
+    super(url);
+    this.message = 'Invalid file URL';
+  }
+}
+
+export class FileNotFoundError extends FileDownloadError {
+  constructor(location: string) {
+    super(location);
+    this.message = 'File not found';
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.spec.ts
@@ -402,7 +402,10 @@ describe('StorageService', () => {
           .update('encrypted-file-content')
           .digest('hex')}.zip`,
         'encrypted-file-content',
-        { 'Cache-Control': 'no-store' },
+        {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/plain',
+        },
       );
     });
 
@@ -440,7 +443,10 @@ describe('StorageService', () => {
           .update('encrypted-file-content')
           .digest('hex')}.zip`,
         'encrypted-file-content',
-        { 'Cache-Control': 'no-store' },
+        {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/plain',
+        },
       );
     });
 
@@ -517,7 +523,10 @@ describe('StorageService', () => {
             .update('some-file-content')
             .digest('hex')}.zip`,
           someFileContent,
-          { 'Cache-Control': 'no-store' },
+          {
+            'Cache-Control': 'no-store',
+            'Content-Type': 'text/plain',
+          },
         );
       });
 
@@ -556,7 +565,10 @@ describe('StorageService', () => {
             .update(someFileContent)
             .digest('hex')}.zip`,
           someFileContent,
-          { 'Cache-Control': 'no-store' },
+          {
+            'Cache-Control': 'no-store',
+            'Content-Type': 'text/plain',
+          },
         );
       });
     });

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
@@ -238,6 +238,7 @@ export class StorageService {
         key,
         content,
         {
+          'Content-Type': 'text/plain',
           'Cache-Control': 'no-store',
         },
       );

--- a/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/storage/storage.service.ts
@@ -4,9 +4,9 @@ import {
   EncryptionUtils,
   EscrowClient,
   KVStoreUtils,
-  StorageClient,
 } from '@human-protocol/sdk';
 import { HttpStatus, Injectable } from '@nestjs/common';
+import axios from 'axios';
 import * as Minio from 'minio';
 import crypto from 'crypto';
 import { UploadedFile } from '../../common/interfaces/s3';
@@ -17,6 +17,11 @@ import { S3ConfigService } from '../../common/config/s3-config.service';
 import { PGPConfigService } from '../../common/config/pgp-config.service';
 import { ControlledError } from '../../common/errors/controlled';
 import { isNotFoundError } from '../../common/utils/minio';
+import {
+  FileDownloadError,
+  FileNotFoundError,
+  InvalidFileUrl,
+} from './storage.errors';
 
 @Injectable()
 export class StorageService {
@@ -35,6 +40,7 @@ export class StorageService {
       useSSL: this.s3ConfigService.useSSL,
     });
   }
+
   public getUrl(key: string): string {
     return `${this.s3ConfigService.useSSL ? 'https' : 'http'}://${
       this.s3ConfigService.endpoint
@@ -75,34 +81,64 @@ export class StorageService {
     ]);
   }
 
-  private async decryptFile(fileContent: any): Promise<any> {
-    if (
-      typeof fileContent === 'string' &&
-      EncryptionUtils.isEncrypted(fileContent)
-    ) {
-      const encryption = await Encryption.build(
-        this.pgpConfigService.privateKey!,
-        this.pgpConfigService.passphrase,
-      );
-      const decryptedData = await encryption.decrypt(fileContent);
-      const content = Buffer.from(decryptedData).toString();
-      try {
-        return JSON.parse(content);
-      } catch {
-        return content;
-      }
-    } else {
+  private async maybeDecryptFile(fileContent: Buffer): Promise<Buffer> {
+    const contentAsString = fileContent.toString();
+    if (!EncryptionUtils.isEncrypted(contentAsString)) {
       return fileContent;
+    }
+
+    const encryption = await Encryption.build(
+      this.pgpConfigService.privateKey!,
+      this.pgpConfigService.passphrase,
+    );
+
+    const decryptedData = await encryption.decrypt(contentAsString);
+
+    return Buffer.from(decryptedData);
+  }
+
+  public static isValidUrl(maybeUrl: string): boolean {
+    try {
+      const url = new URL(maybeUrl);
+      return ['http:', 'https:'].includes(url.protocol);
+    } catch (_error) {
+      return false;
     }
   }
 
-  public async download(url: string): Promise<any> {
-    try {
-      const fileContent = await StorageClient.downloadFileFromUrl(url);
+  public static async downloadFileFromUrl(url: string): Promise<Buffer> {
+    if (!this.isValidUrl(url)) {
+      throw new InvalidFileUrl(url);
+    }
 
-      return await this.decryptFile(fileContent);
+    try {
+      const { data } = await axios.get(url, {
+        responseType: 'arraybuffer',
+      });
+
+      return Buffer.from(data);
     } catch (error) {
-      Logger.error(`Error downloading ${url}:`, error);
+      if (error.response?.status === HttpStatus.NOT_FOUND) {
+        throw new FileNotFoundError(url);
+      }
+      throw new FileDownloadError(url, error.cause || error.message);
+    }
+  }
+
+  public async downloadJsonLikeData(url: string): Promise<any> {
+    try {
+      let fileContent = await StorageService.downloadFileFromUrl(url);
+
+      fileContent = await this.maybeDecryptFile(fileContent);
+
+      let jsonLikeData = fileContent.toString();
+      try {
+        jsonLikeData = JSON.parse(jsonLikeData);
+      } catch (_noop) {}
+
+      return jsonLikeData;
+    } catch (error) {
+      Logger.error(`Error downloading json like data ${url}:`, error);
       return [];
     }
   }
@@ -169,10 +205,8 @@ export class StorageService {
     url: string,
   ): Promise<UploadedFile> {
     try {
-      // Download the content of the file from the bucket
-      let fileContent = await StorageClient.downloadFileFromUrl(url);
-      fileContent = await this.decryptFile(fileContent);
-
+      let fileContent = await StorageService.downloadFileFromUrl(url);
+      fileContent = await this.maybeDecryptFile(fileContent);
       // Encrypt for job launcher
       const content = await this.encryptFile(
         escrowAddress,
@@ -204,7 +238,6 @@ export class StorageService {
         key,
         content,
         {
-          'Content-Type': 'application/json',
           'Cache-Control': 'no-store',
         },
       );

--- a/packages/apps/reputation-oracle/server/test/constants.ts
+++ b/packages/apps/reputation-oracle/server/test/constants.ts
@@ -6,7 +6,7 @@ import { IFortuneManifest } from '../src/common/interfaces/manifest';
 export const MOCK_REQUESTER_TITLE = 'Mock job title';
 export const MOCK_REQUESTER_DESCRIPTION = 'Mock job description';
 export const MOCK_ADDRESS = '0xCf88b3f1992458C2f5a229573c768D0E9F70C44e';
-export const MOCK_FILE_URL = 'mockedFileUrl';
+export const MOCK_FILE_URL = 'http://local.test/some-mocked-file-url';
 export const MOCK_WEBHOOK_URL = 'mockedWebhookUrl';
 export const MOCK_FILE_HASH = 'mockedFileHash';
 export const MOCK_FILE_KEY = 'manifest.json';

--- a/packages/apps/reputation-oracle/server/tsconfig.json
+++ b/packages/apps/reputation-oracle/server/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
-    "target": "ES2020",
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
## Issue tracking
Resolves #2719 

## Context behind the change
Storage module in SDK is going to be deprecated, so we get rid of it here. At the same time existing storage utils have a bug in working with binaries: when doing `copyFileFromURLToBucket` it's being downloaded as string instead of binary (which is expected to be a `.zip`) and it leads to file in invalid format being copied; this PR also fixed that.

## How has this been tested?
- [x] unit tests
- [x] e2e using Minio: create fake route handler to call `copyFileFromURLToBucket` for some encrypted `.zip` file and make sure it's copied to proper bucket;
- [x] get copied file, decrypt it using JL private key, make sure that result is valid `.zip` file that can opened

## Release plan
Merge & deploy as is.
Only open question is if we need to fix some files that already uploaded as string instead of zip?!

## Potential risks; What to monitor; Rollback plan
Can't think of any