### PR TITLE
[CVAT] Dont show hidden escrows, add error message

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/endpoints/exchange.py
+++ b/packages/examples/cvat/exchange-oracle/src/endpoints/exchange.py
@@ -117,6 +117,10 @@ async def list_jobs(
 
     query = select(cvat_service.Project)
 
+    query = query.filter(
+        cvat_service.Project.status.not_in([ProjectStatuses.creation, ProjectStatuses.deleted])
+    )
+
     # We need only high-level jobs (i.e. escrows) without project details
     if db_engine.driver == "psycopg2":
         subquery = select(cvat_service.Project.id).distinct(

--- a/packages/examples/cvat/exchange-oracle/src/services/exchange.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/exchange.py
@@ -11,7 +11,11 @@ from src.utils.time import utcnow
 
 
 class UserHasUnfinishedAssignmentError(Exception):
-    pass
+    def __str__(self) -> str:
+        return (
+            "There are unfinished assignments in this escrow. "
+            "Please complete or resign them first."
+        )
 
 
 def create_assignment(escrow_address: str, chain_id: Networks, wallet_address: str) -> str | None:  # noqa: ARG001 (don't we want to use chain_id for filter?)


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->

## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->

- Escrows in the `creation`, `deleted` statuses will not appear in GET `/job` responses
- Added an explanatory error message for POST /assignment requests, if the user has unfinished assignments

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->