### PR TITLE
[Dashboard] fix: properly filter dashboard stats values

### DIFF
--- a/packages/apps/dashboard/server/docker-compose.yml
+++ b/packages/apps/dashboard/server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: 'dashboard-server'
 
 services:
   redis:

--- a/packages/apps/dashboard/server/src/modules/stats/stats.service.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/stats.service.ts
@@ -352,7 +352,7 @@ export class StatsService implements OnModuleInit {
       }),
     );
 
-    return stats.filter((stat): stat is HcaptchaDailyStats => stat !== null);
+    return stats.filter(Boolean);
   }
 
   public async hCaptchaGeneralStats(): Promise<HcaptchaStats> {
@@ -417,6 +417,6 @@ export class StatsService implements OnModuleInit {
       }),
     );
 
-    return stats.filter((stat): stat is HmtDailyStatsData => stat !== null);
+    return stats.filter(Boolean);
   }
 }

--- a/packages/apps/human-app/server/docker-compose.yml
+++ b/packages/apps/human-app/server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: 'human-app-server'
 
 services:
   human-app:


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When getting values from cache it returns `undefined` when no value is there, so we have to properly check if the stat is missing.

Also updated docker-compose files for human-app and dashboard server:
- removed `version` because it's not necessary anymore
- added `name`, so when you have `redis` started in one of servers already, starting it in another one doesn't kill existing (they run on different ports anyways)

## How has this been tested?
- [x] on local: trigger stats endpoint to check it returns empty array when no data is there
- [x] e2e: check UI is able to display data with missing points

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
N/A