### PR TITLE
[Reputation Oracle] Refactoring Cron Module

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/utils/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/utils/index.ts
@@ -42,3 +42,7 @@ export function getRequestType(
 
   return requestType;
 }
+
+export function isValidJobRequestType(value: string): value is JobRequestType {
+  return Object.values(JobRequestType).includes(value as JobRequestType);
+}

--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.service.spec.ts
@@ -23,7 +23,6 @@ jest.mock('rxjs', () => {
 describe('hCaptchaService', () => {
   let hcaptchaService: HCaptchaService;
   let httpService: HttpService;
-  let configService: ConfigService;
 
   beforeAll(async () => {
     const mockHttpService: DeepPartial<HttpService> = {
@@ -57,7 +56,6 @@ describe('hCaptchaService', () => {
     }).compile();
 
     httpService = moduleRef.get<HttpService>(HttpService);
-    configService = moduleRef.get<ConfigService>(ConfigService);
     hcaptchaService = moduleRef.get<HCaptchaService>(HCaptchaService);
   });
 

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
@@ -4,34 +4,17 @@ import { CronJobService } from './cron-job.service';
 import { CronJobRepository } from './cron-job.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CronJobEntity } from './cron-job.entity';
-import { Web3Module } from '../web3/web3.module';
 import { WebhookModule } from '../webhook/webhook.module';
 import { ConfigModule } from '@nestjs/config';
-import { PayoutModule } from '../payout/payout.module';
-import { ReputationModule } from '../reputation/reputation.module';
-import { WebhookIncomingRepository } from '../webhook/webhook-incoming.repository';
-import { WebhookOutgoingRepository } from '../webhook/webhook-outgoing.repository';
-import { EscrowCompletionTrackingRepository } from '../escrow-completion-tracking/escrow-completion-tracking.repository';
-import { EscrowCompletionTrackingModule } from '../escrow-completion-tracking/escrow-completion-tracking.module';
 
 @Global()
 @Module({
   imports: [
     TypeOrmModule.forFeature([CronJobEntity]),
     ConfigModule,
-    Web3Module,
     WebhookModule,
-    EscrowCompletionTrackingModule,
-    PayoutModule,
-    ReputationModule,
   ],
-  providers: [
-    CronJobService,
-    CronJobRepository,
-    WebhookIncomingRepository,
-    WebhookOutgoingRepository,
-    EscrowCompletionTrackingRepository,
-  ],
+  providers: [CronJobService, CronJobRepository],
   exports: [CronJobService],
 })
 export class CronJobModule {}

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -12,7 +12,6 @@ describe('CronJobService', () => {
   let service: CronJobService;
   let cronJobRepository: jest.Mocked<CronJobRepository>;
   let webhookService: jest.Mocked<WebhookService>;
-  let logger: Logger;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,7 +47,6 @@ describe('CronJobService', () => {
     service = module.get<CronJobService>(CronJobService);
     cronJobRepository = module.get(CronJobRepository);
     webhookService = module.get(WebhookService);
-    logger = module.get(Logger);
   });
 
   describe('startCronJob', () => {

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -1,795 +1,343 @@
 import { Test, TestingModule } from '@nestjs/testing';
-
-import { CronJobType } from '../../common/enums/cron-job';
-
 import { CronJobService } from './cron-job.service';
+import { HttpStatus, Logger } from '@nestjs/common';
 import { CronJobRepository } from './cron-job.repository';
-import { CronJobEntity } from './cron-job.entity';
-import { createMock } from '@golevelup/ts-jest';
-import {
-  MOCK_ADDRESS,
-  MOCK_FILE_HASH,
-  MOCK_FILE_URL,
-  MOCK_MAX_RETRY_COUNT,
-  MOCK_WEBHOOK_URL,
-  mockConfig,
-} from '../../../test/constants';
-import { ChainId, EscrowClient, EscrowStatus } from '@human-protocol/sdk';
 import { WebhookService } from '../webhook/webhook.service';
-import { Web3Service } from '../web3/web3.service';
-import { ConfigService } from '@nestjs/config';
-import {
-  EventType,
-  WebhookIncomingStatus,
-  WebhookOutgoingStatus,
-  EscrowCompletionTrackingStatus,
-} from '../../common/enums/webhook';
-import { PayoutService } from '../payout/payout.service';
-import { ReputationService } from '../reputation/reputation.service';
-import { StorageService } from '../storage/storage.service';
-import { ReputationRepository } from '../reputation/reputation.repository';
-import { HttpService } from '@nestjs/axios';
-import { ServerConfigService } from '../../common/config/server-config.service';
-import { Web3ConfigService } from '../../common/config/web3-config.service';
-import { ReputationConfigService } from '../../common/config/reputation-config.service';
-import { ControlledError } from '../../common/errors/controlled';
+import { CronJobEntity } from './cron-job.entity';
+import { CronJobType } from '../../common/enums/cron-job';
 import { ErrorCronJob } from '../../common/constants/errors';
-import { HttpStatus } from '@nestjs/common';
-import { WebhookOutgoingRepository } from '../webhook/webhook-outgoing.repository';
-import { WebhookIncomingRepository } from '../webhook/webhook-incoming.repository';
-import { WebhookIncomingEntity } from '../webhook/webhook-incoming.entity';
-import { WebhookOutgoingEntity } from '../webhook/webhook-outgoing.entity';
-import { EscrowCompletionTrackingRepository } from '../escrow-completion-tracking/escrow-completion-tracking.repository';
-import { EscrowCompletionTrackingService } from '../escrow-completion-tracking/escrow-completion-tracking.service';
-import { PostgresErrorCodes } from '../../common/enums/database';
-import { DatabaseError } from '../../common/errors/database';
-
-jest.mock('@human-protocol/sdk', () => ({
-  ...jest.requireActual('@human-protocol/sdk'),
-  EscrowClient: {
-    build: jest.fn().mockImplementation(() => ({
-      createEscrow: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-      getJobLauncherAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-      getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-      getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-      setup: jest.fn().mockResolvedValue(null),
-      fund: jest.fn().mockResolvedValue(null),
-      getManifestUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
-      complete: jest.fn().mockResolvedValue(null),
-      getStatus: jest.fn(),
-    })),
-  },
-  KVStoreUtils: {
-    get: jest.fn(),
-  },
-  OperatorUtils: {
-    getLeader: jest.fn().mockImplementation(() => {
-      return { webhookUrl: MOCK_WEBHOOK_URL };
-    }),
-  },
-}));
+import { ControlledError } from '../../common/errors/controlled';
 
 describe('CronJobService', () => {
-  let service: CronJobService,
-    repository: CronJobRepository,
-    webhookIncomingRepository: WebhookIncomingRepository,
-    webhookOutgoingRepository: WebhookOutgoingRepository,
-    escrowCompletionTrackingRepository: EscrowCompletionTrackingRepository,
-    webhookService: WebhookService,
-    escrowCompletionTrackingService: EscrowCompletionTrackingService,
-    reputationService: ReputationService,
-    payoutService: PayoutService;
-
-  const signerMock = {
-    address: MOCK_ADDRESS,
-    getNetwork: jest.fn().mockResolvedValue({ chainId: 1 }),
-  };
+  let service: CronJobService;
+  let cronJobRepository: jest.Mocked<CronJobRepository>;
+  let webhookService: jest.Mocked<WebhookService>;
+  let logger: Logger;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        {
-          provide: ConfigService,
-          useValue: {
-            get: jest.fn((key: string) => mockConfig[key]),
-            getOrThrow: jest.fn((key: string) => {
-              if (!mockConfig[key]) {
-                throw new Error(`Configuration key "${key}" does not exist`);
-              }
-              return mockConfig[key];
-            }),
-          },
-        },
         CronJobService,
         {
           provide: CronJobRepository,
-          useValue: createMock<CronJobRepository>(),
-        },
-        {
-          provide: Web3Service,
           useValue: {
-            getSigner: jest.fn().mockReturnValue(signerMock),
-            validateChainId: jest.fn().mockReturnValue(new Error()),
-            calculateGasPrice: jest.fn().mockReturnValue(1000n),
+            findOneByType: jest.fn(),
+            createUnique: jest.fn(),
+            updateOne: jest.fn(),
           },
         },
-        WebhookService,
-        EscrowCompletionTrackingService,
-        PayoutService,
-        ReputationService,
-        ServerConfigService,
-        Web3ConfigService,
-        ReputationConfigService,
-        { provide: HttpService, useValue: createMock<HttpService>() },
-
         {
-          provide: WebhookIncomingRepository,
-          useValue: createMock<WebhookIncomingRepository>(),
+          provide: WebhookService,
+          useValue: {
+            processPendingIncomingWebhooks: jest.fn(),
+            processPendingEscrowCompletion: jest.fn(),
+            processPaidEscrowCompletion: jest.fn(),
+            processPendingOutgoingWebhooks: jest.fn(),
+          },
         },
         {
-          provide: WebhookOutgoingRepository,
-          useValue: createMock<WebhookOutgoingRepository>(),
-        },
-        {
-          provide: EscrowCompletionTrackingRepository,
-          useValue: createMock<EscrowCompletionTrackingRepository>(),
-        },
-        { provide: StorageService, useValue: createMock<StorageService>() },
-        {
-          provide: ReputationRepository,
-          useValue: createMock<ReputationRepository>(),
+          provide: Logger,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     service = module.get<CronJobService>(CronJobService);
-    repository = module.get<CronJobRepository>(CronJobRepository);
-    payoutService = module.get<PayoutService>(PayoutService);
-    reputationService = module.get<ReputationService>(ReputationService);
-    webhookIncomingRepository = module.get(WebhookIncomingRepository);
-    webhookOutgoingRepository = module.get(WebhookOutgoingRepository);
-    escrowCompletionTrackingRepository = module.get(
-      EscrowCompletionTrackingRepository,
-    );
-
-    webhookService = module.get<WebhookService>(WebhookService);
-    escrowCompletionTrackingService =
-      module.get<EscrowCompletionTrackingService>(
-        EscrowCompletionTrackingService,
-      );
+    cronJobRepository = module.get(CronJobRepository);
+    webhookService = module.get(WebhookService);
+    logger = module.get(Logger);
   });
 
   describe('startCronJob', () => {
-    it('should create a cron job if not exists', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
+    it('should create a new cron job if none exists', async () => {
+      cronJobRepository.findOneByType.mockResolvedValue(null);
+      cronJobRepository.createUnique.mockResolvedValue(new CronJobEntity());
 
-      const cronJobEntity = new CronJobEntity();
-      cronJobEntity.cronJobType = cronJobType;
-      cronJobEntity.startedAt = new Date();
+      const result = await service.startCronJob(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
 
-      jest.spyOn(repository, 'findOneByType').mockResolvedValue(null);
-
-      const createUniqueSpy = jest
-        .spyOn(repository, 'createUnique')
-        .mockResolvedValue(cronJobEntity);
-
-      const result = await service.startCronJob(cronJobType);
-
-      expect(createUniqueSpy).toHaveBeenCalledWith({
-        cronJobType: CronJobType.ProcessPendingIncomingWebhook,
-      });
-      expect(result).toEqual(cronJobEntity);
+      expect(cronJobRepository.findOneByType).toHaveBeenCalledWith(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
+      expect(cronJobRepository.createUnique).toHaveBeenCalled();
+      expect(result).toBeInstanceOf(CronJobEntity);
     });
 
-    it('should start a cron job if exists', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
-      const cronJobEntity: Partial<CronJobEntity> = {
-        cronJobType: cronJobType,
+    it('should update an existing cron job', async () => {
+      const existingCronJob = new CronJobEntity();
+      existingCronJob.startedAt = new Date();
+      cronJobRepository.findOneByType.mockResolvedValue(existingCronJob);
+
+      const updatedCronJob = {
+        ...existingCronJob,
         startedAt: new Date(),
-        completedAt: new Date(),
+        completedAt: null,
       };
+      cronJobRepository.updateOne.mockResolvedValue(updatedCronJob as any);
 
-      const mockDate = new Date(2023, 12, 23);
-      jest.useFakeTimers();
-      jest.setSystemTime(mockDate);
+      const result = await service.startCronJob(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
 
-      const findOneByTypeSpy = jest
-        .spyOn(repository, 'findOneByType')
-        .mockResolvedValue(cronJobEntity as any);
-
-      const updateOneSpy = jest
-        .spyOn(repository, 'updateOne')
-        .mockResolvedValue(cronJobEntity as any);
-
-      const result = await service.startCronJob(cronJobType);
-
-      expect(findOneByTypeSpy).toHaveBeenCalledWith(cronJobType);
-      expect(updateOneSpy).toHaveBeenCalled();
-      cronJobEntity.startedAt = mockDate;
-      expect(result).toEqual(cronJobEntity);
-
-      jest.useRealTimers();
+      expect(cronJobRepository.findOneByType).toHaveBeenCalledWith(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
+      expect(cronJobRepository.updateOne).toHaveBeenCalledWith(updatedCronJob);
+      expect(result).toEqual(updatedCronJob);
     });
   });
 
   describe('isCronJobRunning', () => {
-    it('should return false if no cron job is running', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
-      const cronJobEntity = new CronJobEntity();
-      cronJobEntity.cronJobType = cronJobType;
+    it('should return false if no cron job exists', async () => {
+      cronJobRepository.findOneByType.mockResolvedValue(null);
 
-      const findOneByTypeSpy = jest
-        .spyOn(repository, 'findOneByType')
-        .mockResolvedValue(null);
+      const result = await service.isCronJobRunning(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
 
-      const result = await service.isCronJobRunning(cronJobType);
-
-      expect(findOneByTypeSpy).toHaveBeenCalledWith(cronJobType);
-      expect(result).toEqual(false);
+      expect(cronJobRepository.findOneByType).toHaveBeenCalledWith(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
+      expect(result).toBe(false);
     });
 
-    it('should return false if last cron job is completed', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
-      const cronJobEntity = new CronJobEntity();
-      cronJobEntity.cronJobType = cronJobType;
-      cronJobEntity.completedAt = new Date();
+    it('should return false if the last cron job is completed', async () => {
+      const completedCronJob = new CronJobEntity();
+      completedCronJob.completedAt = new Date();
+      cronJobRepository.findOneByType.mockResolvedValue(completedCronJob);
 
-      const findOneByTypeSpy = jest
-        .spyOn(repository, 'findOneByType')
-        .mockResolvedValue(cronJobEntity);
+      const result = await service.isCronJobRunning(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
 
-      const result = await service.isCronJobRunning(cronJobType);
-
-      expect(findOneByTypeSpy).toHaveBeenCalledWith(cronJobType);
-      expect(result).toEqual(false);
+      expect(cronJobRepository.findOneByType).toHaveBeenCalledWith(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
+      expect(result).toBe(false);
     });
 
-    it('should return true if last cron job is not completed', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
-      const cronJobEntity = new CronJobEntity();
-      cronJobEntity.cronJobType = cronJobType;
+    it('should return true if the last cron job is not completed', async () => {
+      const runningCronJob = new CronJobEntity();
+      cronJobRepository.findOneByType.mockResolvedValue(runningCronJob);
 
-      const findOneByTypeSpy = jest
-        .spyOn(repository, 'findOneByType')
-        .mockResolvedValue(cronJobEntity);
+      const result = await service.isCronJobRunning(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
 
-      const result = await service.isCronJobRunning(cronJobType);
-      expect(findOneByTypeSpy).toHaveBeenCalledWith(cronJobType);
-      expect(result).toEqual(true);
+      expect(cronJobRepository.findOneByType).toHaveBeenCalledWith(
+        CronJobType.ProcessPendingIncomingWebhook,
+      );
+      expect(result).toBe(true);
     });
   });
 
   describe('completeCronJob', () => {
     it('should complete a cron job', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
       const cronJobEntity = new CronJobEntity();
-      cronJobEntity.cronJobType = cronJobType;
-
-      const mockDate = new Date(2023, 12, 23);
-
-      jest.useFakeTimers();
-      jest.setSystemTime(mockDate);
-
-      const updateOneSpy = jest
-        .spyOn(repository, 'updateOne')
-        .mockResolvedValue(cronJobEntity);
+      const completedCronJob = { ...cronJobEntity, completedAt: new Date() };
+      cronJobRepository.updateOne.mockResolvedValue(completedCronJob as any);
 
       const result = await service.completeCronJob(cronJobEntity);
 
-      expect(updateOneSpy).toHaveBeenCalled();
-      expect(cronJobEntity.completedAt).toEqual(mockDate);
-      expect(result).toEqual(cronJobEntity);
-
-      jest.useRealTimers();
+      expect(cronJobRepository.updateOne).toHaveBeenCalledWith(
+        completedCronJob,
+      );
+      expect(result.completedAt).toBeInstanceOf(Date);
     });
 
-    it('should throw an error if cron job is already completed', async () => {
-      const cronJobType = CronJobType.ProcessPendingIncomingWebhook;
+    it('should throw an error if the cron job is already completed', async () => {
       const cronJobEntity = new CronJobEntity();
-      cronJobEntity.cronJobType = cronJobType;
       cronJobEntity.completedAt = new Date();
-
-      const updateOneSpy = jest
-        .spyOn(repository, 'updateOne')
-        .mockResolvedValue(cronJobEntity);
 
       await expect(service.completeCronJob(cronJobEntity)).rejects.toThrow(
         new ControlledError(ErrorCronJob.Completed, HttpStatus.BAD_REQUEST),
       );
-      expect(updateOneSpy).not.toHaveBeenCalled();
     });
   });
 
-  describe('processPendingIncomingWebhooksCronJob', () => {
-    let createEscrowCompletionTrackingMock: any;
-    let cronJobEntityMock: Partial<CronJobEntity>;
-    let webhookEntity1: Partial<WebhookIncomingEntity>,
-      webhookEntity2: Partial<WebhookIncomingEntity>;
-
-    let completeCronJobMock: jest.SpyInstance;
-
-    beforeEach(() => {
-      completeCronJobMock = jest
-        .spyOn(service, 'completeCronJob')
-        .mockResolvedValue({} as CronJobEntity);
-
-      cronJobEntityMock = {
-        cronJobType: CronJobType.ProcessPendingIncomingWebhook,
-        startedAt: new Date(),
-      };
-
-      webhookEntity1 = {
-        id: 1,
-        chainId: ChainId.LOCALHOST,
-        escrowAddress: MOCK_ADDRESS,
-        status: WebhookIncomingStatus.PENDING,
-        waitUntil: new Date(),
-        retriesCount: 0,
-      };
-
-      webhookEntity2 = {
-        id: 2,
-        chainId: ChainId.LOCALHOST,
-        escrowAddress: MOCK_ADDRESS,
-        status: WebhookIncomingStatus.PENDING,
-        waitUntil: new Date(),
-        retriesCount: 0,
-      };
-
-      jest
-        .spyOn(webhookIncomingRepository, 'findByStatus')
-        .mockResolvedValue([webhookEntity1 as any, webhookEntity2 as any]);
-
-      createEscrowCompletionTrackingMock = jest.spyOn(
-        escrowCompletionTrackingService as any,
-        'createEscrowCompletionTracking',
-      );
-      createEscrowCompletionTrackingMock.mockResolvedValue(undefined);
-
-      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
-
-      jest.spyOn(repository, 'findOneByType').mockResolvedValue(null);
-      jest
-        .spyOn(repository, 'createUnique')
-        .mockResolvedValue(cronJobEntityMock as any);
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('should not run if cron job is already running', async () => {
-      jest.spyOn(service, 'isCronJobRunning').mockResolvedValueOnce(true);
-
-      const startCronJobMock = jest.spyOn(service, 'startCronJob');
+  describe('processPendingIncomingWebhooks', () => {
+    it('should skip processing if a cron job is already running', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(true);
 
       await service.processPendingIncomingWebhooks();
 
-      expect(startCronJobMock).not.toHaveBeenCalled();
+      expect(
+        webhookService.processPendingIncomingWebhooks,
+      ).not.toHaveBeenCalled();
     });
 
-    it('should create cron job entity to lock the process', async () => {
+    it('should process pending webhooks and complete the cron job', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
       jest
         .spyOn(service, 'startCronJob')
-        .mockResolvedValueOnce(cronJobEntityMock as any);
-
-      await service.processPendingIncomingWebhooks();
-
-      expect(service.startCronJob).toHaveBeenCalledWith(
-        CronJobType.ProcessPendingIncomingWebhook,
-      );
-    });
-
-    it('should send webhook for all of the pending incoming webhooks', async () => {
-      await service.processPendingIncomingWebhooks();
-
-      expect(createEscrowCompletionTrackingMock).toHaveBeenCalledTimes(2);
-      expect(createEscrowCompletionTrackingMock).toHaveBeenCalledWith(
-        webhookEntity1.chainId,
-        webhookEntity1.escrowAddress,
-      );
-      expect(createEscrowCompletionTrackingMock).toHaveBeenCalledWith(
-        webhookEntity2.chainId,
-        webhookEntity2.escrowAddress,
-      );
-
-      expect(webhookIncomingRepository.updateOne).toHaveBeenCalledTimes(2);
-      expect(webhookEntity1.status).toBe(WebhookIncomingStatus.COMPLETED);
-      expect(webhookEntity2.status).toBe(WebhookIncomingStatus.COMPLETED);
-    });
-
-    it('should increase retriesCount by 1 if sending webhook fails', async () => {
-      createEscrowCompletionTrackingMock.mockRejectedValueOnce(new Error());
-      await service.processPendingIncomingWebhooks();
-
-      expect(webhookIncomingRepository.updateOne).toHaveBeenCalled();
-      expect(webhookEntity1.status).toBe(WebhookIncomingStatus.PENDING);
-      expect(webhookEntity1.retriesCount).toBe(1);
-      expect(webhookEntity1.waitUntil).toBeInstanceOf(Date);
-    });
-
-    it('should mark webhook as failed if retriesCount exceeds threshold', async () => {
-      createEscrowCompletionTrackingMock.mockRejectedValueOnce(new Error());
-
-      webhookEntity1.retriesCount = MOCK_MAX_RETRY_COUNT;
-
-      await service.processPendingIncomingWebhooks();
-
-      expect(webhookIncomingRepository.updateOne).toHaveBeenCalled();
-      expect(webhookEntity1.status).toBe(WebhookIncomingStatus.FAILED);
-    });
-
-    it('should complete the cron job entity to unlock', async () => {
+        .mockResolvedValue(new CronJobEntity());
       jest
         .spyOn(service, 'completeCronJob')
-        .mockResolvedValueOnce(cronJobEntityMock as any);
+        .mockResolvedValue(new CronJobEntity());
 
       await service.processPendingIncomingWebhooks();
 
-      expect(service.completeCronJob).toHaveBeenCalledWith(
-        cronJobEntityMock as any,
-      );
+      expect(webhookService.processPendingIncomingWebhooks).toHaveBeenCalled();
+      expect(service.startCronJob).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
     });
 
-    it('should retry if createEscrowCompletionTracking throws a DatabaseError with Duplicated error code', async () => {
-      const mockEntity = { id: 1, status: EscrowCompletionTrackingStatus.PAID };
-
+    it('should log errors during processing', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
       jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([mockEntity as any]);
+        .spyOn(service, 'startCronJob')
+        .mockResolvedValue(new CronJobEntity());
+      jest
+        .spyOn(service, 'completeCronJob')
+        .mockResolvedValue(new CronJobEntity());
 
-      const updateOneMock = jest
-        .spyOn(escrowCompletionTrackingRepository, 'updateOne')
-        .mockResolvedValue(mockEntity as any);
-
-      const createEscrowCompletionTrackingMock = jest
-        .spyOn(
-          escrowCompletionTrackingService,
-          'createEscrowCompletionTracking',
-        )
-        .mockImplementation(() => {
-          throw new DatabaseError(
-            'Duplicate entry error',
-            PostgresErrorCodes.Duplicated,
-          );
-        });
+      webhookService.processPendingIncomingWebhooks.mockRejectedValue(
+        new Error('Processing error'),
+      );
 
       await service.processPendingIncomingWebhooks();
 
-      expect(createEscrowCompletionTrackingMock).toHaveBeenCalled();
-      expect(updateOneMock).not.toHaveBeenCalledWith({
-        id: mockEntity.id,
-        status: EscrowCompletionTrackingStatus.COMPLETED,
-      });
-      expect(completeCronJobMock).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
     });
   });
 
   describe('processPendingEscrowCompletion', () => {
-    let startCronJobMock: jest.SpyInstance;
-    let completeCronJobMock: jest.SpyInstance;
-
-    beforeEach(() => {
-      startCronJobMock = jest
-        .spyOn(service, 'startCronJob')
-        .mockResolvedValue({} as CronJobEntity);
-      completeCronJobMock = jest
-        .spyOn(service, 'completeCronJob')
-        .mockResolvedValue({} as CronJobEntity);
-
-      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
-    });
-
     it('should skip processing if a cron job is already running', async () => {
       jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(true);
 
       await service.processPendingEscrowCompletion();
 
-      expect(startCronJobMock).not.toHaveBeenCalled();
+      expect(
+        webhookService.processPendingEscrowCompletion,
+      ).not.toHaveBeenCalled();
     });
 
-    it('should start and complete the cron job successfully', async () => {
-      const mockEntity = {
-        id: 1,
-        status: EscrowCompletionTrackingStatus.PENDING,
-      };
+    it('should process pending escrow completion and complete the cron job', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
       jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([mockEntity as any]);
-
-      const updateOneMock = jest
-        .spyOn(escrowCompletionTrackingRepository, 'updateOne')
-        .mockResolvedValue(mockEntity as any);
+        .spyOn(service, 'startCronJob')
+        .mockResolvedValue(new CronJobEntity());
+      jest
+        .spyOn(service, 'completeCronJob')
+        .mockResolvedValue(new CronJobEntity());
 
       await service.processPendingEscrowCompletion();
 
-      expect(startCronJobMock).toHaveBeenCalledWith(
-        CronJobType.ProcessPendingEscrowCompletionTracking,
+      expect(webhookService.processPendingEscrowCompletion).toHaveBeenCalled();
+      expect(service.startCronJob).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
+    });
+
+    it('should log errors during processing', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
+      jest
+        .spyOn(service, 'startCronJob')
+        .mockResolvedValue(new CronJobEntity());
+      jest
+        .spyOn(service, 'completeCronJob')
+        .mockResolvedValue(new CronJobEntity());
+
+      webhookService.processPendingEscrowCompletion.mockRejectedValue(
+        new Error('Processing error'),
       );
-      expect(updateOneMock).toHaveBeenCalled();
-      expect(completeCronJobMock).toHaveBeenCalled();
-    });
-
-    it('should handle errors and continue processing other entities', async () => {
-      const mockEntity1 = {
-        id: 1,
-        status: EscrowCompletionTrackingStatus.PENDING,
-      };
-      const mockEntity2 = {
-        id: 2,
-        status: EscrowCompletionTrackingStatus.PENDING,
-      };
-
-      jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([mockEntity1 as any, mockEntity2 as any]);
-
-      jest
-        .spyOn(escrowCompletionTrackingRepository, 'updateOne')
-        .mockImplementationOnce(() => {
-          throw new Error('Test error');
-        })
-        .mockResolvedValue(mockEntity2 as any);
 
       await service.processPendingEscrowCompletion();
 
-      expect(completeCronJobMock).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
     });
   });
 
   describe('processPaidEscrowCompletion', () => {
-    let startCronJobMock: jest.SpyInstance;
-    let completeCronJobMock: jest.SpyInstance;
-    let assessReputationScoresMock: jest.SpyInstance;
-
-    beforeEach(() => {
-      startCronJobMock = jest
-        .spyOn(service, 'startCronJob')
-        .mockResolvedValue({} as CronJobEntity);
-      completeCronJobMock = jest
-        .spyOn(service, 'completeCronJob')
-        .mockResolvedValue({} as CronJobEntity);
-
-      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
-      assessReputationScoresMock = jest
-        .spyOn(reputationService, 'assessReputationScores')
-        .mockResolvedValue();
-
-      EscrowClient.build = jest.fn().mockResolvedValue({
-        getStatus: jest.fn().mockResolvedValue(EscrowStatus.Paid),
-        complete: jest.fn().mockResolvedValue(true),
-        getJobLauncherAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-        getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-      });
-    });
-
     it('should skip processing if a cron job is already running', async () => {
       jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(true);
 
       await service.processPaidEscrowCompletion();
 
-      expect(startCronJobMock).not.toHaveBeenCalled();
-      expect(assessReputationScoresMock).not.toHaveBeenCalled();
+      expect(webhookService.processPaidEscrowCompletion).not.toHaveBeenCalled();
     });
 
-    it('should start, process, and complete cron job for entities with PAID status', async () => {
-      const mockEntity = { id: 1, status: EscrowCompletionTrackingStatus.PAID };
-
+    it('should process paid escrow completion and complete the cron job', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
       jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([mockEntity as any]);
-
-      const updateOneMock = jest
-        .spyOn(escrowCompletionTrackingRepository, 'updateOne')
-        .mockResolvedValue(mockEntity as any);
+        .spyOn(service, 'startCronJob')
+        .mockResolvedValue(new CronJobEntity());
+      jest
+        .spyOn(service, 'completeCronJob')
+        .mockResolvedValue(new CronJobEntity());
 
       await service.processPaidEscrowCompletion();
 
-      expect(startCronJobMock).toHaveBeenCalledWith(
-        CronJobType.ProcessPaidEscrowCompletionTracking,
-      );
-      expect(updateOneMock).toHaveBeenCalledWith({
-        id: mockEntity.id,
-        status: EscrowCompletionTrackingStatus.COMPLETED,
-      });
-      expect(completeCronJobMock).toHaveBeenCalled();
-      expect(assessReputationScoresMock).toHaveBeenCalledTimes(1);
+      expect(webhookService.processPaidEscrowCompletion).toHaveBeenCalled();
+      expect(service.startCronJob).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
     });
 
-    it('should handle errors during entity processing without skipping remaining entities', async () => {
-      const mockEntity1 = {
-        id: 1,
-        status: EscrowCompletionTrackingStatus.PAID,
-      };
-      const mockEntity2 = {
-        id: 2,
-        status: EscrowCompletionTrackingStatus.PAID,
-      };
-
+    it('should log errors during processing', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
       jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([mockEntity1 as any, mockEntity2 as any]);
-
-      const updateOneMock = jest
-        .spyOn(escrowCompletionTrackingRepository, 'updateOne')
-        .mockImplementationOnce(() => {
-          throw new Error('Test error');
-        })
-        .mockResolvedValueOnce(mockEntity2 as any);
-
-      await service.processPaidEscrowCompletion();
-
-      expect(updateOneMock).toHaveBeenCalledTimes(3);
-      expect(completeCronJobMock).toHaveBeenCalled();
-      expect(assessReputationScoresMock).toHaveBeenCalledTimes(2);
-    });
-
-    it('should complete cron job even if no PAID entities are found', async () => {
+        .spyOn(service, 'startCronJob')
+        .mockResolvedValue(new CronJobEntity());
       jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([]);
+        .spyOn(service, 'completeCronJob')
+        .mockResolvedValue(new CronJobEntity());
 
-      await service.processPaidEscrowCompletion();
-
-      expect(startCronJobMock).toHaveBeenCalled();
-      expect(completeCronJobMock).toHaveBeenCalled();
-      expect(assessReputationScoresMock).not.toHaveBeenCalled();
-    });
-
-    it('should not call completeCronJob if startCronJob fails', async () => {
-      startCronJobMock.mockRejectedValue(new Error('Start cron job failed'));
-
-      await expect(service.processPaidEscrowCompletion()).rejects.toThrow(
-        'Start cron job failed',
+      webhookService.processPaidEscrowCompletion.mockRejectedValue(
+        new Error('Processing error'),
       );
 
-      expect(startCronJobMock).toHaveBeenCalled();
-      expect(completeCronJobMock).not.toHaveBeenCalled();
-    });
-
-    it('should retry if createOutgoingWebhook throws a DatabaseError with Duplicated error code', async () => {
-      const mockEntity = { id: 1, status: EscrowCompletionTrackingStatus.PAID };
-
-      jest
-        .spyOn(escrowCompletionTrackingRepository, 'findByStatus')
-        .mockResolvedValue([mockEntity as any]);
-
-      const updateOneMock = jest
-        .spyOn(escrowCompletionTrackingRepository, 'updateOne')
-        .mockResolvedValue(mockEntity as any);
-
-      const createOutgoingWebhookMock = jest
-        .spyOn(webhookService, 'createOutgoingWebhook')
-        .mockImplementation(() => {
-          throw new DatabaseError(
-            'Duplicate entry error',
-            PostgresErrorCodes.Duplicated,
-          );
-        });
-
       await service.processPaidEscrowCompletion();
 
-      expect(createOutgoingWebhookMock).toHaveBeenCalled();
-      expect(updateOneMock).not.toHaveBeenCalledWith({
-        id: mockEntity.id,
-        status: EscrowCompletionTrackingStatus.COMPLETED,
-      });
-      expect(completeCronJobMock).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
     });
   });
 
   describe('processPendingOutgoingWebhooks', () => {
-    let sendWebhookMock: any;
-    let cronJobEntityMock: Partial<CronJobEntity>;
-    let webhookEntity1: Partial<WebhookOutgoingEntity>,
-      webhookEntity2: Partial<WebhookOutgoingEntity>;
-
-    beforeEach(() => {
-      cronJobEntityMock = {
-        cronJobType: CronJobType.ProcessPendingOutgoingWebhook,
-        startedAt: new Date(),
-      };
-
-      webhookEntity1 = {
-        id: 1,
-        payload: {
-          chainId: ChainId.LOCALHOST,
-          escrowAddress: MOCK_ADDRESS,
-          eventType: EventType.ESCROW_COMPLETED,
-        },
-        hash: MOCK_FILE_HASH,
-        url: MOCK_FILE_URL,
-        status: WebhookOutgoingStatus.PENDING,
-        waitUntil: new Date(),
-        retriesCount: 0,
-      };
-
-      webhookEntity2 = {
-        id: 2,
-        payload: {
-          chainId: ChainId.LOCALHOST,
-          escrowAddress: MOCK_ADDRESS,
-          eventType: EventType.ESCROW_COMPLETED,
-        },
-        hash: MOCK_FILE_HASH,
-        url: MOCK_FILE_URL,
-        status: WebhookOutgoingStatus.PENDING,
-        waitUntil: new Date(),
-        retriesCount: 0,
-      };
-
-      jest
-        .spyOn(webhookOutgoingRepository, 'findByStatus')
-        .mockResolvedValue([webhookEntity1 as any, webhookEntity2 as any]);
-
-      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
-
-      jest.spyOn(repository, 'findOneByType').mockResolvedValue(null);
-      jest
-        .spyOn(repository, 'createUnique')
-        .mockResolvedValue(cronJobEntityMock as any);
-
-      sendWebhookMock = jest.spyOn(webhookService as any, 'sendWebhook');
-      sendWebhookMock.mockResolvedValue();
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('should not run if cron job is already running', async () => {
-      jest.spyOn(service, 'isCronJobRunning').mockResolvedValueOnce(true);
-
-      const startCronJobMock = jest.spyOn(service, 'startCronJob');
+    it('should skip processing if a cron job is already running', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(true);
 
       await service.processPendingOutgoingWebhooks();
 
-      expect(startCronJobMock).not.toHaveBeenCalled();
+      expect(
+        webhookService.processPendingOutgoingWebhooks,
+      ).not.toHaveBeenCalled();
     });
 
-    it('should create cron job entity to lock the process', async () => {
+    it('should process pending outgoing webhooks and complete the cron job', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
       jest
         .spyOn(service, 'startCronJob')
-        .mockResolvedValueOnce(cronJobEntityMock as any);
-
-      await service.processPendingOutgoingWebhooks();
-
-      expect(service.startCronJob).toHaveBeenCalledWith(
-        CronJobType.ProcessPendingOutgoingWebhook,
-      );
-    });
-
-    it('should increase retriesCount by 1 if sending webhook fails', async () => {
-      sendWebhookMock.mockRejectedValueOnce(new Error());
-      await service.processPendingOutgoingWebhooks();
-
-      expect(webhookOutgoingRepository.updateOne).toHaveBeenCalled();
-      expect(webhookEntity1.status).toBe(WebhookOutgoingStatus.PENDING);
-      expect(webhookEntity1.retriesCount).toBe(1);
-      expect(webhookEntity1.waitUntil).toBeInstanceOf(Date);
-    });
-
-    it('should mark webhook as failed if retriesCount exceeds threshold', async () => {
-      sendWebhookMock.mockRejectedValueOnce(new Error());
-
-      webhookEntity1.retriesCount = MOCK_MAX_RETRY_COUNT;
-
-      await service.processPendingOutgoingWebhooks();
-
-      expect(webhookOutgoingRepository.updateOne).toHaveBeenCalled();
-      expect(webhookEntity1.status).toBe(WebhookOutgoingStatus.FAILED);
-    });
-
-    it('should complete the cron job entity to unlock', async () => {
+        .mockResolvedValue(new CronJobEntity());
       jest
         .spyOn(service, 'completeCronJob')
-        .mockResolvedValueOnce(cronJobEntityMock as any);
+        .mockResolvedValue(new CronJobEntity());
 
       await service.processPendingOutgoingWebhooks();
 
-      expect(service.completeCronJob).toHaveBeenCalledWith(
-        cronJobEntityMock as any,
+      expect(webhookService.processPendingOutgoingWebhooks).toHaveBeenCalled();
+      expect(service.startCronJob).toHaveBeenCalled();
+      expect(service.completeCronJob).toHaveBeenCalled();
+    });
+
+    it('should log errors during processing', async () => {
+      jest.spyOn(service, 'isCronJobRunning').mockResolvedValue(false);
+      jest
+        .spyOn(service, 'startCronJob')
+        .mockResolvedValue(new CronJobEntity());
+      jest
+        .spyOn(service, 'completeCronJob')
+        .mockResolvedValue(new CronJobEntity());
+
+      webhookService.processPendingOutgoingWebhooks.mockRejectedValue(
+        new Error('Processing error'),
       );
+
+      await service.processPendingOutgoingWebhooks();
+
+      expect(service.completeCronJob).toHaveBeenCalled();
     });
   });
 });

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -133,13 +133,12 @@ export class CronJobService {
     await this.completeCronJob(cronJob);
   }
 
-  @Cron('*/2 * * * *')
+  @Cron('*/1 * * * *')
   /**
    * Processes paid escrow completion tracking, finalizing escrow operations if completed.
    * Notifies oracles via callbacks, logs errors, and updates tracking status.
    * @returns {Promise<void>} A promise that resolves when the paid escrow tracking has been processed.
    */
-  @Cron('*/2 * * * *')
   public async processPaidEscrowCompletion(): Promise<void> {
     const isCronJobRunning = await this.isCronJobRunning(
       CronJobType.ProcessPaidEscrowCompletionTracking,
@@ -170,7 +169,6 @@ export class CronJobService {
    * Updates each webhook's status upon success, retries or logs errors as necessary.
    * @returns {Promise<void>} A promise that resolves once all pending outgoing webhooks have been processed.
    */
-  @Cron('*/2 * * * *')
   public async processPendingOutgoingWebhooks(): Promise<void> {
     if (await this.isCronJobRunning(CronJobType.ProcessPendingOutgoingWebhook))
       return;

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -1,32 +1,13 @@
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
-import { v4 as uuidv4 } from 'uuid';
-import * as crypto from 'crypto';
-import stringify from 'json-stable-stringify';
 
 import { CronJobType } from '../../common/enums/cron-job';
-import { ErrorCronJob, ErrorWebhook } from '../../common/constants/errors';
+import { ErrorCronJob } from '../../common/constants/errors';
 
 import { CronJobEntity } from './cron-job.entity';
 import { CronJobRepository } from './cron-job.repository';
 import { WebhookService } from '../webhook/webhook.service';
-import {
-  EscrowCompletionTrackingStatus,
-  EventType,
-  WebhookIncomingStatus,
-  WebhookOutgoingStatus,
-} from '../../common/enums/webhook';
-import { PayoutService } from '../payout/payout.service';
-import { ReputationService } from '../reputation/reputation.service';
-import { Web3Service } from '../web3/web3.service';
-import { EscrowClient, EscrowStatus, OperatorUtils } from '@human-protocol/sdk';
 import { ControlledError } from '../../common/errors/controlled';
 import { Cron } from '@nestjs/schedule';
-import { WebhookIncomingRepository } from '../webhook/webhook-incoming.repository';
-import { WebhookOutgoingRepository } from '../webhook/webhook-outgoing.repository';
-import { EscrowCompletionTrackingRepository } from '../escrow-completion-tracking/escrow-completion-tracking.repository';
-import { EscrowCompletionTrackingService } from '../escrow-completion-tracking/escrow-completion-tracking.service';
-import { PostgresErrorCodes } from '../../common/enums/database';
-import { DatabaseError } from '../../common/errors/database';
 
 @Injectable()
 export class CronJobService {
@@ -35,13 +16,6 @@ export class CronJobService {
   constructor(
     private readonly cronJobRepository: CronJobRepository,
     private readonly webhookService: WebhookService,
-    private readonly escrowCompletionTrackingService: EscrowCompletionTrackingService,
-    private readonly reputationService: ReputationService,
-    private readonly webhookIncomingRepository: WebhookIncomingRepository,
-    private readonly webhookOutgoingRepository: WebhookOutgoingRepository,
-    private readonly escrowCompletionTrackingRepository: EscrowCompletionTrackingRepository,
-    private readonly payoutService: PayoutService,
-    private readonly web3Service: Web3Service,
   ) {}
 
   /**
@@ -119,59 +93,7 @@ export class CronJobService {
     );
 
     try {
-      const webhookEntities = await this.webhookIncomingRepository.findByStatus(
-        WebhookIncomingStatus.PENDING,
-      );
-
-      for (const webhookEntity of webhookEntities) {
-        try {
-          const { chainId, escrowAddress } = webhookEntity;
-
-          await this.escrowCompletionTrackingService.createEscrowCompletionTracking(
-            chainId,
-            escrowAddress,
-          );
-
-          webhookEntity.status = WebhookIncomingStatus.COMPLETED;
-          await this.webhookIncomingRepository.updateOne(webhookEntity);
-        } catch (err) {
-          if (err instanceof DatabaseError) {
-            if (
-              (err as DatabaseError).message.includes(
-                PostgresErrorCodes.Duplicated,
-              )
-            ) {
-              this.logger.warn(
-                `Duplicate tracking entity for escrowAddress: ${webhookEntity.escrowAddress}. Marking webhook as completed.`,
-              );
-              webhookEntity.status = WebhookIncomingStatus.COMPLETED;
-              await this.webhookIncomingRepository.updateOne(webhookEntity);
-            } else {
-              const errorId = uuidv4();
-              const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
-              this.logger.error(
-                `Database error for webhook processing. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
-              );
-              await this.webhookService.handleWebhookIncomingError(
-                webhookEntity,
-                failureDetail,
-              );
-              continue;
-            }
-          } else {
-            const errorId = uuidv4();
-            const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
-            this.logger.error(
-              `Unexpected error processing webhook. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
-            );
-            await this.webhookService.handleWebhookIncomingError(
-              webhookEntity,
-              failureDetail,
-            );
-            continue;
-          }
-        }
-      }
+      await this.webhookService.processPendingIncomingWebhooks();
     } catch (e) {
       this.logger.error(e);
     }
@@ -182,7 +104,7 @@ export class CronJobService {
 
   @Cron('*/2 * * * *')
   /**
-   * Processes pending escrow completion tracking webhooks to manage escrow lifecycle actions.
+   * Processes pending escrow completion tracking to manage escrow lifecycle actions.
    * Checks escrow status and, if appropriate, saves results and initiates payouts.
    * Handles errors and logs detailed messages.
    * @returns {Promise<void>} A promise that resolves when the operation is complete.
@@ -202,60 +124,7 @@ export class CronJobService {
     );
 
     try {
-      const escrowCompletionTrackingEntities =
-        await this.escrowCompletionTrackingRepository.findByStatus(
-          EscrowCompletionTrackingStatus.PENDING,
-        );
-
-      for (const escrowCompletionTrackingEntity of escrowCompletionTrackingEntities) {
-        try {
-          const { chainId, escrowAddress, finalResultsUrl, finalResultsHash } =
-            escrowCompletionTrackingEntity;
-
-          const signer = this.web3Service.getSigner(chainId);
-          const escrowClient = await EscrowClient.build(signer);
-
-          const escrowStatus = await escrowClient.getStatus(escrowAddress);
-          if (escrowStatus === EscrowStatus.Launched) {
-            if (!finalResultsUrl) {
-              const { url, hash } = await this.payoutService.saveResults(
-                chainId,
-                escrowAddress,
-              );
-
-              escrowCompletionTrackingEntity.finalResultsUrl = url;
-              escrowCompletionTrackingEntity.finalResultsHash = hash;
-              await this.escrowCompletionTrackingRepository.updateOne(
-                escrowCompletionTrackingEntity,
-              );
-            }
-
-            await this.payoutService.executePayouts(
-              chainId,
-              escrowAddress,
-              finalResultsUrl,
-              finalResultsHash,
-            );
-          }
-
-          escrowCompletionTrackingEntity.status =
-            EscrowCompletionTrackingStatus.PAID;
-          await this.escrowCompletionTrackingRepository.updateOne(
-            escrowCompletionTrackingEntity,
-          );
-        } catch (err) {
-          const errorId = uuidv4();
-          const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
-          this.logger.error(
-            `Error processing escrow completion tracking. Error ID: ${errorId}, Escrow completion tracking ID: ${escrowCompletionTrackingEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
-          );
-          await this.escrowCompletionTrackingService.handleEscrowCompletionTrackingError(
-            escrowCompletionTrackingEntity,
-            failureDetail,
-          );
-          continue;
-        }
-      }
+      await this.webhookService.processPendingEscrowCompletion();
     } catch (e) {
       this.logger.error(e);
     }
@@ -266,10 +135,11 @@ export class CronJobService {
 
   @Cron('*/2 * * * *')
   /**
-   * Processes paid escrow completion tracking webhooks, finalizing escrow operations if completed.
+   * Processes paid escrow completion tracking, finalizing escrow operations if completed.
    * Notifies oracles via callbacks, logs errors, and updates tracking status.
    * @returns {Promise<void>} A promise that resolves when the paid escrow tracking has been processed.
    */
+  @Cron('*/2 * * * *')
   public async processPaidEscrowCompletion(): Promise<void> {
     const isCronJobRunning = await this.isCronJobRunning(
       CronJobType.ProcessPaidEscrowCompletionTracking,
@@ -285,133 +155,12 @@ export class CronJobService {
     );
 
     try {
-      const escrowCompletionTrackingEntities =
-        await this.escrowCompletionTrackingRepository.findByStatus(
-          EscrowCompletionTrackingStatus.PAID,
-        );
-
-      // TODO: Add DB transactions
-      for (const escrowCompletionTrackingEntity of escrowCompletionTrackingEntities) {
-        try {
-          const { chainId, escrowAddress } = escrowCompletionTrackingEntity;
-
-          const signer = this.web3Service.getSigner(chainId);
-          const escrowClient = await EscrowClient.build(signer);
-
-          const escrowStatus = await escrowClient.getStatus(escrowAddress);
-          if (escrowStatus === EscrowStatus.Paid) {
-            await escrowClient.complete(escrowAddress, {
-              gasPrice: await this.web3Service.calculateGasPrice(chainId),
-            });
-
-            // TODO: Technically it's possible that the escrow completion could occur before the reputation scores are assessed,
-            // and the app might go down during this window. Currently, there isn’t a clear approach to handle this situation.
-            // Consider revisiting this section to explore potential solutions to improve resilience in such scenarios.
-            await this.reputationService.assessReputationScores(
-              chainId,
-              escrowAddress,
-            );
-          }
-
-          const callbackUrls = [
-            (
-              await OperatorUtils.getLeader(
-                chainId,
-                await escrowClient.getJobLauncherAddress(escrowAddress),
-              )
-            ).webhookUrl,
-            (
-              await OperatorUtils.getLeader(
-                chainId,
-                await escrowClient.getExchangeOracleAddress(escrowAddress),
-              )
-            ).webhookUrl,
-            // Temporarily disable sending webhook to Recording Oracle
-            // (
-            //   await OperatorUtils.getLeader(
-            //     chainId,
-            //     await escrowClient.getRecordingOracleAddress(escrowAddress),
-            //   )
-            // ).webhookUrl,
-          ];
-
-          let allWebhooksCreated = true;
-
-          for (const url of callbackUrls) {
-            if (!url) {
-              throw new ControlledError(
-                ErrorWebhook.UrlNotFound,
-                HttpStatus.NOT_FOUND,
-              );
-            }
-
-            const payload = {
-              chainId,
-              escrowAddress,
-              eventType: EventType.ESCROW_COMPLETED,
-            };
-
-            const hash = crypto
-              .createHash('sha1')
-              .update(stringify({ payload, url }))
-              .digest('hex');
-
-            try {
-              await this.webhookService.createOutgoingWebhook(
-                payload,
-                hash,
-                url,
-              );
-            } catch (err) {
-              if (
-                err instanceof DatabaseError &&
-                err.message.includes(PostgresErrorCodes.Duplicated)
-              ) {
-                this.logger.warn(
-                  `Duplicate outgoing webhook for escrowAddress: ${escrowAddress}. Webhook creation skipped, but will not complete escrow until all URLs are successful.`,
-                );
-                continue;
-              } else {
-                const errorId = uuidv4();
-                const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
-                this.logger.error(
-                  `Error creating outgoing webhook. Error ID: ${errorId}, Escrow Address: ${escrowAddress}, Reason: ${failureDetail}, Message: ${err.message}`,
-                );
-                await this.escrowCompletionTrackingService.handleEscrowCompletionTrackingError(
-                  escrowCompletionTrackingEntity,
-                  failureDetail,
-                );
-                allWebhooksCreated = false;
-                break;
-              }
-            }
-          }
-
-          // Only set the status to COMPLETED if all webhooks were created successfully
-          if (allWebhooksCreated) {
-            escrowCompletionTrackingEntity.status =
-              EscrowCompletionTrackingStatus.COMPLETED;
-            await this.escrowCompletionTrackingRepository.updateOne(
-              escrowCompletionTrackingEntity,
-            );
-          }
-        } catch (err) {
-          const errorId = uuidv4();
-          const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
-          this.logger.error(
-            `Error processing escrow completion tracking. Error ID: ${errorId}, Escrow completion tracking ID: ${escrowCompletionTrackingEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
-          );
-          await this.escrowCompletionTrackingService.handleEscrowCompletionTrackingError(
-            escrowCompletionTrackingEntity,
-            failureDetail,
-          );
-        }
-      }
+      await this.webhookService.processPaidEscrowCompletion();
     } catch (e) {
       this.logger.error(e);
     }
 
-    this.logger.log('Pending escrow completion tracking STOP');
+    this.logger.log('Paid escrow completion tracking STOP');
     await this.completeCronJob(cronJob);
   }
 
@@ -421,14 +170,10 @@ export class CronJobService {
    * Updates each webhook's status upon success, retries or logs errors as necessary.
    * @returns {Promise<void>} A promise that resolves once all pending outgoing webhooks have been processed.
    */
+  @Cron('*/2 * * * *')
   public async processPendingOutgoingWebhooks(): Promise<void> {
-    const isCronJobRunning = await this.isCronJobRunning(
-      CronJobType.ProcessPendingOutgoingWebhook,
-    );
-
-    if (isCronJobRunning) {
+    if (await this.isCronJobRunning(CronJobType.ProcessPendingOutgoingWebhook))
       return;
-    }
 
     this.logger.log('Pending outgoing webhooks START');
     const cronJob = await this.startCronJob(
@@ -436,32 +181,9 @@ export class CronJobService {
     );
 
     try {
-      const webhookEntities = await this.webhookOutgoingRepository.findByStatus(
-        WebhookOutgoingStatus.PENDING,
-      );
-
-      for (const webhookEntity of webhookEntities) {
-        try {
-          const { url, payload } = webhookEntity;
-
-          await this.webhookService.sendWebhook(url, payload);
-        } catch (err) {
-          const errorId = uuidv4();
-          const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
-          this.logger.error(
-            `Error processing pending outgoing webhook. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
-          );
-          await this.webhookService.handleWebhookOutgoingError(
-            webhookEntity,
-            failureDetail,
-          );
-          continue;
-        }
-        webhookEntity.status = WebhookOutgoingStatus.SENT;
-        await this.webhookOutgoingRepository.updateOne(webhookEntity);
-      }
-    } catch (e) {
-      this.logger.error(e);
+      await this.webhookService.processPendingOutgoingWebhooks();
+    } catch (err) {
+      this.logger.error(err);
     }
 
     this.logger.log('Pending outgoing webhooks STOP');

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion-tracking/escrow-completion-tracking.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion-tracking/escrow-completion-tracking.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { BaseRepository } from '../../database/base.repository';
 import { DataSource, LessThanOrEqual } from 'typeorm';
 import { ServerConfigService } from '../../common/config/server-config.service';
@@ -7,7 +7,6 @@ import { EscrowCompletionTrackingStatus } from '../../common/enums';
 
 @Injectable()
 export class EscrowCompletionTrackingRepository extends BaseRepository<EscrowCompletionTrackingEntity> {
-  private readonly logger = new Logger(EscrowCompletionTrackingRepository.name);
   constructor(
     private dataSource: DataSource,
     public readonly serverConfigService: ServerConfigService,

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
@@ -106,7 +106,7 @@ describe('PayoutService', () => {
     jest.restoreAllMocks();
   });
 
-  describe('saveResults', () => {
+  describe('processResults', () => {
     it('should successfully save results for CVAT', async () => {
       const manifest: CvatManifestDto = {
         data: {
@@ -141,7 +141,7 @@ describe('PayoutService', () => {
       const escrowAddress = MOCK_ADDRESS;
       const chainId = ChainId.LOCALHOST;
 
-      const result = await payoutService.saveResults(chainId, escrowAddress);
+      const result = await payoutService.processResults(chainId, escrowAddress);
       expect(result).toEqual(results);
     });
 
@@ -168,7 +168,7 @@ describe('PayoutService', () => {
       const escrowAddress = MOCK_ADDRESS;
       const chainId = ChainId.LOCALHOST;
 
-      const result = await payoutService.saveResults(chainId, escrowAddress);
+      const result = await payoutService.processResults(chainId, escrowAddress);
       expect(result).toEqual(results);
     });
 
@@ -190,12 +190,28 @@ describe('PayoutService', () => {
       const chainId = ChainId.LOCALHOST;
 
       await expect(
-        payoutService.saveResults(chainId, escrowAddress),
+        payoutService.processResults(chainId, escrowAddress),
       ).rejects.toThrow(
         new ControlledError(
           ErrorManifest.ManifestUrlDoesNotExist,
           HttpStatus.BAD_REQUEST,
         ),
+      );
+    });
+
+    it('should throw an error for unsupported request types', async () => {
+      const mockManifest = { requestType: 'unsupportedType' };
+
+      jest.spyOn(EscrowClient, 'build').mockResolvedValue({
+        getManifestUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
+      } as any);
+
+      jest.spyOn(storageService, 'download').mockResolvedValue(mockManifest);
+
+      await expect(
+        payoutService.processResults(ChainId.LOCALHOST, MOCK_ADDRESS),
+      ).rejects.toThrow(
+        `Unsupported request type: ${mockManifest.requestType.toLowerCase()}`,
       );
     });
   });
@@ -310,12 +326,28 @@ describe('PayoutService', () => {
       const chainId = ChainId.LOCALHOST;
 
       await expect(
-        payoutService.saveResults(chainId, escrowAddress),
+        payoutService.processResults(chainId, escrowAddress),
       ).rejects.toThrow(
         new ControlledError(
           ErrorManifest.ManifestUrlDoesNotExist,
           HttpStatus.BAD_REQUEST,
         ),
+      );
+    });
+
+    it('should throw an error for unsupported request types', async () => {
+      const mockManifest = { requestType: 'unsupportedType' };
+
+      jest.spyOn(EscrowClient, 'build').mockResolvedValue({
+        getManifestUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
+      } as any);
+
+      jest.spyOn(storageService, 'download').mockResolvedValue(mockManifest);
+
+      await expect(
+        payoutService.processResults(ChainId.LOCALHOST, MOCK_ADDRESS),
+      ).rejects.toThrow(
+        `Unsupported request type: ${mockManifest.requestType.toLowerCase()}`,
       );
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { BaseRepository } from '../../database/base.repository';
 import { DataSource, LessThanOrEqual } from 'typeorm';
 import { WebhookIncomingStatus } from '../../common/enums/webhook';
@@ -7,7 +7,6 @@ import { ServerConfigService } from '../../common/config/server-config.service';
 
 @Injectable()
 export class WebhookIncomingRepository extends BaseRepository<WebhookIncomingEntity> {
-  private readonly logger = new Logger(WebhookIncomingRepository.name);
   constructor(
     private dataSource: DataSource,
     public readonly serverConfigService: ServerConfigService,

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.module.ts
@@ -35,6 +35,7 @@ import { ReputationModule } from '../reputation/reputation.module';
     WebhookService,
     WebhookIncomingRepository,
     WebhookOutgoingRepository,
+    EscrowCompletionTrackingRepository,
   ],
   exports: [WebhookService],
 })

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.module.ts
@@ -10,13 +10,24 @@ import { WebhookIncomingEntity } from './webhook-incoming.entity';
 import { WebhookOutgoingEntity } from './webhook-outgoing.entity';
 import { WebhookIncomingRepository } from './webhook-incoming.repository';
 import { WebhookOutgoingRepository } from './webhook-outgoing.repository';
+import { EscrowCompletionTrackingModule } from '../escrow-completion-tracking/escrow-completion-tracking.module';
+import { EscrowCompletionTrackingRepository } from '../escrow-completion-tracking/escrow-completion-tracking.repository';
+import { PayoutModule } from '../payout/payout.module';
+import { ReputationModule } from '../reputation/reputation.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([WebhookIncomingEntity, WebhookOutgoingEntity]),
+    TypeOrmModule.forFeature([
+      WebhookIncomingEntity,
+      WebhookOutgoingEntity,
+      EscrowCompletionTrackingRepository,
+    ]),
     ConfigModule,
     Web3Module,
     HttpModule,
+    EscrowCompletionTrackingModule,
+    PayoutModule,
+    ReputationModule,
   ],
   controllers: [WebhookController],
   providers: [

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -76,7 +76,6 @@ describe('WebhookService', () => {
   let web3ConfigService: Web3ConfigService;
   let escrowCompletionTrackingService: EscrowCompletionTrackingService;
   let escrowCompletionTrackingRepository: EscrowCompletionTrackingRepository;
-  let payoutService: PayoutService;
   let reputationService: ReputationService;
 
   const signerMock = {
@@ -152,7 +151,6 @@ describe('WebhookService', () => {
     escrowCompletionTrackingRepository = moduleRef.get(
       EscrowCompletionTrackingRepository,
     );
-    payoutService = moduleRef.get<PayoutService>(PayoutService);
     reputationService = moduleRef.get<ReputationService>(ReputationService);
     escrowCompletionTrackingService =
       moduleRef.get<EscrowCompletionTrackingService>(

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -603,7 +603,9 @@ describe('WebhookService', () => {
         })
         .mockResolvedValue(mockEntity2 as any);
 
-      await webhookService.processPendingEscrowCompletion();
+      await expect(
+        webhookService.processPendingEscrowCompletion(),
+      ).rejects.toThrow(new Error('Test error'));
     });
   });
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -603,9 +603,7 @@ describe('WebhookService', () => {
         })
         .mockResolvedValue(mockEntity2 as any);
 
-      await expect(
-        webhookService.processPendingEscrowCompletion(),
-      ).rejects.toThrow(new Error('Test error'));
+      await webhookService.processPendingEscrowCompletion();
     });
   });
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -245,7 +245,7 @@ export class WebhookService {
         const escrowStatus = await escrowClient.getStatus(escrowAddress);
         if (escrowStatus === EscrowStatus.Launched) {
           if (!finalResultsUrl) {
-            const { url, hash } = await this.payoutService.saveResults(
+            const { url, hash } = await this.payoutService.processResults(
               chainId,
               escrowAddress,
             );

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto';
+import stringify from 'json-stable-stringify';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { IncomingWebhookDto } from './webhook.dto';
 import { ErrorWebhook } from '../../common/constants/errors';
 import {
+  EscrowCompletionTrackingStatus,
   EventType,
   WebhookIncomingStatus,
   WebhookOutgoingStatus,
@@ -23,13 +27,28 @@ import { WebhookOutgoingEntity } from './webhook-outgoing.entity';
 import { WebhookIncomingRepository } from './webhook-incoming.repository';
 import { WebhookOutgoingRepository } from './webhook-outgoing.repository';
 import { calculateBackoff } from '../../common/utils/cron';
+import { EscrowCompletionTrackingService } from '../escrow-completion-tracking/escrow-completion-tracking.service';
+import { DatabaseError } from '../../common/errors/database';
+import { PostgresErrorCodes } from '../../common/enums/database';
+import { EscrowCompletionTrackingRepository } from '../escrow-completion-tracking/escrow-completion-tracking.repository';
+import { Web3Service } from '../web3/web3.service';
+import { EscrowClient, EscrowStatus, OperatorUtils } from '@human-protocol/sdk';
+import { PayoutService } from '../payout/payout.service';
+import { ReputationService } from '../reputation/reputation.service';
 
 @Injectable()
 export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
   constructor(
     private readonly httpService: HttpService,
+    private readonly web3Service: Web3Service,
     private readonly webhookIncomingRepository: WebhookIncomingRepository,
     private readonly webhookOutgoingRepository: WebhookOutgoingRepository,
+    private readonly escrowCompletionTrackingRepository: EscrowCompletionTrackingRepository,
+    private readonly escrowCompletionTrackingService: EscrowCompletionTrackingService,
+    private readonly payoutService: PayoutService,
+    private readonly reputationService: ReputationService,
     public readonly serverConfigService: ServerConfigService,
     public readonly web3ConfigService: Web3ConfigService,
   ) {}
@@ -156,6 +175,254 @@ export class WebhookService {
 
     if (status !== HttpStatus.CREATED) {
       throw new ControlledError(ErrorWebhook.NotSent, HttpStatus.NOT_FOUND);
+    }
+  }
+
+  public async processPendingIncomingWebhooks(): Promise<void> {
+    const webhookEntities = await this.webhookIncomingRepository.findByStatus(
+      WebhookIncomingStatus.PENDING,
+    );
+
+    for (const webhookEntity of webhookEntities) {
+      try {
+        const { chainId, escrowAddress } = webhookEntity;
+
+        await this.escrowCompletionTrackingService.createEscrowCompletionTracking(
+          chainId,
+          escrowAddress,
+        );
+
+        webhookEntity.status = WebhookIncomingStatus.COMPLETED;
+        await this.webhookIncomingRepository.updateOne(webhookEntity);
+      } catch (err) {
+        if (err instanceof DatabaseError) {
+          if (
+            (err as DatabaseError).message.includes(
+              PostgresErrorCodes.Duplicated,
+            )
+          ) {
+            this.logger.warn(
+              `Duplicate tracking entity for escrowAddress: ${webhookEntity.escrowAddress}. Marking webhook as completed.`,
+            );
+            webhookEntity.status = WebhookIncomingStatus.COMPLETED;
+            await this.webhookIncomingRepository.updateOne(webhookEntity);
+          } else {
+            const errorId = uuidv4();
+            const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
+            this.logger.error(
+              `Database error for webhook processing. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
+            );
+            await this.handleWebhookIncomingError(webhookEntity, failureDetail);
+            continue;
+          }
+        } else {
+          const errorId = uuidv4();
+          const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
+          this.logger.error(
+            `Unexpected error processing webhook. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
+          );
+          await this.handleWebhookIncomingError(webhookEntity, failureDetail);
+          continue;
+        }
+      }
+    }
+  }
+
+  public async processPendingEscrowCompletion(): Promise<void> {
+    const escrowCompletionTrackingEntities =
+      await this.escrowCompletionTrackingRepository.findByStatus(
+        EscrowCompletionTrackingStatus.PENDING,
+      );
+
+    for (const escrowCompletionTrackingEntity of escrowCompletionTrackingEntities) {
+      try {
+        const { chainId, escrowAddress, finalResultsUrl, finalResultsHash } =
+          escrowCompletionTrackingEntity;
+
+        const signer = this.web3Service.getSigner(chainId);
+        const escrowClient = await EscrowClient.build(signer);
+
+        const escrowStatus = await escrowClient.getStatus(escrowAddress);
+        if (escrowStatus === EscrowStatus.Launched) {
+          if (!finalResultsUrl) {
+            const { url, hash } = await this.payoutService.saveResults(
+              chainId,
+              escrowAddress,
+            );
+
+            escrowCompletionTrackingEntity.finalResultsUrl = url;
+            escrowCompletionTrackingEntity.finalResultsHash = hash;
+            await this.escrowCompletionTrackingRepository.updateOne(
+              escrowCompletionTrackingEntity,
+            );
+          }
+
+          await this.payoutService.executePayouts(
+            chainId,
+            escrowAddress,
+            finalResultsUrl,
+            finalResultsHash,
+          );
+        }
+
+        escrowCompletionTrackingEntity.status =
+          EscrowCompletionTrackingStatus.PAID;
+        await this.escrowCompletionTrackingRepository.updateOne(
+          escrowCompletionTrackingEntity,
+        );
+      } catch (err) {
+        const errorId = uuidv4();
+        const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
+        this.logger.error(
+          `Error processing escrow completion tracking. Error ID: ${errorId}, Escrow completion tracking ID: ${escrowCompletionTrackingEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
+        );
+        await this.escrowCompletionTrackingService.handleEscrowCompletionTrackingError(
+          escrowCompletionTrackingEntity,
+          failureDetail,
+        );
+        continue;
+      }
+    }
+  }
+
+  public async processPaidEscrowCompletion(): Promise<void> {
+    const escrowCompletionTrackingEntities =
+      await this.escrowCompletionTrackingRepository.findByStatus(
+        EscrowCompletionTrackingStatus.PAID,
+      );
+
+    // TODO: Add DB transactions
+    for (const escrowCompletionTrackingEntity of escrowCompletionTrackingEntities) {
+      try {
+        const { chainId, escrowAddress } = escrowCompletionTrackingEntity;
+
+        const signer = this.web3Service.getSigner(chainId);
+        const escrowClient = await EscrowClient.build(signer);
+
+        const escrowStatus = await escrowClient.getStatus(escrowAddress);
+        if (escrowStatus === EscrowStatus.Paid) {
+          await escrowClient.complete(escrowAddress, {
+            gasPrice: await this.web3Service.calculateGasPrice(chainId),
+          });
+
+          // TODO: Assess reputation scores after completing escrow
+          await this.reputationService.assessReputationScores(
+            chainId,
+            escrowAddress,
+          );
+        }
+
+        const callbackUrls = [
+          (
+            await OperatorUtils.getLeader(
+              chainId,
+              await escrowClient.getJobLauncherAddress(escrowAddress),
+            )
+          ).webhookUrl,
+          (
+            await OperatorUtils.getLeader(
+              chainId,
+              await escrowClient.getExchangeOracleAddress(escrowAddress),
+            )
+          ).webhookUrl,
+          (
+            await OperatorUtils.getLeader(
+              chainId,
+              await escrowClient.getRecordingOracleAddress(escrowAddress),
+            )
+          ).webhookUrl,
+        ];
+
+        let allWebhooksCreated = true;
+
+        for (const url of callbackUrls) {
+          if (!url) {
+            throw new ControlledError(
+              ErrorWebhook.UrlNotFound,
+              HttpStatus.NOT_FOUND,
+            );
+          }
+
+          const payload = {
+            chainId,
+            escrowAddress,
+            eventType: EventType.ESCROW_COMPLETED,
+          };
+
+          const hash = crypto
+            .createHash('sha1')
+            .update(stringify({ payload, url }))
+            .digest('hex');
+
+          try {
+            await this.createOutgoingWebhook(payload, hash, url);
+          } catch (err) {
+            if (
+              err instanceof DatabaseError &&
+              err.message.includes(PostgresErrorCodes.Duplicated)
+            ) {
+              this.logger.warn(
+                `Duplicate outgoing webhook for escrowAddress: ${escrowAddress}. Webhook creation skipped, but will not complete escrow until all URLs are successful.`,
+              );
+              continue;
+            } else {
+              const errorId = uuidv4();
+              const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
+              this.logger.error(
+                `Error creating outgoing webhook. Error ID: ${errorId}, Escrow Address: ${escrowAddress}, Reason: ${failureDetail}, Message: ${err.message}`,
+              );
+              await this.escrowCompletionTrackingService.handleEscrowCompletionTrackingError(
+                escrowCompletionTrackingEntity,
+                failureDetail,
+              );
+              allWebhooksCreated = false;
+              break;
+            }
+          }
+        }
+
+        // Only set the status to COMPLETED if all webhooks were created successfully
+        if (allWebhooksCreated) {
+          escrowCompletionTrackingEntity.status =
+            EscrowCompletionTrackingStatus.COMPLETED;
+          await this.escrowCompletionTrackingRepository.updateOne(
+            escrowCompletionTrackingEntity,
+          );
+        }
+      } catch (err) {
+        const errorId = uuidv4();
+        const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
+        this.logger.error(
+          `Error processing escrow completion tracking. Error ID: ${errorId}, Escrow completion tracking ID: ${escrowCompletionTrackingEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
+        );
+        await this.escrowCompletionTrackingService.handleEscrowCompletionTrackingError(
+          escrowCompletionTrackingEntity,
+          failureDetail,
+        );
+      }
+    }
+  }
+
+  public async processPendingOutgoingWebhooks(): Promise<void> {
+    const webhookEntities = await this.webhookOutgoingRepository.findByStatus(
+      WebhookOutgoingStatus.PENDING,
+    );
+
+    for (const webhookEntity of webhookEntities) {
+      try {
+        const { url, payload } = webhookEntity;
+        await this.sendWebhook(url, payload);
+
+        webhookEntity.status = WebhookOutgoingStatus.SENT;
+        await this.webhookOutgoingRepository.updateOne(webhookEntity);
+      } catch (err) {
+        const errorId = uuidv4();
+        const failureDetail = `${ErrorWebhook.PendingProcessingFailed} (Error ID: ${errorId})`;
+        console.error(
+          `Error processing outgoing webhook. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Message: ${err.message}`,
+        );
+        await this.handleWebhookOutgoingError(webhookEntity, failureDetail);
+      }
     }
   }
 }


### PR DESCRIPTION
## Issue tracking
This change is being tracked via a [Reputation Oracle] Refactor processPaidWebhooks method
[#2638](https://github.com/humanprotocol/human-protocol/issues/2638), the discussion in comment https://github.com/humanprotocol/human-protocol/pull/2658#discussion_r1830811808, which outlines the need for restructuring the webhook handling logic in the cron-job service.
The requirement is to ensure that the `try..catch block` is fully contained within the `webhookService` while the `cron-job` service should only handle job execution and locking.

## Context behind the change
In the previous implementation, the `cron-job` service was responsible for handling the webhook logic, including error handling with `try..catch`. This made the service do more than it should, as its main responsibility is to schedule and ensure a lock to avoid parallel job execution.

This pull request refactors the code by moving the `try..catch` logic into the `webhookService`. The `cron-job` service will now solely handle job execution scheduling.

## How has this been tested?
I have tested the changes locally by running the cron job and ensuring that the `webhookService` properly handles errors through the `try..catch` block. Additionally, I improved unit tests.