### PR TITLE
[SDK] Change python sdk name to be PEP 625 compliance

### DIFF
--- a/docs/sdk/python/human_protocol_sdk.encryption.encryption.md
+++ b/docs/sdk/python/human_protocol_sdk.encryption.encryption.md
@@ -60,7 +60,7 @@ Decrypts a message using the private key.
   * **message** (`str`) – Armored message to decrypt
   * **public_key** (`Optional`[`str`]) – Armored public key used for signature verification. Defaults to None.
 * **Return type:**
-  `str`
+  `bytes`
 * **Returns:**
   Decrypted message
 * **Example:**
@@ -94,7 +94,7 @@ Decrypts a message using the private key.
 Signs a message using the private key.
 
 * **Parameters:**
-  **message** (`str`) – Message to sign
+  **message** (`Union`[`str`, `bytes`]) – Message to sign
 * **Return type:**
   `str`
 * **Returns:**
@@ -130,7 +130,7 @@ Signs a message using the private key.
 Signs and encrypts a message using the private key and recipient’s public keys.
 
 * **Parameters:**
-  * **message** (`str`) – Message to sign and encrypt
+  * **message** (`Union`[`str`, `bytes`]) – Message to sign and encrypt
   * **public_keys** (`List`[`str`]) – List of armored public keys of the recipients
 * **Return type:**
   `str`

--- a/docs/sdk/python/index.md
+++ b/docs/sdk/python/index.md
@@ -10,13 +10,13 @@ contain the root `toctree` directive. -->
 To install the Human Protocol SDK, run the following command:
 
 ```bash
-pip install human-protocol-sdk
+pip install human_protocol_sdk
 ```
 
 In case you want to use the features of the agreement module, make sure to install corresponding extras as well.
 
 ```bash
-pip install human-protocol-sdk[agreement]
+pip install human_protocol_sdk[agreement]
 ```
 
 ## Contents:

--- a/packages/sdk/python/human-protocol-sdk/README.md
+++ b/packages/sdk/python/human-protocol-sdk/README.md
@@ -7,7 +7,7 @@ Python SDK to interact with [Human Protocol](https://www.humanprotocol.org/)
 [Python3](https://www.python.org/) is required.
 
 ```bash
-pip install human-protocol-sdk
+pip install human_protocol_sdk
 ```
 
 ## Getting Started

--- a/packages/sdk/python/human-protocol-sdk/docs/index.rst
+++ b/packages/sdk/python/human-protocol-sdk/docs/index.rst
@@ -13,13 +13,13 @@ To install the Human Protocol SDK, run the following command:
 
 .. code-block:: bash
 
-   pip install human-protocol-sdk
+   pip install human_protocol_sdk
 
 In case you want to use the features of the agreement module, make sure to install corresponding extras as well.
 
 .. code-block:: bash
 
-   pip install human-protocol-sdk[agreement]
+   pip install human_protocol_sdk[agreement]
 
 .. toctree::
    :maxdepth: 4

--- a/packages/sdk/python/human-protocol-sdk/setup.py
+++ b/packages/sdk/python/human-protocol-sdk/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 setuptools.setup(
-    name="human-protocol-sdk",
+    name="human_protocol_sdk",
     version="0.0.0",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",


### PR DESCRIPTION
## Issue tracking
Closes #2857 

## Context behind the change
Change python sdk name to be PEP 625 compliance

## How has this been tested?
Cannot be tested until deployment is triggered.

## Release plan
- Trigger release
- Check if sdk with old name is linked to the new released version: https://pypi.org/project/human-protocol-sdk/

## Potential risks; What to monitor; Rollback plan
- Pypi might consider them as different packages.