### PR TITLE
feat: loading state for refresh tasks

### DIFF
--- a/packages/apps/human-app/frontend/src/pages/worker/jobs/components/my-jobs/mobile/my-jobs-table-mobile.tsx
+++ b/packages/apps/human-app/frontend/src/pages/worker/jobs/components/my-jobs/mobile/my-jobs-table-mobile.tsx
@@ -50,7 +50,8 @@ export function MyJobsTableMobile({
   } = useInfiniteGetMyJobsData();
 
   const { mutate: rejectTaskMutation } = useRejectTaskMutation();
-  const { mutate: refreshTasksMutation } = useRefreshTasksMutation();
+  const { mutate: refreshTasksMutation, isPending: isRefreshTasksPending } =
+    useRefreshTasksMutation();
   const { setSearchEscrowAddress } = useJobsFilterStore();
   const { address: oracle_address } = useParams<{ address: string }>();
 
@@ -106,6 +107,7 @@ export function MyJobsTableMobile({
             }}
             type="button"
             variant="outlined"
+            loading={isRefreshTasksPending}
             onClick={() => {
               refreshTasksMutation({
                 oracle_address: oracle_address ?? '',


### PR DESCRIPTION
## Issue tracking
Closes #2795 

## Context behind the change
Right now it's possible to keep clicking "Refresh" button many times and spamming with refresh requests to underlying servers. Taking into account that endpoint doesn't have any kind of rate-limiter (and might not need for now) we simply add "loading" state to "refresh" button to avoid spamming with requests.

## How has this been tested?
- [x] Open "My Tasks", click "Refresh", button should become disabled and kept loading till response
- [x] Same as above but on mobile 
- [x] Double-check on Vercel preview

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
N/A