### PR TITLE
[Reputation Oracle] fix: escrow completion tracking process

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -194,18 +194,19 @@ export class CronJobService {
 
       for (const escrowCompletionTrackingEntity of escrowCompletionTrackingEntities) {
         try {
-          const { chainId, escrowAddress, finalResultsUrl, finalResultsHash } =
-            escrowCompletionTrackingEntity;
-
-          const signer = this.web3Service.getSigner(chainId);
+          const signer = this.web3Service.getSigner(
+            escrowCompletionTrackingEntity.chainId,
+          );
           const escrowClient = await EscrowClient.build(signer);
 
-          const escrowStatus = await escrowClient.getStatus(escrowAddress);
+          const escrowStatus = await escrowClient.getStatus(
+            escrowCompletionTrackingEntity.escrowAddress,
+          );
           if (escrowStatus === EscrowStatus.Pending) {
-            if (!finalResultsUrl) {
+            if (!escrowCompletionTrackingEntity.finalResultsUrl) {
               const { url, hash } = await this.payoutService.saveResults(
-                chainId,
-                escrowAddress,
+                escrowCompletionTrackingEntity.chainId,
+                escrowCompletionTrackingEntity.escrowAddress,
               );
 
               escrowCompletionTrackingEntity.finalResultsUrl = url;
@@ -216,10 +217,10 @@ export class CronJobService {
             }
 
             await this.payoutService.executePayouts(
-              chainId,
-              escrowAddress,
-              finalResultsUrl,
-              finalResultsHash,
+              escrowCompletionTrackingEntity.chainId,
+              escrowCompletionTrackingEntity.escrowAddress,
+              escrowCompletionTrackingEntity.finalResultsUrl,
+              escrowCompletionTrackingEntity.finalResultsHash,
             );
           }
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.spec.ts
@@ -25,7 +25,7 @@ import { WebhookIncomingEntity } from './webhook-incoming.entity';
 import { WebhookOutgoingEntity } from './webhook-outgoing.entity';
 import { IncomingWebhookDto } from './webhook.dto';
 import { ErrorWebhook } from '../../common/constants/errors';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { HEADER_SIGNATURE_KEY } from '../../common/constants';
 import { signMessage } from '../../common/utils/signature';
 import { HttpStatus } from '@nestjs/common';
@@ -283,15 +283,14 @@ describe('WebhookService', () => {
         },
       );
     });
-    it('should return an error if there is no response', async () => {
+    it('throws an error if there request webhook sending fails', async () => {
+      const testError = new Error('non-axios error');
       jest.spyOn(httpService as any, 'post').mockImplementation(() => {
-        return of({});
+        return throwError(() => testError);
       });
       await expect(
         webhookService.sendWebhook(MOCK_WEBHOOK_URL, payload),
-      ).rejects.toThrow(
-        new ControlledError(ErrorWebhook.NotSent, HttpStatus.BAD_REQUEST),
-      );
+      ).rejects.toThrow(testError);
     });
   });
 });

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.service.ts
@@ -147,14 +147,10 @@ export class WebhookService {
       snake_case_body,
       this.web3ConfigService.privateKey,
     );
-    const { status } = await firstValueFrom(
+    await firstValueFrom(
       await this.httpService.post(url, snake_case_body, {
         headers: { [HEADER_SIGNATURE_KEY]: signedBody },
       }),
     );
-
-    if (status !== HttpStatus.CREATED) {
-      throw new ControlledError(ErrorWebhook.NotSent, HttpStatus.NOT_FOUND);
-    }
   }
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
1. When there is no `finalResultsUrl` in `escrowCompletionTrackingEntity`, we get it, update the entity, but in the code we still use destructured value, hence no proper value passed to `executePayouts`. Fixing this and adding a test on it
2. If webhook receiver returns code other than `201` - we considered it as error, but we need any 2xx, so changing the behavior to throw native Axios error

## How has this been tested?
- [x] unit tests

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
N/A