### PR TITLE
fix: change yarn workspaces pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "workspaces": {
     "packages": [
-      "packages/**/*"
+      "packages/**/!(dist)"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Right now in case you have `human-app/server` built and then try to `yarn install` - you will get an error about duplicated `@human-protocol/human-app-server` workspace. It's because `package.json` is included in build and when `yarn` searches for workspaces using existing glob-pattern it finds another one in `dist` folder.

Changing glob pattern to not take `dist` into account.

As an alternative - we can list all workspaces manually, but it might be tedious.

## How has this been tested?
- [x] build `human-app-server`, run `yarn install` from root & ensure it finishes
- [x] build `human-app-server`, run `yarn workspaces info` from project root, it should return all workspaces with `package.json`

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
N/A