### PR TITLE
[HUMAN App client] Update oracles discovery schema

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
+++ b/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
@@ -16,7 +16,10 @@ const OracleSuccessSchema = z.object({
   registrationInstructions: z.string().optional().nullable(),
 });
 
-const OraclesSuccessSchema = z.array(OracleSuccessSchema);
+const OraclesSuccessSchema = z.object({
+  oracles: z.array(OracleSuccessSchema),
+  chainIdsEnabled: z.array(z.string()),
+});
 
 export type OracleSuccessResponse = z.infer<typeof OracleSuccessSchema> & {
   name: string;
@@ -70,7 +73,7 @@ export async function getOracles({
     );
 
     oracles = oracles.concat(
-      fetchedOracles.map((oracle) => ({
+      fetchedOracles.oracles.map((oracle) => ({
         ...oracle,
         name: oracleUrlToNameMap.get(oracle.url) ?? '',
       }))


### PR DESCRIPTION
## Issue tracking
Update response schema after #2816 

## Context behind the change
Update response schem to:
```
{
  oracles: [oracle1, oracle2],
  chainIdsEnabled: ['80002', '11155111']
}
```

## How has this been tested?
Run locally and verify this error is fixed 
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/69b9c8a7-3683-4f1b-ac54-36b07da066cc">

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA