### PR TITLE
fix: global handling of axios errors

### DIFF
--- a/packages/apps/human-app/server/src/common/filter/global-exceptions.filter.ts
+++ b/packages/apps/human-app/server/src/common/filter/global-exceptions.filter.ts
@@ -22,9 +22,10 @@ export class GlobalExceptionsFilter implements ExceptionFilter {
     if (exception instanceof HttpException) {
       status = exception.getStatus();
       message = exception.getResponse();
-    } else if (exception.response && exception.response.data?.statusCode) {
-      status = exception.response.data.statusCode;
-      message = exception.response.data.message;
+    } else if (exception.response) {
+      status = exception.response.status;
+      message =
+        exception.response.data?.message || exception.response.statusText;
     } else {
       this.logger.error(
         `Exception without status code: ${JSON.stringify(exception)}`,

--- a/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.gateway.ts
@@ -55,7 +55,7 @@ export class ExchangeOracleGateway {
       return response.data as T;
     } catch (e) {
       console.error(
-        `Error, while executing exchange oracle API call to ${options.url}, error details: ${e}`,
+        `Error, while executing exchange oracle API call to ${options.url}, error details: ${e.message}`,
       );
       throw e;
     }


### PR DESCRIPTION
## Issue tracking
Closes #2796 

## Context behind the change
When `exception` is the instance of `AxiosError`. Unfortunately there is no way to export it from `@nestjs/axios` in order to check as `exception instanceof AxiosError`; it can be done from `axios` itself, but then we might lack consistency. However, we we need to respond with meaningful errors we can rely on existence of `exception.response` ([docs ref](https://axios-http.com/docs/handling_errors)) and use what axios provides. It has a `status` property that we should use, not one we might have in response body (e.g. when in Fortune's responses), because if there is no `statusCode` in response body - we assign `undefined` and it will be `500` on the client w/o meaningful error message.

## How has this been tested?
- [x] on local, with STG setup: go to CVAT oracle and attempt to assign task twice, it should display new meaningful error message
[x] on local, with STG setup: go to Fortune oracle and attempt to assign task twice, it should keep displaying meaningful errors

## Release plan
Simply merge.

## Potential risks; What to monitor; Rollback plan
N/A