### PR TITLE
feat: add image_polygons to human-app and repo

### DIFF
--- a/packages/apps/human-app/frontend/src/i18n/en.json
+++ b/packages/apps/human-app/frontend/src/i18n/en.json
@@ -405,6 +405,7 @@
     "image_points": "Points",
     "image_boxes": "Bounding Boxes",
     "image_boxes_from_points": "Bounding Boxes from Points",
-    "image_skeletons_from_boxes": "Skeletons from Bounding Boxes"
+    "image_skeletons_from_boxes": "Skeletons from Bounding Boxes",
+    "image_polygons": "Polygons"
   }
 }

--- a/packages/apps/human-app/frontend/src/smart-contracts/EthKVStore/config.ts
+++ b/packages/apps/human-app/frontend/src/smart-contracts/EthKVStore/config.ts
@@ -11,6 +11,7 @@ export enum JobType {
   BoundingBoxes = 'image_boxes',
   BoundingBoxesFromPoints = 'image_boxes_from_points',
   SkeletonsFromBoundingBoxes = 'image_skeletons_from_boxes',
+  Polygons = 'image_polygons',
 }
 
 export const EthKVStoreKeys = {

--- a/packages/apps/reputation-oracle/server/src/common/constants/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/index.ts
@@ -23,6 +23,7 @@ export const CVAT_JOB_TYPES = [
   JobRequestType.IMAGE_POINTS,
   JobRequestType.IMAGE_BOXES_FROM_POINTS,
   JobRequestType.IMAGE_SKELETONS_FROM_BOXES,
+  JobRequestType.IMAGE_POLYGONS,
 ];
 
 export const HEADER_SIGNATURE_KEY = 'human-signature';

--- a/packages/apps/reputation-oracle/server/src/common/enums/job.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/job.ts
@@ -4,6 +4,7 @@ export enum JobRequestType {
   IMAGE_BOXES_FROM_POINTS = 'image_boxes_from_points',
   IMAGE_SKELETONS_FROM_BOXES = 'image_skeletons_from_boxes',
   FORTUNE = 'fortune',
+  IMAGE_POLYGONS = 'image_polygons',
 }
 
 export enum SolutionError {

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.spec.ts
@@ -99,6 +99,10 @@ describe('PayoutService', () => {
         calculatePayouts: jest.fn(),
         saveResults: jest.fn(),
       },
+      [JobRequestType.IMAGE_POLYGONS]: {
+        calculatePayouts: jest.fn(),
+        saveResults: jest.fn(),
+      },
     };
   });
 

--- a/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/payout/payout.service.ts
@@ -189,6 +189,17 @@ export class PayoutService {
         escrowAddress: string,
       ): Promise<SaveResultDto> => this.saveResultsCvat(chainId, escrowAddress),
     },
+    [JobRequestType.IMAGE_POLYGONS]: {
+      calculatePayouts: async (
+        manifest: CvatManifestDto,
+        data: CalculatePayoutsDto,
+      ): Promise<PayoutsDataDto> =>
+        this.calculatePayoutsCvat(manifest, data.chainId, data.escrowAddress),
+      saveResults: async (
+        chainId: ChainId,
+        escrowAddress: string,
+      ): Promise<SaveResultDto> => this.saveResultsCvat(chainId, escrowAddress),
+    },
   };
 
   /**

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -151,6 +151,13 @@ export class ReputationService {
         manifest: CvatManifestDto,
       ): Promise<void> => this.processCvat(chainId, escrowAddress, manifest),
     },
+    [JobRequestType.IMAGE_POLYGONS]: {
+      assessWorkerReputationScores: async (
+        chainId: ChainId,
+        escrowAddress: string,
+        manifest: CvatManifestDto,
+      ): Promise<void> => this.processCvat(chainId, escrowAddress, manifest),
+    },
   };
 
   private async processFortune(


### PR DESCRIPTION
## Issue tracking
Addition to https://github.com/humanprotocol/human-protocol/pull/2845

## Context behind the change
In order to properly support new job type we need to add it to `human-app` and `reputation-oracle`.

For `human-app` it's just about updating few enums that affect:
- how job type is displayed (aka human-readable labels for user)
- adds new job type to list of options for "operator registration" form

For `reputation-oracle` we need to:
- update enums, so types are valid
- update mappings for payouts and reputation calculation

Ideally, would be nice to refactor code in RO to not depend on job type (code is the same for all CVAT types, but different for Fortune), but it would be better to do it in separate PR

## How has this been tested?
- [x] reputation oracle: lint + existing unit tests; make sure that service can run
- [x] check proper UI values displayed on `human-app`

## Release plan
1. Merge. Release together with main PR that adds it to ExO and JL.
2. In order to see proper job types on `human-app` UI - we either need to flush cached oracles to get them with new job types or wait till cache expires (take into account it might take too long)

## Potential risks; What to monitor; Rollback plan
Double-check that `human-app` and `reputation-oracle` run w/o errors after merge