### PR TITLE
[Human App] fix: invalid imports of auth schema

### DIFF
--- a/packages/apps/human-app/frontend/src/auth-web3/web3-auth-context.tsx
+++ b/packages/apps/human-app/frontend/src/auth-web3/web3-auth-context.tsx
@@ -3,7 +3,7 @@ import { useState, createContext, useEffect } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { z } from 'zod';
 import { useQueryClient } from '@tanstack/react-query';
-import type { SignInSuccessResponse } from '@/api/services/worker/sign-in/sign-in';
+import type { SignInSuccessResponse } from '@/api/services/worker/sign-in/types';
 import { browserAuthProvider } from '@/shared/helpers/browser-auth-provider';
 import { useModalStore } from '@/components/ui/modal/modal.store';
 

--- a/packages/apps/human-app/frontend/src/auth/auth-context.tsx
+++ b/packages/apps/human-app/frontend/src/auth/auth-context.tsx
@@ -3,7 +3,7 @@ import { useState, createContext, useEffect } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { z } from 'zod';
 import { useQueryClient } from '@tanstack/react-query';
-import type { SignInSuccessResponse } from '@/api/services/worker/sign-in/sign-in';
+import type { SignInSuccessResponse } from '@/api/services/worker/sign-in/types';
 import { browserAuthProvider } from '@/shared/helpers/browser-auth-provider';
 import { useModalStore } from '@/components/ui/modal/modal.store';
 

--- a/packages/apps/human-app/frontend/src/shared/types/browser-auth-provider.ts
+++ b/packages/apps/human-app/frontend/src/shared/types/browser-auth-provider.ts
@@ -1,4 +1,4 @@
-import type { SignInSuccessResponse } from '@/api/services/worker/sign-in/sign-in';
+import type { SignInSuccessResponse } from '@/api/services/worker/sign-in/types';
 import type { Web3UserData } from '@/auth-web3/web3-auth-context';
 import type { UserData } from '@/auth/auth-context';
 


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Failing to deploy ([ref](https://vercel.com/humanprotocol/human-app/8eNQxHXRSEcXrgBWeg3EpM6W4RSW?filter=errors)) after merging https://github.com/humanprotocol/human-protocol/pull/2824. By some reason linter didn't catch invalid imports (neither did `yarn dev`)

## How has this been tested?
- [x] run `yarn build` for human-app frontend and ensure it's successful

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
Monitor that deployment is successful after merge