### PR TITLE
[Dashboard Server] Fixed roles values

### DIFF
--- a/packages/apps/dashboard/server/src/common/enums/roles.ts
+++ b/packages/apps/dashboard/server/src/common/enums/roles.ts
@@ -1,0 +1,6 @@
+export enum OracleRole {
+  JOB_LAUNCHER = 'job_launcher',
+  EXCHANGE_ORACLE = 'exchange_oracle',
+  RECORDING_ORACLE = 'recording_oracle',
+  REPUTATION_ORACLE = 'reputation_oracle',
+}

--- a/packages/apps/dashboard/server/src/modules/details/details.service.ts
+++ b/packages/apps/dashboard/server/src/modules/details/details.service.ts
@@ -20,6 +20,7 @@ import { firstValueFrom } from 'rxjs';
 import { HMToken__factory } from '@human-protocol/core/typechain-types';
 import { ethers } from 'ethers';
 import { NetworkConfigService } from '../../common/config/network-config.service';
+import { OracleRole } from '../../common/enums/roles';
 
 @Injectable()
 export class DetailsService {
@@ -243,10 +244,10 @@ export class DetailsService {
             params: {
               chain_id: ChainId.POLYGON,
               roles: [
-                'JOB_LAUNCHER',
-                'EXCHANGE_ORACLE',
-                'RECORDING_ORACLE',
-                'REPUTATION_ORACLE',
+                OracleRole.JOB_LAUNCHER,
+                OracleRole.EXCHANGE_ORACLE,
+                OracleRole.RECORDING_ORACLE,
+                OracleRole.REPUTATION_ORACLE,
               ],
             },
           },
@@ -254,6 +255,7 @@ export class DetailsService {
       );
       return response.data;
     } catch (error) {
+      console.log(error);
       this.logger.error('Error fetching reputations:', error);
       return [];
     }

--- a/packages/apps/dashboard/server/src/modules/details/details.service.ts
+++ b/packages/apps/dashboard/server/src/modules/details/details.service.ts
@@ -255,7 +255,6 @@ export class DetailsService {
       );
       return response.data;
     } catch (error) {
-      console.log(error);
       this.logger.error('Error fetching reputations:', error);
       return [];
     }


### PR DESCRIPTION
## Issue tracking  
[Dashboard server] Error fetching reputations
[#2848](https://github.com/humanprotocol/human-protocol/issues/2848)

## Context behind the change  
The Reputation Oracle server returned errors when validating role values because they were provided in uppercase (`JOB_LAUNCHER`, etc.), while the server expected them in lowercase (`job_launcher`, etc.).  

To address this, was implemented an `OracleRole` enum that standardizes the role values to lowercase, ensuring compatibility with the Reputation Oracle server and preventing further validation errors.

Changes made:  
- Created a new `OracleRole` enum to enforce consistent lowercase role values.
- Updated relevant code sections where role values are assigned or validated to use the `OracleRole` enum.

## How has this been tested?  
1. **Manual Testing**  
   - Simulated different role assignments and confirmed that the server no longer returns validation errors.
