### PR TITLE
[Human App] Fixed ui configuration response dto

### DIFF
--- a/packages/apps/human-app/server/src/integrations/kv-store/kv-store.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/kv-store/kv-store.gateway.ts
@@ -79,9 +79,8 @@ export class KvStoreGateway {
     if (!jobTypes || jobTypes === '') {
       return;
     } else {
-      await this.cacheManager.set(key, jobTypes, {
-        ttl: this.configService.cacheTtlJobTypes,
-      } as any);
+      await this.cacheManager.set(key, jobTypes, this.configService.cacheTtlJobTypes);
+
       return jobTypes;
     }
   }

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.spec.ts
@@ -222,7 +222,8 @@ describe('OracleDiscoveryService', () => {
 
     const result = await oracleDiscoveryService.processOracleDiscovery({});
 
-    const expectedResponse = generateOracleDiscoveryResponseBodyByJobType('job-type-1');
+    const expectedResponse =
+      generateOracleDiscoveryResponseBodyByJobType('job-type-1');
     expect(result).toEqual(expectedResponse);
 
     result.forEach((oracle) => {

--- a/packages/apps/human-app/server/src/modules/ui-configuration/ui-configuration.dto.ts
+++ b/packages/apps/human-app/server/src/modules/ui-configuration/ui-configuration.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class UiConfigResponseDto {
   @ApiProperty({
-    type: [String],
+    type: [Number],
     description: 'Chain ids enabled for the application',
     enum: ChainId,
     enumName: 'ChainId',

--- a/packages/apps/human-app/server/src/modules/ui-configuration/ui-configuration.dto.ts
+++ b/packages/apps/human-app/server/src/modules/ui-configuration/ui-configuration.dto.ts
@@ -3,8 +3,10 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class UiConfigResponseDto {
   @ApiProperty({
-    type: [ChainId],
+    type: [String],
     description: 'Chain ids enabled for the application',
+    enum: ChainId,
+    enumName: 'ChainId',
   })
   chainIdsEnabled: ChainId[];
 }


### PR DESCRIPTION
## Issue tracking
This issue was identified due to a circular dependency error when attempting to document `ChainId` from `@human-protocol/sdk` in the NestJS Swagger schema. The error was triggered by using `ChainId` directly as an array in `@ApiProperty`. 

## Context behind the change
To resolve the circular dependency and make sure Swagger correctly interprets the `ChainId` enum, the following changes were made:
- Updated the `@ApiProperty` decorator for `chainIdsEnabled` in the `UiConfigResponseDto` to properly handle the `ChainId` enum in an array.
- Changed `type: [ChainId]` to `type: [String]` and included `enum: ChainId` for correct enum documentation.
- Ensured that Swagger UI shows the list of possible enum values for `ChainId`.

## How has this been tested?
- `yarn build && yarn start:prod` 
- Verified the Swagger UI to ensure the `ChainId` enum is properly displayed as an array of possible values.
- Ran the application and checked that the Swagger documentation now displays the correct types without throwing any errors.
- Confirmed that other related DTOs are unaffected and work as expected.
