### PR TITLE
[Dashboard] Added config controller

### DIFF
--- a/packages/apps/dashboard/server/src/common/config/config.controller.ts
+++ b/packages/apps/dashboard/server/src/common/config/config.controller.ts
@@ -1,0 +1,26 @@
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, HttpCode } from '@nestjs/common';
+
+import { ChainId } from '@human-protocol/sdk';
+import { NetworkConfigService } from '../../common/config/network-config.service';
+
+@ApiTags('Config')
+@Controller('/config')
+export class ConfigController {
+  constructor(private readonly networkConfigService: NetworkConfigService) {}
+
+  @Get('/available-networks')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get available networks with recent usage',
+    description: 'Endpoint to return networks filtered by recent activity.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Networks retrieved successfully',
+    type: Array<ChainId>,
+  })
+  public async getAvailableNetworks(): Promise<ChainId[]> {
+    return this.networkConfigService.getAvailableNetworks();
+  }
+}

--- a/packages/apps/dashboard/server/src/common/config/config.module.ts
+++ b/packages/apps/dashboard/server/src/common/config/config.module.ts
@@ -3,6 +3,7 @@ import { EnvironmentConfigService } from './env-config.service';
 import { RedisConfigService } from './redis-config.service';
 import { NetworkConfigService } from './network-config.service';
 import { S3ConfigService } from './s3-config.service';
+import { ConfigController } from './config.controller';
 
 @Global()
 @Module({
@@ -12,6 +13,7 @@ import { S3ConfigService } from './s3-config.service';
     NetworkConfigService,
     S3ConfigService,
   ],
+  controllers: [ConfigController],
   exports: [
     RedisConfigService,
     EnvironmentConfigService,

--- a/packages/apps/dashboard/server/src/modules/stats/stats.controller.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/stats.controller.ts
@@ -10,16 +10,11 @@ import {
 import { HmtDailyStatsResponseDto } from './dto/hmt.dto';
 import { DateValidationPipe } from '../../common/pipes/date-validation.pipe';
 import { HmtGeneralStatsDto } from './dto/hmt-general-stats.dto';
-import { ChainId } from '@human-protocol/sdk';
-import { NetworkConfigService } from '../../common/config/network-config.service';
 
 @ApiTags('Stats')
 @Controller('/stats')
 export class StatsController {
-  constructor(
-    private readonly statsService: StatsService,
-    private readonly networkConfigService: NetworkConfigService,
-  ) {}
+  constructor(private readonly statsService: StatsService) {}
 
   @Get('/hmt-price')
   @HttpCode(200)
@@ -131,20 +126,5 @@ export class StatsController {
   ): Promise<HmtDailyStatsResponseDto> {
     const results = await this.statsService.hmtDailyStats(from, to);
     return { from, to, results };
-  }
-
-  @Get('/available-networks')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get available networks with recent usage',
-    description: 'Endpoint to return networks filtered by recent activity.',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Networks retrieved successfully',
-    type: Array<ChainId>,
-  })
-  public async getAvailableNetworks(): Promise<ChainId[]> {
-    return this.networkConfigService.getAvailableNetworks();
   }
 }


### PR DESCRIPTION
## Issue tracking  
The request for this change originated from a need to restructure configuration paths. This issue is tracked in [Dashboard server] Move /stats/networks-available to /config/networks-available
[#2851](https://github.com/humanprotocol/human-protocol/issues/2851).

## Context behind the change  
The `/stats/available-networks` endpoint has been moved to `/config/available-networks` to better reflect its purpose as part of the configuration layer rather than statistical data.  

### Changes made:  
- Updated the routing logic to point to `/config/available-networks`.  
- Modified any references to the old endpoint in the following files:  
  - `dashboard/server/src/modules/stats` ➡️ `dashboard/server/src/common/config`  
  - Added new controller `dashboard/server/src/common/config/config.controller.ts``

## How has this been tested?  
- **Manual Testing**:  
  Manually tested the application via the browser (Swagger)  and API tools (Postman) to confirm:  
  - `GET /config/available-networks`

## Release Plan  
### Pre-release:  
- Communicate endpoint change to relevant teams (frontend, API consumers).  
- Update internal and external API documentation.  