### PR TITLE
[HUMAN App] Add enabled chain ids to oracles discovery response

### DIFF
--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -48,9 +48,11 @@ export class CronJobService {
     this.logger.log('CRON START');
 
     const oracleDiscoveryCommand: OracleDiscoveryCommand = {};
-    const oracles = await this.oracleDiscoveryService.processOracleDiscovery(
-      oracleDiscoveryCommand,
-    );
+    const oracles = (
+      await this.oracleDiscoveryService.processOracleDiscovery(
+        oracleDiscoveryCommand,
+      )
+    )?.oracles;
 
     if (!oracles || oracles.length < 1) return;
 

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -52,7 +52,7 @@ export class CronJobService {
       await this.oracleDiscoveryService.processOracleDiscovery(
         oracleDiscoveryCommand,
       )
-    )?.oracles;
+    ).oracles;
 
     if (!oracles || oracles.length < 1) return;
 

--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -13,6 +13,7 @@ import { JOB_DISCOVERY_CACHE_KEY } from '../../../common/constants/cache';
 import { JobStatus } from '../../../common/enums/global-common';
 import { OracleDiscoveryResponse } from '../../../modules/oracle-discovery/model/oracle-discovery.model';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { generateOracleDiscoveryResponseBody } from '../../../modules/oracle-discovery/spec/oracle-discovery.fixture';
 
 jest.mock('cron', () => {
   return {
@@ -134,10 +135,10 @@ describe('CronJobService', () => {
     });
 
     it('should proceed with valid oracles and update jobs list cache', async () => {
-      const oracles = [{ address: '0x123' }];
+      const oraclesDiscovery = generateOracleDiscoveryResponseBody();
       (
         oracleDiscoveryServiceMock.processOracleDiscovery as jest.Mock
-      ).mockResolvedValue(oracles);
+      ).mockResolvedValue(oraclesDiscovery);
       (workerServiceMock.signinWorker as jest.Mock).mockResolvedValue({
         access_token: 'token',
       });
@@ -156,7 +157,7 @@ describe('CronJobService', () => {
         password: configServiceMock.password,
       });
       expect(updateJobsListCacheSpy).toHaveBeenCalledWith(
-        oracles[0],
+        oraclesDiscovery.oracles[0],
         'Bearer token',
       );
     });

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
@@ -55,6 +55,19 @@ export class OracleDiscoveryResponse implements IOperator {
     this.registrationInstructions = registrationInstructions;
   }
 }
+
+export class OracleDiscoveryResponseDto {
+  @ApiProperty({
+    type: [OracleDiscoveryResponse],
+    description: 'List of discovered oracles',
+  })
+  oracles: OracleDiscoveryResponse[];
+  @ApiProperty({
+    type: [String],
+    description: 'Chain ids where oracles haven been discovered',
+  })
+  chainIdsEnabled: string[];
+}
 export class OracleDiscoveryDto {
   @ApiPropertyOptional({ type: [String] })
   @IsArray()

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
@@ -13,11 +13,11 @@ import {
   OracleDiscoveryCommand,
   OracleDiscoveryDto,
   OracleDiscoveryResponse,
+  OracleDiscoveryResponseDto,
 } from './model/oracle-discovery.model';
 import { InjectMapper } from '@automapper/nestjs';
 import { Mapper } from '@automapper/core';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
-import { plainToInstance } from 'class-transformer';
 
 @Controller()
 export class OracleDiscoveryController {
@@ -36,7 +36,7 @@ export class OracleDiscoveryController {
   @UsePipes(new ValidationPipe())
   public async getOracles(
     @Query() dto: OracleDiscoveryDto,
-  ): Promise<OracleDiscoveryResponse[]> {
+  ): Promise<OracleDiscoveryResponseDto> {
     if (!this.environmentConfigService.jobsDiscoveryFlag) {
       throw new HttpException(
         'Oracles discovery is disabled',
@@ -48,9 +48,6 @@ export class OracleDiscoveryController {
       OracleDiscoveryDto,
       OracleDiscoveryCommand,
     );
-    const oracles = await this.service.processOracleDiscovery(command);
-    return oracles.map((oracle) =>
-      plainToInstance(OracleDiscoveryResponse, oracle),
-    );
+    return await this.service.processOracleDiscovery(command);
   }
 }

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   OracleDiscoveryCommand,
   OracleDiscoveryResponse,
+  OracleDiscoveryResponseDto,
 } from './model/oracle-discovery.model';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -19,7 +20,7 @@ export class OracleDiscoveryService {
 
   async processOracleDiscovery(
     command: OracleDiscoveryCommand,
-  ): Promise<OracleDiscoveryResponse[]> {
+  ): Promise<OracleDiscoveryResponseDto> {
     const address = this.configService.reputationOracleAddress;
     const chainIds = this.configService.chainIdsEnabled;
     const oraclesForChainIds = await Promise.all(
@@ -28,7 +29,10 @@ export class OracleDiscoveryService {
       ),
     );
 
-    const filteredOracles: OracleDiscoveryResponse[] = [];
+    const response: OracleDiscoveryResponseDto = {
+      oracles: [],
+      chainIdsEnabled: this.configService.chainIdsEnabled,
+    };
     for (const oraclesForChainId of oraclesForChainIds) {
       for (const oracle of oraclesForChainId) {
         if (command.selectedJobTypes?.length) {
@@ -46,11 +50,11 @@ export class OracleDiscoveryService {
           }
         }
 
-        filteredOracles.push(oracle);
+        response.oracles.push(oracle);
       }
     }
 
-    return filteredOracles;
+    return response;
   }
 
   private async findOraclesByChainId(

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -7,7 +7,7 @@ import { oracleDiscoveryServiceMock } from './oracle-discovery.service.mock';
 import {
   OracleDiscoveryCommand,
   OracleDiscoveryDto,
-  OracleDiscoveryResponse,
+  OracleDiscoveryResponseDto,
 } from '../model/oracle-discovery.model';
 import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
@@ -68,7 +68,7 @@ describe('OracleDiscoveryController', () => {
       const commandFixture = {
         selectedJobTypes: ['job-type-1', 'job-type-2'],
       } as OracleDiscoveryCommand;
-      const result: OracleDiscoveryResponse[] =
+      const result: OracleDiscoveryResponseDto =
         await controller.getOracles(dtoFixture);
       const expectedResponse = generateOracleDiscoveryResponseBody();
       expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
@@ -3,43 +3,79 @@ import {
   OracleDiscoveryResponse,
 } from '../model/oracle-discovery.model';
 
+const response1: OracleDiscoveryResponse = {
+  address: '0xd06eac24a0c47c776Ce6826A93162c4AfC029047',
+  chainId: '4200',
+  role: 'role1',
+  url: 'common-url',
+  jobTypes: ['job-type-3'],
+  retriesCount: 0,
+  executionsToSkip: 0,
+  registrationNeeded: true,
+  registrationInstructions: 'https://instructions.com',
+};
+const response2: OracleDiscoveryResponse = {
+  address: '0xd10c3402155c058D78e4D5fB5f50E125F06eb39d',
+  chainId: '4200',
+  role: 'role2',
+  jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
+  retriesCount: 0,
+  executionsToSkip: 0,
+  registrationNeeded: false,
+  registrationInstructions: undefined,
+};
+const response3: OracleDiscoveryResponse = {
+  address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
+  chainId: '4200',
+  role: 'role3',
+  url: 'common-url',
+  jobTypes: ['job-type-2'],
+  retriesCount: 0,
+  executionsToSkip: 0,
+  registrationNeeded: false,
+  registrationInstructions: undefined,
+};
+const response4: OracleDiscoveryResponse = {
+  address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
+  chainId: '4201',
+  role: 'role3',
+  url: 'common-url',
+  jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
+  retriesCount: 0,
+  executionsToSkip: 0,
+  registrationNeeded: false,
+  registrationInstructions: undefined,
+};
+
+export function generateGetReputationNetworkOperatorsResponseByChainId(
+  chainId: string,
+) {
+  return [response1, response2, response3, response4].filter(
+    (oracle) => oracle.chainId === chainId,
+  );
+}
+
+export function generateOracleDiscoveryResponseBodyByChainId(chainId: string) {
+  return {
+    oracles: [response1, response3, response4].filter(
+      (oracle) => oracle.chainId === chainId,
+    ),
+    chainIdsEnabled: ['4200', '4201'],
+  };
+}
+
 export function generateOracleDiscoveryResponseBody() {
-  const response1: OracleDiscoveryResponse = {
-    address: '0xd06eac24a0c47c776Ce6826A93162c4AfC029047',
-    chainId: '4200',
-    role: 'role1',
-    url: 'common-url',
-    jobTypes: ['job-type-3'],
-    retriesCount: 0,
-    executionsToSkip: 0,
+  return {
+    oracles: [response1, response3, response4],
+    chainIdsEnabled: ['4200', '4201'],
   };
-  const response2: OracleDiscoveryResponse = {
-    address: '0xd10c3402155c058D78e4D5fB5f50E125F06eb39d',
-    chainId: '4200',
-    role: 'role2',
-    url: 'common-url',
-    jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
-    retriesCount: 0,
-    executionsToSkip: 0,
+}
+
+export function generateOracleDiscoveryResponseBodyByJobType() {
+  return {
+    oracles: [response3, response4],
+    chainIdsEnabled: ['4200', '4201'],
   };
-  const response3: OracleDiscoveryResponse = {
-    address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
-    chainId: '4200',
-    role: 'role3',
-    url: 'common-url',
-    jobTypes: ['job-type-2'],
-    retriesCount: 0,
-    executionsToSkip: 0,
-  };
-  const response4: OracleDiscoveryResponse = {
-    address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
-    chainId: '4200',
-    role: 'role3',
-    jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
-    retriesCount: 0,
-    executionsToSkip: 0,
-  };
-  return [response1, response2, response3, response4];
 }
 
 export const filledCommandFixture = {
@@ -49,3 +85,4 @@ export const emptyCommandFixture = {
   selectedJobTypes: [],
 } as OracleDiscoveryCommand;
 export const notSetCommandFixture = {} as OracleDiscoveryCommand;
+export const errorResponse = { chainIdsEnabled: ['4200', '4201'], oracles: [] };

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
@@ -5,12 +5,15 @@ import { Test } from '@nestjs/testing';
 import { Cache } from 'cache-manager';
 import { CommonConfigModule } from '../../../common/config/common-config.module';
 import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
-import { OracleDiscoveryResponse } from '../model/oracle-discovery.model';
 import { OracleDiscoveryService } from '../oracle-discovery.service';
 import {
   emptyCommandFixture,
+  errorResponse,
   filledCommandFixture,
+  generateGetReputationNetworkOperatorsResponseByChainId,
   generateOracleDiscoveryResponseBody,
+  generateOracleDiscoveryResponseBodyByChainId,
+  generateOracleDiscoveryResponseBodyByJobType,
   notSetCommandFixture,
 } from './oracle-discovery.fixture';
 
@@ -26,7 +29,7 @@ jest.mock('@human-protocol/sdk', () => {
 
 describe('OracleDiscoveryService', () => {
   const EXCHANGE_ORACLE = 'Exchange Oracle';
-  const EXPECTED_CHAIN_IDS = ['4200'];
+  const EXPECTED_CHAIN_IDS = ['4200', '4201'];
   const REPUTATION_ORACLE_ADDRESS = 'the_oracle';
   const TTL = '300';
   let oracleDiscoveryService: OracleDiscoveryService;
@@ -76,23 +79,14 @@ describe('OracleDiscoveryService', () => {
   });
 
   it('should return cached data if available', async () => {
-    const mockData: OracleDiscoveryResponse[] = [
-      {
-        address: 'mockAddress1',
-        role: 'validator',
-        chainId: '4200',
-        retriesCount: 0,
-        executionsToSkip: 0,
-      },
-      {
-        address: 'mockAddress2',
-        role: 'validator',
-        chainId: '4200',
-        retriesCount: 0,
-        executionsToSkip: 0,
-      },
-    ];
-    jest.spyOn(cacheManager, 'get').mockResolvedValueOnce(mockData);
+    const mockData = generateOracleDiscoveryResponseBody();
+    EXPECTED_CHAIN_IDS.forEach((chainId) => {
+      jest
+        .spyOn(cacheManager, 'get')
+        .mockResolvedValueOnce(
+          generateOracleDiscoveryResponseBodyByChainId(chainId).oracles,
+        );
+    });
 
     const result =
       await oracleDiscoveryService.processOracleDiscovery(notSetCommandFixture);
@@ -102,38 +96,24 @@ describe('OracleDiscoveryService', () => {
   });
 
   it('should fetch and cache data if not already cached', async () => {
-    const mockData: OracleDiscoveryResponse[] = [
-      {
-        address: 'mockAddress1',
-        role: 'validator',
-        url: 'url1',
-        chainId: '4200',
-        retriesCount: 0,
-        executionsToSkip: 0,
-      },
-      {
-        address: 'mockAddress2',
-        role: 'validator',
-        chainId: '4200',
-        retriesCount: 0,
-        executionsToSkip: 0,
-      },
-    ];
-
     jest.spyOn(cacheManager, 'get').mockResolvedValueOnce(undefined);
-    jest
-      .spyOn(OperatorUtils, 'getReputationNetworkOperators')
-      .mockResolvedValueOnce(mockData);
+    EXPECTED_CHAIN_IDS.forEach((chainId) => {
+      jest
+        .spyOn(OperatorUtils, 'getReputationNetworkOperators')
+        .mockResolvedValueOnce(
+          generateGetReputationNetworkOperatorsResponseByChainId(chainId),
+        );
+    });
 
     const result =
       await oracleDiscoveryService.processOracleDiscovery(emptyCommandFixture);
 
-    expect(result).toEqual([mockData[0]]);
+    expect(result).toEqual(generateOracleDiscoveryResponseBody());
     EXPECTED_CHAIN_IDS.forEach((chainId) => {
       expect(cacheManager.get).toHaveBeenCalledWith(chainId);
       expect(cacheManager.set).toHaveBeenCalledWith(
         chainId,
-        [mockData[0]],
+        generateOracleDiscoveryResponseBodyByChainId(chainId).oracles,
         TTL,
       );
       expect(OperatorUtils.getReputationNetworkOperators).toHaveBeenCalledWith(
@@ -145,37 +125,39 @@ describe('OracleDiscoveryService', () => {
   });
 
   it('should filter oracles if selectedJobTypes not empty, or url not set', async () => {
-    const mockData: OracleDiscoveryResponse[] =
-      generateOracleDiscoveryResponseBody();
-
     jest.spyOn(cacheManager, 'get').mockResolvedValueOnce(undefined);
-    jest
-      .spyOn(OperatorUtils, 'getReputationNetworkOperators')
-      .mockResolvedValueOnce(mockData);
+    EXPECTED_CHAIN_IDS.forEach((chainId) => {
+      jest
+        .spyOn(OperatorUtils, 'getReputationNetworkOperators')
+        .mockResolvedValueOnce(
+          generateGetReputationNetworkOperatorsResponseByChainId(chainId),
+        );
+    });
 
     const result =
       await oracleDiscoveryService.processOracleDiscovery(filledCommandFixture);
 
-    expect(result).toEqual([mockData[1], mockData[2]]);
+    expect(result).toEqual(generateOracleDiscoveryResponseBodyByJobType());
   });
 
   it('should not filter responses if selectedJobTypes is empty', async () => {
-    const mockData: OracleDiscoveryResponse[] =
-      generateOracleDiscoveryResponseBody();
-
     jest.spyOn(cacheManager, 'get').mockResolvedValueOnce(undefined);
-    jest
-      .spyOn(OperatorUtils, 'getReputationNetworkOperators')
-      .mockResolvedValueOnce(mockData);
+    EXPECTED_CHAIN_IDS.forEach((chainId) => {
+      jest
+        .spyOn(OperatorUtils, 'getReputationNetworkOperators')
+        .mockResolvedValueOnce(
+          generateGetReputationNetworkOperatorsResponseByChainId(chainId),
+        );
+    });
 
     const result = await oracleDiscoveryService.processOracleDiscovery({
       selectedJobTypes: [],
     });
 
-    expect(result).toEqual([mockData[0], mockData[1], mockData[2]]);
+    expect(result).toEqual(generateOracleDiscoveryResponseBody());
   });
 
-  it('should handle errors and return an empty array', async () => {
+  it('should handle errors and return an empty array of oracles', async () => {
     const error = new Error('Test error');
     jest.spyOn(cacheManager, 'get').mockResolvedValueOnce(undefined);
     jest
@@ -190,14 +172,14 @@ describe('OracleDiscoveryService', () => {
     const result =
       await oracleDiscoveryService.processOracleDiscovery(emptyCommandFixture);
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(errorResponse);
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       `Error processing chainId 4200:`,
       error,
     );
   });
 
-  it('should return an empty array if no oracles are found', async () => {
+  it('should return an empty array of oracles if no oracles are found', async () => {
     jest.spyOn(cacheManager, 'get').mockResolvedValueOnce(undefined);
     jest
       .spyOn(OperatorUtils, 'getReputationNetworkOperators')
@@ -206,7 +188,7 @@ describe('OracleDiscoveryService', () => {
     const result =
       await oracleDiscoveryService.processOracleDiscovery(emptyCommandFixture);
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(errorResponse);
     EXPECTED_CHAIN_IDS.forEach((chainId) => {
       expect(cacheManager.get).toHaveBeenCalledWith(chainId);
     });


### PR DESCRIPTION
## Issue tracking
Closes #2815 

## Context behind the change
- Modify response dto of oracles discovery to include `chainIdsEnabled`
- Update tests

## How has this been tested?
- Unit tests
- Run locally and verified the response

## Release plan
Frontend should be updated.

## Potential risks; What to monitor; Rollback plan
Node