### PR TITLE
[Human App] Added oracles filter

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
+++ b/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
@@ -68,12 +68,20 @@ export async function getOracles({
       signal
     );
 
-    oracles = oracles.concat(
-      results.map((oracle) => ({
-        ...oracle,
-        name: oracleUrlToNameMap.get(oracle.url) ?? '',
-      }))
-    );
+    // Add new results and filter duplicates based on `url` and `address`
+    const uniqueOraclesMap = new Map<string, Oracle>();
+
+    results.forEach((oracle) => {
+      const key = `${oracle.url}-${oracle.address}`;
+      if (!uniqueOraclesMap.has(key)) {
+        uniqueOraclesMap.set(key, {
+          ...oracle,
+          name: oracleUrlToNameMap.get(oracle.url) ?? '',
+        });
+      }
+    });
+
+    oracles = oracles.concat(Array.from(uniqueOraclesMap.values()));
   }
   return oracles;
 }


### PR DESCRIPTION
## Issue tracking  
The progress of this issue is being tracked via internal bug reports related to duplicate oracles being displayed in the frontend when fetching data from the backend. [HUMAN App] Duplicate oracle entries when Amoy and Sepolia networks are enabled
[#2804](https://github.com/humanprotocol/human-protocol/issues/2804)

## Context behind the change  
### Goal of the change:  
The goal of this pull request is to filter and display only unique oracles in the frontend based on a combination of their `url` and `address`. This prevents duplicate oracles from being rendered when the backend provides multiple entries with the same `url` and `address` but different `chainId` values.

### Code changes:  
1. **Introduction of a `Map` to filter unique oracles:**
   - A `Map` object is used to filter out duplicate oracles from the response based on a unique key combining `url` and `address`.
   - This ensures that only one oracle is displayed even if multiple entries with the same `url` and `address` are present in the response.

2. **Key generation logic:**
   - A unique key is generated for each oracle using the following pattern:  
     `const key = `${oracle.url}-${oracle.address}`;`
   - If the key already exists in the `Map`, the duplicate entry is ignored.

3. **Updated `getOracles` function:**  
   - The oracles are fetched from the backend and processed through the `Map` to ensure only unique entries are retained.  

## How has this been tested?  
### Steps taken:
**Manual testing:**
   - Loaded the application in a local development environment and verified that only unique oracles are displayed.
   - Tested different scenarios where:
     - Oracles with the same `url` but different `chainId` are returned.
     - Oracles with unique `url` and `address` combinations are returned.