### PR TITLE
[Job Launcher] feat: ability to download decrypted job results

### DIFF
--- a/packages/apps/job-launcher/client/package.json
+++ b/packages/apps/job-launcher/client/package.json
@@ -21,6 +21,7 @@
     "copy-to-clipboard": "^3.3.3",
     "dayjs": "^1.11.12",
     "ethers": "^6.12.1",
+    "file-saver": "^2.0.5",
     "formik": "^2.4.2",
     "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^15.0.7",
+    "@types/file-saver": "^2.0.7",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.2.25",
     "@types/react-test-renderer": "^18.0.0",

--- a/packages/apps/job-launcher/client/src/services/job.ts
+++ b/packages/apps/job-launcher/client/src/services/job.ts
@@ -10,6 +10,7 @@ import {
   FortuneFinalResult,
 } from '../types';
 import api from '../utils/api';
+import { getFilenameFromContentDisposition } from '../utils/string';
 
 export const createFortuneJob = async (
   chainId: number,
@@ -89,6 +90,18 @@ export const getJobResult = async (jobId: number) => {
     {},
   );
   return data;
+};
+
+export const downloadJobResult = async (jobId: number) => {
+  const { data, headers } = await api.get(`/job/result/${jobId}/download`, {
+    responseType: 'blob',
+  });
+
+  const contentDisposition = headers['content-disposition'] || '';
+  return {
+    data,
+    filename: getFilenameFromContentDisposition(contentDisposition),
+  };
 };
 
 export const getJobDetails = async (jobId: number) => {

--- a/packages/apps/job-launcher/client/src/utils/api.ts
+++ b/packages/apps/job-launcher/client/src/utils/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
+import { LOCAL_STORAGE_KEYS } from '../constants';
 import { CaseConverter } from './case-converter';
-import { LOCAL_STORAGE_KEYS } from 'src/constants';
 
 interface FailedPromise {
   resolve: (value?: unknown) => void;
@@ -49,7 +49,7 @@ axiosInstance.interceptors.request.use(
 
 axiosInstance.interceptors.response.use(
   (response) => {
-    if (response.data) {
+    if (response.data && response.config.responseType !== 'blob') {
       response.data = CaseConverter.transformToCamelCase(response.data);
     }
     return response;

--- a/packages/apps/job-launcher/client/src/utils/string.ts
+++ b/packages/apps/job-launcher/client/src/utils/string.ts
@@ -7,3 +7,14 @@ export const parseErrorMessage = (error: any) => {
   }
   return error.message ?? 'Something went wrong.';
 };
+
+export const getFilenameFromContentDisposition = (
+  headerValue: string,
+): string | null => {
+  const match = /filename="(.+)"/.exec(headerValue);
+  if (!match) {
+    return null;
+  }
+
+  return match[1];
+};

--- a/packages/apps/job-launcher/server/src/main.ts
+++ b/packages/apps/job-launcher/server/src/main.ts
@@ -11,7 +11,9 @@ import { ServerConfigService } from './common/config/server-config.service';
 
 async function bootstrap() {
   const app = await NestFactory.create<INestApplication>(AppModule, {
-    cors: true,
+    cors: {
+      exposedHeaders: ['Content-Disposition'],
+    },
   });
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -8,6 +8,7 @@ import {
   Post,
   Query,
   Request,
+  StreamableFile,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -42,8 +43,8 @@ import { MUTEX_TIMEOUT } from '../../common/constants';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
-@ApiTags('Job')
 @ApiKey()
+@ApiTags('Job')
 @Controller('/job')
 export class JobController {
   constructor(
@@ -261,6 +262,20 @@ export class JobController {
     @Request() req: RequestWithUser,
   ): Promise<FortuneFinalResultDto[] | string> {
     return this.jobService.getResult(req.user.id, params.id);
+  }
+
+  @Get('result/:id/download')
+  public async downloadResult(
+    @Param() params: JobIdDto,
+    @Request() req: RequestWithUser,
+  ): Promise<StreamableFile> {
+    const decryptedResult = await this.jobService.downloadJobResults(
+      req.user.id,
+      params.id,
+    );
+    return new StreamableFile(decryptedResult.contents, {
+      disposition: `attachment; filename="${decryptedResult.filename}"`,
+    });
   }
 
   @ApiOperation({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/file-saver@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.7.tgz#8dbb2f24bdc7486c54aa854eb414940bbd056f7d"
+  integrity sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==
+
 "@types/form-data@0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
@@ -11409,6 +11414,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -18636,16 +18646,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18762,7 +18763,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18775,13 +18776,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -20897,7 +20891,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20910,15 +20904,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Issue tracking
Closes #2642 

## Context behind the change
Right now there is no way to easily download job results in case they are encrypted, so adding this functionality both on BE & FE. Fortune results are displayed on UI from JSON, so no need to do it for them.

Access to download results in decrypted format (if encrypted) should be possible only for auth'ed users, so we had two options:
1. create some sort of "share-able" link with short-lived token that we include in response to `getResult`
2. have a separate endpoint for downloading, that has common auth mechanism
Decided to got option 2 in order to not refactor existing functionality with `getResult` a lot (it is already mixed for Fortune and others)

Taking into account that "results" is not big in size and the fact that now we get it into app memory in order to decrypt (due to sdk implementation), it should be fine to have "download" functionality w/o streams as well.

## How has this been tested?
- [x] e2e on staging: https://www.loom.com/share/1e8abfd6b7514cc4a83aad483ef36f1f?sid=e11bb1b6-5dc6-4b04-9036-ac4f95f27e6d

## Release plan
Merge & deploy

## Potential risks; What to monitor; Rollback plan
No, this is new functionality