### PR TITLE
[Human App] feat: replace tutorial link with button

### DIFF
--- a/packages/apps/human-app/frontend/src/i18n/en.json
+++ b/packages/apps/human-app/frontend/src/i18n/en.json
@@ -218,7 +218,8 @@
       "allJobs": "All tasks"
     },
     "registrationInExchangeOracle": {
-      "requiredMessage": "This oracle requires a registration process. Click on the link below to see the registration tutorial:",
+      "requiredMessage": "This oracle requires a registration process. Click on the button below to see the registration tutorial:",
+      "instructionsButton": "See registration tutorial",
       "completeMessage": "Click on Complete once you have finished the registration process:",
       "completeButton": "Complete"
     },

--- a/packages/apps/human-app/frontend/src/pages/worker/registration/registration.page.tsx
+++ b/packages/apps/human-app/frontend/src/pages/worker/registration/registration.page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Box, Grid, Link, Paper, Stack } from '@mui/material';
+import { Box, Grid, Paper, Stack } from '@mui/material';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -43,7 +43,8 @@ export function RegistrationPage() {
     error: registrationInExchangeOracleError,
   } = useExchangeOracleRegistrationMutation();
 
-  const handleLinkClick = () => {
+  const handleInstructionsLinkClick = () => {
+    window.open(oracleData?.registrationInstructions ?? '', '_blank');
     setHasClickedRegistrationLink(true);
   };
 
@@ -104,15 +105,13 @@ export function RegistrationPage() {
             <Box>
               {t('worker.registrationInExchangeOracle.requiredMessage')}
             </Box>
-            <Link
-              href={oracleData?.registrationInstructions ?? ''}
-              onClick={handleLinkClick}
-              rel="noopener"
-              sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}
-              target="_blank"
+            <Button
+              onClick={handleInstructionsLinkClick}
+              fullWidth
+              variant="contained"
             >
-              {oracleData?.registrationInstructions}
-            </Link>
+              {t('worker.registrationInExchangeOracle.instructionsButton')}
+            </Button>
             <Box>
               {t('worker.registrationInExchangeOracle.completeMessage')}
             </Box>


### PR DESCRIPTION
## Issue tracking
Closes #2823 

## Context behind the change
We can handle middle-click with `onAuxClick` handler, but user is still able to click on right button and choose "open in new tab", so in order to avoid some other potential edge cases we simply change the link to button.

## How has this been tested?
- [x] Locally: click on "Check instructions" button, ensure that instructions opened in new tab and "Complete" button becomes enabled only after the click

<img width="675" alt="Screenshot 2024-11-20 at 17 07 15" src="https://github.com/user-attachments/assets/62bf6bd0-aae3-409d-9171-457942b41211">

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
N/A