### PR TITLE
feat: use auth retry on refresh tasks button

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/worker/refresh-tasks.ts
+++ b/packages/apps/human-app/frontend/src/api/services/worker/refresh-tasks.ts
@@ -7,6 +7,7 @@ function refreshTasks(data: { oracle_address: string }) {
   return apiClient(apiPaths.worker.refreshJob.path, {
     successSchema: z.unknown(),
     authenticated: true,
+    withAuthRetry: true,
     options: { method: 'PUT', body: JSON.stringify(data) },
   });
 }


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Right now if user hits "Refresh Tasks" button and gets 401 - nothing happens. In order to remove confusion we adding auto refresh of auth tokens for that op.

## How has this been tested?
TBD

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
N/A