### PR TITLE
fix: base url for refreshToken fn

### DIFF
--- a/packages/apps/human-app/frontend/src/api/fetcher.ts
+++ b/packages/apps/human-app/frontend/src/api/fetcher.ts
@@ -4,6 +4,7 @@ import type { ResponseError } from '@/shared/types/global.type';
 import { browserAuthProvider } from '@/shared/helpers/browser-auth-provider';
 import { env } from '@/shared/env';
 import { type SignInSuccessResponse } from '@/api/services/worker/sign-in/types';
+import { normalizeBaseUrl } from '@/shared/helpers/normalize-base-url';
 import { fetchTokenRefresh } from './fetch-refresh-token';
 
 const appendHeader = (
@@ -72,7 +73,7 @@ export async function refreshToken(): Promise<{
   refresh_token: string;
 } | null> {
   if (!refreshPromise) {
-    refreshPromise = fetchTokenRefresh(env.VITE_API_URL);
+    refreshPromise = fetchTokenRefresh(normalizeBaseUrl(env.VITE_API_URL));
   }
 
   const result = await refreshPromise;
@@ -159,7 +160,7 @@ export function createFetcher(defaultFetcherConfig?: {
       const urlAsString = fetchUrlToString(baseUrl);
       if (!urlAsString) return url;
       const normalizedUrl = fetchUrlToString(url).replace(/\//, '');
-      const normalizedBaseUrl = urlAsString.replace(/\/$/, '');
+      const normalizedBaseUrl = normalizeBaseUrl(urlAsString);
 
       return `${normalizedBaseUrl}/${normalizedUrl}`;
     })();

--- a/packages/apps/human-app/frontend/src/shared/helpers/normalize-base-url.ts
+++ b/packages/apps/human-app/frontend/src/shared/helpers/normalize-base-url.ts
@@ -1,0 +1,3 @@
+export function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, '');
+}


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Regression appeared after https://github.com/humanprotocol/human-protocol/pull/2824.
Right now on STG we have base url as `https://app.url/` (with slash at the end), and it's not considered when constructing url for `refreshToken`, hence request fails with 404. Adding common normalization logic to remove that slash symbol.

> [!NOTE] 
I haven't fully refactored it to normalize in `env` or in some centralized place because event though we you create `apiClient` to communicate with BE, `baseUrl` can be overloaded by a specific fetcher call, e.g. [here](https://github.com/humanprotocol/human-protocol/blob/f20d30d75d129f5765824ac1ed0263697bd3d5b3/packages/apps/human-app/frontend/src/api/services/operator/get-stats.ts#L40), so it would cause a big refactoring of `apiClient`, not intended for now.

## How has this been tested?
- [x] on local: set `VITE_API_URL=http://localhost:3000/`, imitate `refreshToken` call on page load, make sure request doesn't fail

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
N/A