### PR TITLE
[Job Launcher] Implemented image polygons job type

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -239,6 +239,9 @@ export const CvatJobRequestForm = () => {
                     onBlur={handleBlur}
                   >
                     <MenuItem value={CvatJobType.IMAGE_POINTS}>Points</MenuItem>
+                    <MenuItem value={CvatJobType.IMAGE_POLYGONS}>
+                      Polygons
+                    </MenuItem>
                     <MenuItem value={CvatJobType.IMAGE_BOXES}>
                       Bounding Boxes
                     </MenuItem>

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -77,6 +77,7 @@ export enum JobType {
 
 export enum CvatJobType {
   IMAGE_POINTS = 'image_points',
+  IMAGE_POLYGONS = 'image_polygons',
   IMAGE_BOXES = 'image_boxes',
   IMAGE_BOXES_FROM_POINTS = 'image_boxes_from_points',
   IMAGE_SKELETONS_FROM_BOXES = 'image_skeletons_from_boxes',

--- a/packages/apps/job-launcher/client/src/utils/api.ts
+++ b/packages/apps/job-launcher/client/src/utils/api.ts
@@ -55,6 +55,7 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   (error) => {
+    console.log(21312321312);
     const originalRequest = error.config;
     if (error.response.status === 401 && !originalRequest._retry) {
       if (isRefreshing) {

--- a/packages/apps/job-launcher/client/src/utils/api.ts
+++ b/packages/apps/job-launcher/client/src/utils/api.ts
@@ -55,7 +55,6 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   (error) => {
-    console.log(21312321312);
     const originalRequest = error.config;
     if (error.response.status === 401 && !originalRequest._retry) {
       if (isRefreshing) {

--- a/packages/apps/job-launcher/server/src/common/constants/index.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/index.ts
@@ -33,6 +33,7 @@ export const SENDGRID_API_KEY_DISABLED = 'sendgrid-disabled';
 export const HEADER_SIGNATURE_KEY = 'human-signature';
 
 export const CVAT_JOB_TYPES = [
+  JobRequestType.IMAGE_POLYGONS,
   JobRequestType.IMAGE_BOXES,
   JobRequestType.IMAGE_POINTS,
   JobRequestType.IMAGE_BOXES_FROM_POINTS,

--- a/packages/apps/job-launcher/server/src/common/enums/job.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/job.ts
@@ -27,6 +27,7 @@ export enum JobSortField {
 
 export enum JobRequestType {
   IMAGE_POINTS = 'image_points',
+  IMAGE_POLYGONS = 'image_polygons',
   IMAGE_BOXES = 'image_boxes',
   IMAGE_BOXES_FROM_POINTS = 'image_boxes_from_points',
   IMAGE_SKELETONS_FROM_BOXES = 'image_skeletons_from_boxes',

--- a/packages/apps/job-launcher/server/src/common/utils/index.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/index.ts
@@ -121,6 +121,8 @@ export const mapJobType = (requestType: JobRequestType): string => {
   switch (requestType) {
     case JobRequestType.IMAGE_POINTS:
       return 'Points';
+    case JobRequestType.IMAGE_POLYGONS:
+      return 'Polygons';
     case JobRequestType.IMAGE_BOXES:
       return 'Bounding Boxes';
     case JobRequestType.IMAGE_BOXES_FROM_POINTS:

--- a/packages/apps/job-launcher/server/src/common/utils/storage.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/storage.ts
@@ -12,7 +12,8 @@ export function generateBucketUrl(
   jobType: JobRequestType,
 ): URL {
   if (
-    (jobType === JobRequestType.IMAGE_BOXES ||
+    (jobType === JobRequestType.IMAGE_POLYGONS ||
+      jobType === JobRequestType.IMAGE_BOXES ||
       jobType === JobRequestType.IMAGE_POINTS ||
       jobType === JobRequestType.IMAGE_BOXES_FROM_POINTS ||
       jobType === JobRequestType.IMAGE_SKELETONS_FROM_BOXES) &&

--- a/packages/apps/job-launcher/server/src/database/migrations/1732612497937-addJobTypeToJobsRequestTypeEnum.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1732612497937-addJobTypeToJobsRequestTypeEnum.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddJobTypeToJobsRequestTypeEnum1732612497937
+  implements MigrationInterface
+{
+  name = 'AddJobTypeToJobsRequestTypeEnum1732612497937';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."jobs_request_type_enum"
+            RENAME TO "jobs_request_type_enum_old"
+        `);
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."jobs_request_type_enum" AS ENUM(
+                'image_points',
+                'image_polygons',
+                'image_boxes',
+                'image_boxes_from_points',
+                'image_skeletons_from_boxes',
+                'hcaptcha',
+                'fortune'
+            )
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ALTER COLUMN "request_type" TYPE "hmt"."jobs_request_type_enum" USING "request_type"::"text"::"hmt"."jobs_request_type_enum"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."jobs_request_type_enum_old"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."jobs_request_type_enum_old" AS ENUM(
+                'image_points',
+                'image_boxes',
+                'image_boxes_from_points',
+                'image_skeletons_from_boxes',
+                'hcaptcha',
+                'fortune'
+            )
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ALTER COLUMN "request_type" TYPE "hmt"."jobs_request_type_enum_old" USING "request_type"::"text"::"hmt"."jobs_request_type_enum_old"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."jobs_request_type_enum"
+        `);
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."jobs_request_type_enum_old"
+            RENAME TO "jobs_request_type_enum"
+        `);
+  }
+}

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -674,6 +674,53 @@ describe('JobService', () => {
       });
     });
 
+    it('should create a valid CVAT manifest for image polygons job type', async () => {
+      const jobBounty = '100';
+      jest
+        .spyOn(jobService, 'calculateJobBounty')
+        .mockResolvedValueOnce(jobBounty);
+
+      const dto: JobCvatDto = {
+        data: MOCK_CVAT_DATA_DATASET,
+        labels: MOCK_CVAT_LABELS,
+        requesterDescription: MOCK_REQUESTER_DESCRIPTION,
+        userGuide: MOCK_FILE_URL,
+        minQuality: 0.8,
+        groundTruth: MOCK_STORAGE_DATA,
+        type: JobRequestType.IMAGE_POLYGONS,
+        fundAmount: 10,
+        currency: JobCurrency.HMT,
+      };
+
+      const requestType = JobRequestType.IMAGE_POLYGONS;
+      const tokenFundAmount = 100;
+
+      const result = await jobService.createCvatManifest(
+        dto,
+        requestType,
+        tokenFundAmount,
+      );
+
+      expect(result).toEqual({
+        data: {
+          data_url: MOCK_BUCKET_FILE,
+        },
+        annotation: {
+          labels: MOCK_CVAT_LABELS,
+          description: MOCK_REQUESTER_DESCRIPTION,
+          user_guide: MOCK_FILE_URL,
+          type: requestType,
+          job_size: 1,
+        },
+        validation: {
+          min_quality: 0.8,
+          val_size: 2,
+          gt_url: MOCK_BUCKET_FILE,
+        },
+        job_bounty: jobBounty,
+      });
+    });
+
     it('should create a valid CVAT manifest for image boxes from points job type', async () => {
       const jobBounty = '50.0';
 


### PR DESCRIPTION
**## Issue tracking**  
The progress of this issue is being tracked in [Job Launcher][Client/Server] Add a new CVAT job type - IMAGE_POLYGONS
[#2700](https://github.com/humanprotocol/human-protocol/issues/2700).  

**## Context behind the change**  
This PR introduces a new CVAT job type: `IMAGE_POLYGONS`.  

- **Front-End (FE):**  
  The implementation for the `IMAGE_POLYGONS` job type uses the same general and annotation details as the existing `IMAGE_BOXES` job type.  

- **Back-End (BE):**  
The manifest schema for `IMAGE_POLYGONS` follows the same structure as `IMAGE_BOXES` to maintain consistency.  
New migration was added `1732612497937-addJobTypeToJobsRequestTypeEnum.ts`.

**## How has this been tested?**  
The following tests were conducted to validate the changes:  

1. **Unit tests:**  
   - Created unit tests for the new job type to ensure proper schema validation and compatibility.  

2. **Integration tests:**  
   - Tested the creation and management of `IMAGE_POLYGONS` jobs through the UI and APIs.  

**## Release plan**  
- **Pre-release actions:**  
  - Notify relevant teams about the new job type.  
  - Update documentation to reflect the addition of `IMAGE_POLYGONS`.  


**## Potential risks; What to monitor; Rollback plan**  
**Rollback plan:**  
1. If issues are related to the migration:  
   - Roll back the database schema to the previous state using the migration rollback script.  

2. If issues are related to functionality:  
   - Revert the codebase to the previous stable release using Git.  
   - Redeploy the stable version to production.  
