### PR TITLE
[Human App] feat: add hardcoded oracles name mapping

### DIFF
--- a/packages/apps/human-app/frontend/src/hooks/use-my-jobs-filter-store.tsx
+++ b/packages/apps/human-app/frontend/src/hooks/use-my-jobs-filter-store.tsx
@@ -16,7 +16,12 @@ type JobStatus = (typeof jobStatuses)[number];
 export interface MyJobsFilterStoreProps {
   filterParams: {
     sort?: 'asc' | 'desc';
-    sort_field?: 'chain_id' | 'job_type' | 'reward_amount' | 'expires_at';
+    sort_field?:
+      | 'chain_id'
+      | 'job_type'
+      | 'reward_amount'
+      | 'expires_at'
+      | 'created_at';
     job_type?: string;
     status?: JobStatus;
     escrow_address?: string;
@@ -36,11 +41,11 @@ export interface MyJobsFilterStoreProps {
 }
 
 const initialFiltersState = {
+  escrow_address: '',
   page: 0,
   page_size: 5,
-  filterParams: {
-    escrow_address: '',
-  },
+  sort_field: 'created_at',
+  sort: 'desc',
 } as const;
 
 export const useMyJobsFilterStore = create<MyJobsFilterStoreProps>((set) => ({

--- a/packages/apps/human-app/frontend/src/pages/worker/jobs-discovery/components/oracles-table/oracles-table-mobile.tsx
+++ b/packages/apps/human-app/frontend/src/pages/worker/jobs-discovery/components/oracles-table/oracles-table-mobile.tsx
@@ -61,7 +61,7 @@ export function OraclesTableMobile({
               <EvmAddress address={d.address} />
             </ListItem>
             <ListItem label={t('worker.oraclesTable.annotationTool')}>
-              <Typography variant="body2">{d.url ?? ''}</Typography>
+              <Typography variant="body2">{d.name}</Typography>
             </ListItem>
             <ListItem label={t('worker.oraclesTable.jobTypes')}>
               <Chips

--- a/packages/apps/human-app/frontend/src/pages/worker/jobs-discovery/components/oracles-table/oracles-table.tsx
+++ b/packages/apps/human-app/frontend/src/pages/worker/jobs-discovery/components/oracles-table/oracles-table.tsx
@@ -26,7 +26,7 @@ const getColumns = (
 ): MRT_ColumnDef<OracleSuccessResponse>[] => {
   return [
     {
-      accessorKey: 'url',
+      accessorKey: 'name',
       header: t('worker.oraclesTable.annotationTool'),
       size: 100,
       enableSorting: false,

--- a/packages/apps/human-app/frontend/src/pages/worker/jobs/jobs.page.tsx
+++ b/packages/apps/human-app/frontend/src/pages/worker/jobs/jobs.page.tsx
@@ -59,7 +59,7 @@ export function JobsPage() {
 
   const oracleName = data?.find(
     ({ address }) => address === oracle_address
-  )?.role;
+  )?.name;
 
   if (isPending) {
     return <PageCardLoader />;


### PR DESCRIPTION
## Issue tracking
Closes #2805 

## Context behind the change
Adding hardcoded mapping from oracle url to human readable-names. There are three options:
1) Do it on UI
2) Do it in response with oracles
3) Do it when we fetch data by chain id

2 & 3 will also affect swagger documentation and that might be confusing for now, so chose first option.

## How has this been tested?
- [x] Locally
<img width="1418" alt="Screenshot 2024-11-18 at 18 27 16" src="https://github.com/user-attachments/assets/cbac771c-b07b-49fd-b901-960a7bd55701">
<img width="1498" alt="Screenshot 2024-11-18 at 18 27 24" src="https://github.com/user-attachments/assets/3392cc56-8d26-42ad-a098-a41f3c7e79cf">

- [ ] Staging w/ Vercel

## Release plan
Merge & deploy

## Potential risks; What to monitor; Rollback plan
N/A