### PR TITLE
[Human App] feat: filter out oracle jobs as per enabled chain id

### DIFF
--- a/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
+++ b/packages/apps/human-app/frontend/src/api/services/worker/oracles.ts
@@ -53,7 +53,16 @@ export async function getOracles({
   selected_job_types: string[];
   signal: AbortSignal;
 }) {
-  let oracles = [H_CAPTCHA_ORACLE];
+  let oracles: Oracle[] = [];
+  if (
+    selected_job_types.length === 0 ||
+    selected_job_types.some((selected_job_type) =>
+      H_CAPTCHA_ORACLE.jobTypes.includes(selected_job_type)
+    )
+  ) {
+    oracles.push(H_CAPTCHA_ORACLE);
+  }
+
   if (env.VITE_FEATURE_FLAG_JOBS_DISCOVERY) {
     const queryParams = selected_job_types.length
       ? `?${stringifyUrlQueryObject({ selected_job_types })}`
@@ -75,6 +84,7 @@ export async function getOracles({
       }))
     );
   }
+
   return oracles;
 }
 

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.module.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.module.ts
@@ -4,12 +4,14 @@ import { ExchangeOracleModule } from '../../integrations/exchange-oracle/exchang
 import { CronJobService } from './cron-job.service';
 import { OracleDiscoveryModule } from '../oracle-discovery/oracle-discovery.module';
 import { WorkerModule } from '../user-worker/worker.module';
+import { JobsDiscoveryModule } from '../jobs-discovery/jobs-discovery.module';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
     ExchangeOracleModule,
     OracleDiscoveryModule,
+    JobsDiscoveryModule,
     WorkerModule,
   ],
   providers: [CronJobService],

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -13,7 +13,7 @@ import { JOB_DISCOVERY_CACHE_KEY } from '../../common/constants/cache';
 import { OracleDiscoveryService } from '../oracle-discovery/oracle-discovery.service';
 import {
   OracleDiscoveryCommand,
-  OracleDiscoveryResult,
+  OracleDiscovered,
 } from '../oracle-discovery/model/oracle-discovery.model';
 import { WorkerService } from '../user-worker/worker.service';
 import { JobDiscoveryFieldName } from '../../common/enums/global-common';
@@ -84,7 +84,7 @@ export class CronJobService {
     this.logger.log('CRON END');
   }
 
-  async updateJobsListCache(oracle: OracleDiscoveryResult, token: string) {
+  async updateJobsListCache(oracle: OracleDiscovered, token: string) {
     try {
       let allResults: JobsDiscoveryResponseItem[] = [];
 
@@ -136,14 +136,14 @@ export class CronJobService {
   }
 
   private async updateOracleInCache(
-    oracleData: OracleDiscoveryResult,
-    updates: Partial<OracleDiscoveryResult>,
+    oracleData: OracleDiscovered,
+    updates: Partial<OracleDiscovered>,
   ) {
     const updatedOracle = { ...oracleData, ...updates };
 
     const chainId = oracleData.chainId?.toString();
     const cachedOracles =
-      await this.cacheManager.get<OracleDiscoveryResult[]>(chainId);
+      await this.cacheManager.get<OracleDiscovered[]>(chainId);
 
     if (cachedOracles) {
       const updatedOracles = cachedOracles.map((oracle) =>
@@ -157,7 +157,7 @@ export class CronJobService {
     }
   }
 
-  private async handleJobListError(oracleData: OracleDiscoveryResult) {
+  private async handleJobListError(oracleData: OracleDiscovered) {
     const retriesCount = oracleData.retriesCount || 0;
     const newExecutionsToSkip = Math.min(
       (oracleData.executionsToSkip || 0) + Math.pow(2, retriesCount),

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -1,6 +1,4 @@
-import { Injectable, Inject, Logger } from '@nestjs/common';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Cache } from 'cache-manager';
+import { Injectable, Logger } from '@nestjs/common';
 import { CronJob } from 'cron';
 import { ExchangeOracleGateway } from '../../integrations/exchange-oracle/exchange-oracle.gateway';
 import {
@@ -9,24 +7,21 @@ import {
   JobsDiscoveryResponseItem,
 } from '../jobs-discovery/model/jobs-discovery.model';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
-import { JOB_DISCOVERY_CACHE_KEY } from '../../common/constants/cache';
 import { OracleDiscoveryService } from '../oracle-discovery/oracle-discovery.service';
-import {
-  OracleDiscoveryCommand,
-  OracleDiscovered,
-} from '../oracle-discovery/model/oracle-discovery.model';
+import { DiscoveredOracle } from '../oracle-discovery/model/oracle-discovery.model';
 import { WorkerService } from '../user-worker/worker.service';
 import { JobDiscoveryFieldName } from '../../common/enums/global-common';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { JobsDiscoveryService } from '../jobs-discovery/jobs-discovery.service';
 
 @Injectable()
 export class CronJobService {
   private readonly logger = new Logger(CronJobService.name);
   constructor(
     private readonly exchangeOracleGateway: ExchangeOracleGateway,
-    @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private configService: EnvironmentConfigService,
     private oracleDiscoveryService: OracleDiscoveryService,
+    private jobsDiscoveryService: JobsDiscoveryService,
     private workerService: WorkerService,
     private schedulerRegistry: SchedulerRegistry,
   ) {
@@ -47,12 +42,11 @@ export class CronJobService {
   async updateJobsListCron() {
     this.logger.log('CRON START');
 
-    const oracleDiscoveryCommand: OracleDiscoveryCommand = {};
-    const oracles = await this.oracleDiscoveryService.processOracleDiscovery(
-      oracleDiscoveryCommand,
-    );
+    const oracles = await this.oracleDiscoveryService.discoverOracles();
 
-    if (!oracles || oracles.length < 1) return;
+    if (oracles.length === 0) {
+      return;
+    }
 
     try {
       const response = await this.workerService.signinWorker({
@@ -66,7 +60,8 @@ export class CronJobService {
             `Skipping execution for oracle: ${oracle.address}. Remaining skips: ${oracle.executionsToSkip}`,
           );
 
-          await this.updateOracleInCache(oracle, {
+          await this.oracleDiscoveryService.updateOracleInCache({
+            ...oracle,
             executionsToSkip: oracle.executionsToSkip - 1,
           });
           continue;
@@ -84,7 +79,7 @@ export class CronJobService {
     this.logger.log('CRON END');
   }
 
-  async updateJobsListCache(oracle: OracleDiscovered, token: string) {
+  async updateJobsListCache(oracle: DiscoveredOracle, token: string) {
     try {
       let allResults: JobsDiscoveryResponseItem[] = [];
 
@@ -120,51 +115,28 @@ export class CronJobService {
         allResults = this.mergeJobs(allResults, response.results);
       }
 
-      await this.updateOracleInCache(oracle, {
+      await this.oracleDiscoveryService.updateOracleInCache({
+        ...oracle,
         retriesCount: 0,
         executionsToSkip: 0,
       });
 
-      await this.cacheManager.set(
-        `${JOB_DISCOVERY_CACHE_KEY}:${oracle.address}`,
-        allResults,
-      );
+      await this.jobsDiscoveryService.setCachedJobs(oracle.address, allResults);
     } catch (e) {
       this.logger.error(e);
       await this.handleJobListError(oracle);
     }
   }
 
-  private async updateOracleInCache(
-    oracleData: OracleDiscovered,
-    updates: Partial<OracleDiscovered>,
-  ) {
-    const updatedOracle = { ...oracleData, ...updates };
-
-    const chainId = oracleData.chainId?.toString();
-    const cachedOracles =
-      await this.cacheManager.get<OracleDiscovered[]>(chainId);
-
-    if (cachedOracles) {
-      const updatedOracles = cachedOracles.map((oracle) =>
-        oracle.address === oracleData.address ? updatedOracle : oracle,
-      );
-      await this.cacheManager.set(
-        chainId,
-        updatedOracles,
-        this.configService.cacheTtlOracleDiscovery,
-      );
-    }
-  }
-
-  private async handleJobListError(oracleData: OracleDiscovered) {
+  private async handleJobListError(oracleData: DiscoveredOracle) {
     const retriesCount = oracleData.retriesCount || 0;
     const newExecutionsToSkip = Math.min(
       (oracleData.executionsToSkip || 0) + Math.pow(2, retriesCount),
       this.configService.maxExecutionToSkip,
     );
 
-    await this.updateOracleInCache(oracleData, {
+    await this.oracleDiscoveryService.updateOracleInCache({
+      ...oracleData,
       retriesCount: retriesCount + 1,
       executionsToSkip: newExecutionsToSkip,
     });

--- a/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/spec/cron-job.service.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../modules/jobs-discovery/model/jobs-discovery.model';
 import { JOB_DISCOVERY_CACHE_KEY } from '../../../common/constants/cache';
 import { JobStatus } from '../../../common/enums/global-common';
-import { OracleDiscoveryResult } from '../../../modules/oracle-discovery/model/oracle-discovery.model';
+import { OracleDiscovered } from '../../../modules/oracle-discovery/model/oracle-discovery.model';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { generateOracleDiscoveryResponseBody } from '../../../modules/oracle-discovery/spec/oracle-discovery.fixture';
 import { ChainId } from '@human-protocol/sdk';
@@ -166,7 +166,7 @@ describe('CronJobService', () => {
 
   describe('updateJobsListCache', () => {
     it('should fetch all jobs and update the cache', async () => {
-      const oracle: OracleDiscoveryResult = {
+      const oracle: OracleDiscovered = {
         address: 'mockAddress1',
         role: 'validator',
         chainId: ChainId.POLYGON,
@@ -194,7 +194,7 @@ describe('CronJobService', () => {
     });
 
     it('should handle errors and call handleJobListError', async () => {
-      const oracle: OracleDiscoveryResult = {
+      const oracle: OracleDiscovered = {
         address: 'mockAddress1',
         role: 'validator',
         chainId: ChainId.POLYGON,
@@ -220,7 +220,7 @@ describe('CronJobService', () => {
     });
 
     it('should reset retries count after successful job fetch', async () => {
-      const oracle: OracleDiscoveryResult = {
+      const oracle: OracleDiscovered = {
         address: 'mockAddress1',
         role: 'validator',
         chainId: ChainId.POLYGON,
@@ -320,7 +320,7 @@ describe('CronJobService', () => {
 
   describe('updateOracleInCache', () => {
     it('should update oracle in cache', async () => {
-      const oracleData: OracleDiscoveryResult = {
+      const oracleData: OracleDiscovered = {
         address: 'mockAddress1',
         role: 'validator',
         chainId: ChainId.POLYGON,
@@ -345,7 +345,7 @@ describe('CronJobService', () => {
 
   describe('handleJobListError', () => {
     it('should increment retries count and executions to skip but not exceed the limit', async () => {
-      const oracleData: OracleDiscoveryResult = {
+      const oracleData: OracleDiscovered = {
         address: 'mockAddress1',
         role: 'validator',
 
@@ -366,7 +366,7 @@ describe('CronJobService', () => {
     });
 
     it('should increment retries count and executions to skip', async () => {
-      const oracleData: OracleDiscoveryResult = {
+      const oracleData: OracleDiscovered = {
         address: 'mockAddress1',
         role: 'validator',
         chainId: ChainId.POLYGON,

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
@@ -81,13 +81,27 @@ export class JobsDiscoveryService {
       });
   }
 
+  static makeCacheKeyForOracle(oracleAddress: string): string {
+    return `${JOB_DISCOVERY_CACHE_KEY}:${oracleAddress}`;
+  }
+
   async getCachedJobs(
     oracleAddress: string,
   ): Promise<JobsDiscoveryResponseItem[]> {
-    return (
-      (await this.cacheManager.get<JobsDiscoveryResponseItem[]>(
-        `${JOB_DISCOVERY_CACHE_KEY}:${oracleAddress}`,
-      )) || []
-    );
+    const cacheKey = JobsDiscoveryService.makeCacheKeyForOracle(oracleAddress);
+
+    const cachedJobs = await this.cacheManager.get<
+      JobsDiscoveryResponseItem[] | undefined
+    >(cacheKey);
+
+    return cachedJobs || [];
+  }
+
+  async setCachedJobs(
+    oracleAddress: string,
+    jobs: JobsDiscoveryResponseItem[],
+  ): Promise<void> {
+    const cacheKey = JobsDiscoveryService.makeCacheKeyForOracle(oracleAddress);
+    await this.cacheManager.set(cacheKey, jobs);
   }
 }

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
@@ -7,18 +7,25 @@ import {
 } from './model/jobs-discovery.model';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 import { JOB_DISCOVERY_CACHE_KEY } from '../../common/constants/cache';
 import { JobDiscoveryFieldName } from '../../common/enums/global-common';
 
 @Injectable()
 export class JobsDiscoveryService {
-  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+  constructor(
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private configService: EnvironmentConfigService,
+  ) {}
 
   async processJobsDiscovery(
     command: JobsDiscoveryParamsCommand,
   ): Promise<JobsDiscoveryResponse> {
     const allJobs = await this.getCachedJobs(command.oracleAddress);
-    const filteredJobs = this.applyFilters(allJobs || [], command.data);
+    let filteredJobs = this.applyFilters(allJobs, command.data);
+    filteredJobs = filteredJobs.filter((job) =>
+      this.configService.chainIdsEnabled.includes(job.chain_id),
+    );
 
     return paginateAndSortResults(
       filteredJobs,

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.service.spec.ts
@@ -1,3 +1,5 @@
+import { ChainId } from '@human-protocol/sdk';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { JobsDiscoveryService } from '../jobs-discovery.service';
 import { ExchangeOracleGateway } from '../../../integrations/exchange-oracle/exchange-oracle.gateway';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -7,6 +9,7 @@ import {
   responseItemFixture1,
   responseItemFixture3,
 } from './jobs-discovery.fixtures';
+import { EnvironmentConfigService } from '../../../common/config/environment-config.service';
 
 describe('JobsDiscoveryService', () => {
   let service: JobsDiscoveryService;
@@ -27,6 +30,13 @@ describe('JobsDiscoveryService', () => {
       providers: [
         JobsDiscoveryService,
         { provide: ExchangeOracleGateway, useValue: exchangeOracleGatewayMock },
+        { provide: CACHE_MANAGER, useValue: cacheManagerMock },
+        {
+          provide: EnvironmentConfigService,
+          useValue: {
+            chainIdsEnabled: [ChainId.MAINNET],
+          },
+        },
       ],
     }).compile();
 

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.service.spec.ts
@@ -7,7 +7,6 @@ import {
   responseItemFixture1,
   responseItemFixture3,
 } from './jobs-discovery.fixtures';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 describe('JobsDiscoveryService', () => {
   let service: JobsDiscoveryService;
@@ -28,7 +27,6 @@ describe('JobsDiscoveryService', () => {
       providers: [
         JobsDiscoveryService,
         { provide: ExchangeOracleGateway, useValue: exchangeOracleGatewayMock },
-        { provide: CACHE_MANAGER, useValue: cacheManagerMock },
       ],
     }).compile();
 

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
@@ -4,27 +4,37 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsArray, IsOptional } from 'class-validator';
 import { Exclude, Transform } from 'class-transformer';
 
-export class OracleDiscovered implements IOperator {
+type DiscoveredOracleCreateProps = {
+  address: string;
+  chainId: ChainId;
+  role?: string;
+  url: string;
+  jobTypes: string[];
+  registrationNeeded?: boolean;
+  registrationInstructions?: string;
+};
+
+export class DiscoveredOracle implements IOperator {
   @ApiProperty({ description: 'Address of the oracle operator' })
   address: string;
 
   @ApiProperty({ description: 'Chain ID where the oracle is registered' })
   chainId: ChainId;
 
+  @ApiPropertyOptional({ description: 'URL of the oracle operator' })
+  url: string;
+
   @ApiPropertyOptional({ description: 'Role of the oracle operator' })
   role?: string;
-
-  @ApiPropertyOptional({ description: 'URL of the oracle operator' })
-  url?: string;
 
   @ApiPropertyOptional({
     type: [String],
     description: 'Types of jobs the oracle supports',
   })
-  jobTypes?: string[];
+  jobTypes: string[];
 
   @ApiPropertyOptional({ description: 'Indicates if registration is needed' })
-  registrationNeeded?: boolean;
+  registrationNeeded: boolean;
 
   @ApiPropertyOptional({
     description: 'Instructions for registration, if needed',
@@ -37,32 +47,33 @@ export class OracleDiscovered implements IOperator {
   @Exclude()
   executionsToSkip = 0;
 
-  constructor(
-    address: string,
-    chainId: ChainId,
-    role?: string,
-    url?: string,
-    jobTypes?: string[],
-    registrationNeeded?: boolean,
-    registrationInstructions?: string,
-  ) {
+  constructor({
+    address,
+    chainId,
+    role,
+    url,
+    jobTypes,
+    registrationNeeded,
+    registrationInstructions,
+  }: DiscoveredOracleCreateProps) {
     this.address = address;
     this.chainId = chainId;
     this.role = role;
     this.url = url;
     this.jobTypes = jobTypes;
-    this.registrationNeeded = registrationNeeded;
+    this.registrationNeeded = registrationNeeded || false;
     this.registrationInstructions = registrationInstructions;
   }
 }
-export class OracleDiscoveryDto {
+
+export class GetOraclesQuery {
   @ApiPropertyOptional({ type: [String] })
   @IsArray()
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : Array(value)))
   selected_job_types?: string[];
 }
-export class OracleDiscoveryCommand {
+export class GetOraclesCommand {
   @AutoMap()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
   selectedJobTypes?: string[];

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/model/oracle-discovery.model.ts
@@ -4,7 +4,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsArray, IsOptional } from 'class-validator';
 import { Exclude, Transform } from 'class-transformer';
 
-export class OracleDiscoveryResult implements IOperator {
+export class OracleDiscovered implements IOperator {
   @ApiProperty({ description: 'Address of the oracle operator' })
   address: string;
 

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
@@ -12,7 +12,7 @@ import { OracleDiscoveryService } from './oracle-discovery.service';
 import {
   OracleDiscoveryCommand,
   OracleDiscoveryDto,
-  OracleDiscoveryResult,
+  OracleDiscovered,
 } from './model/oracle-discovery.model';
 import { InjectMapper } from '@automapper/nestjs';
 import { Mapper } from '@automapper/core';
@@ -29,13 +29,13 @@ export class OracleDiscoveryController {
   @Get('/oracles')
   @ApiOperation({ summary: 'Oracles discovery' })
   @ApiOkResponse({
-    type: Array<OracleDiscoveryResult>,
+    type: Array<OracleDiscovered>,
     description: 'List of oracles',
   })
   @UsePipes(new ValidationPipe())
   public async getOracles(
     @Query() dto: OracleDiscoveryDto,
-  ): Promise<OracleDiscoveryResult[]> {
+  ): Promise<OracleDiscovered[]> {
     if (!this.environmentConfigService.jobsDiscoveryFlag) {
       throw new HttpException(
         'Oracles discovery is disabled',

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
@@ -10,9 +10,9 @@ import {
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { OracleDiscoveryService } from './oracle-discovery.service';
 import {
-  OracleDiscoveryCommand,
-  OracleDiscoveryDto,
-  OracleDiscovered,
+  GetOraclesCommand,
+  GetOraclesQuery,
+  DiscoveredOracle,
 } from './model/oracle-discovery.model';
 import { InjectMapper } from '@automapper/nestjs';
 import { Mapper } from '@automapper/core';
@@ -21,7 +21,7 @@ import { EnvironmentConfigService } from '../../common/config/environment-config
 @Controller()
 export class OracleDiscoveryController {
   constructor(
-    private readonly service: OracleDiscoveryService,
+    private readonly oracleDiscoveryService: OracleDiscoveryService,
     private readonly environmentConfigService: EnvironmentConfigService,
     @InjectMapper() private readonly mapper: Mapper,
   ) {}
@@ -29,24 +29,20 @@ export class OracleDiscoveryController {
   @Get('/oracles')
   @ApiOperation({ summary: 'Oracles discovery' })
   @ApiOkResponse({
-    type: Array<OracleDiscovered>,
+    type: Array<DiscoveredOracle>,
     description: 'List of oracles',
   })
   @UsePipes(new ValidationPipe())
   public async getOracles(
-    @Query() dto: OracleDiscoveryDto,
-  ): Promise<OracleDiscovered[]> {
+    @Query() query: GetOraclesQuery,
+  ): Promise<DiscoveredOracle[]> {
     if (!this.environmentConfigService.jobsDiscoveryFlag) {
       throw new HttpException(
         'Oracles discovery is disabled',
         HttpStatus.FORBIDDEN,
       );
     }
-    const command = this.mapper.map(
-      dto,
-      OracleDiscoveryDto,
-      OracleDiscoveryCommand,
-    );
-    return await this.service.processOracleDiscovery(command);
+    const command = this.mapper.map(query, GetOraclesQuery, GetOraclesCommand);
+    return await this.oracleDiscoveryService.getOracles(command);
   }
 }

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.mapper.profile.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.mapper.profile.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { AutomapperProfile, InjectMapper } from '@automapper/nestjs';
 import { createMap, forMember, mapFrom, Mapper } from '@automapper/core';
 import {
-  OracleDiscoveryCommand,
-  OracleDiscoveryDto,
+  GetOraclesCommand,
+  GetOraclesQuery,
 } from './model/oracle-discovery.model';
 
 @Injectable()
@@ -16,8 +16,8 @@ export class OracleDiscoveryProfile extends AutomapperProfile {
     return (mapper: Mapper) => {
       createMap(
         mapper,
-        OracleDiscoveryDto,
-        OracleDiscoveryCommand,
+        GetOraclesQuery,
+        GetOraclesCommand,
         forMember(
           (destination) => destination.selectedJobTypes,
           mapFrom((source) => source.selected_job_types),

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.service.ts
@@ -1,11 +1,12 @@
+import _ from 'lodash';
+import { ChainId, IOperator, OperatorUtils, Role } from '@human-protocol/sdk';
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import {
-  OracleDiscoveryCommand,
-  OracleDiscovered,
-} from './model/oracle-discovery.model';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
-import { ChainId, OperatorUtils, Role } from '@human-protocol/sdk';
+import {
+  DiscoveredOracle,
+  GetOraclesCommand,
+} from './model/oracle-discovery.model';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 import { KvStoreGateway } from '../../integrations/kv-store/kv-store.gateway';
 
@@ -19,106 +20,140 @@ export class OracleDiscoveryService {
     private kvStoreGateway: KvStoreGateway,
   ) {}
 
-  async processOracleDiscovery(
-    command: OracleDiscoveryCommand,
-  ): Promise<OracleDiscovered[]> {
-    const address = this.configService.reputationOracleAddress;
-    const chainIds = this.configService.chainIdsEnabled;
+  async getOracles(command: GetOraclesCommand): Promise<DiscoveredOracle[]> {
+    const oracles = await this.discoverOracles();
 
-    const oraclesForChainIds = await Promise.all(
-      chainIds.map(async (chainId) => {
-        const jobTypes = (
-          (await this.kvStoreGateway.getJobTypesByAddress(chainId, address)) ??
-          ''
-        )
-          .split(',')
-          .map((job) => job.trim().toLowerCase());
-
-        return this.findOraclesByChainIdAndJobTypes(chainId, address, jobTypes);
-      }),
-    );
-
-    const oracles: OracleDiscovered[] = [];
-    for (const oraclesForChainId of oraclesForChainIds) {
-      for (const oracle of oraclesForChainId) {
-        if (command.selectedJobTypes?.length) {
-          // Keep only oracles that have at least one selected job type
-          const oracleJobTypesSet = new Set(oracle.jobTypes || []);
-          let oracleHasSomeSelectedJobType = false;
-          for (const selectedJobType of command.selectedJobTypes) {
-            if (oracleJobTypesSet.has(selectedJobType)) {
-              oracleHasSomeSelectedJobType = true;
-              break;
-            }
-          }
-          if (!oracleHasSomeSelectedJobType) {
-            continue;
-          }
-        }
-
-        oracles.push(oracle);
-      }
+    if (!command.selectedJobTypes?.length) {
+      return oracles;
     }
 
-    return oracles;
+    const selectedJobTypesSet = new Set(command.selectedJobTypes);
+    return oracles.filter((oracle) =>
+      oracle.jobTypes.some((jobType) => selectedJobTypesSet.has(jobType)),
+    );
   }
 
-  private async findOraclesByChainIdAndJobTypes(
-    chainId: ChainId,
-    address: string,
-    jobTypes: string[],
-  ): Promise<OracleDiscovered[]> {
-    try {
-      const cachedOracles = await this.cacheManager.get<OracleDiscovered[]>(
-        chainId.toString(),
-      );
-      if (cachedOracles) return cachedOracles;
+  async discoverOracles(): Promise<DiscoveredOracle[]> {
+    const discoveryPromises = [];
+    for (const enabledChainId of this.configService.chainIdsEnabled) {
+      discoveryPromises.push(this.discoverOraclesForChain(enabledChainId));
+    }
 
-      const operators = await OperatorUtils.getReputationNetworkOperators(
-        Number(chainId),
-        address,
+    const oraclesDiscoveredForChains = await Promise.all(discoveryPromises);
+
+    return oraclesDiscoveredForChains.flat();
+  }
+
+  private async discoverOraclesForChain(
+    chainId: ChainId,
+  ): Promise<DiscoveredOracle[]> {
+    try {
+      const cacheKey = chainId.toString();
+
+      const cachedOracles = await this.cacheManager.get<
+        DiscoveredOracle[] | undefined
+      >(cacheKey);
+
+      if (cachedOracles) {
+        return cachedOracles;
+      }
+
+      const reputationOracleAddress =
+        this.configService.reputationOracleAddress;
+
+      const reputationOracleJobTypesValue =
+        await this.kvStoreGateway.getJobTypesByAddress(
+          chainId,
+          reputationOracleAddress,
+        );
+
+      if (!reputationOracleJobTypesValue) {
+        return [];
+      }
+      const reputationOracleJobTypes = reputationOracleJobTypesValue.split(',');
+
+      const exchangeOracles = await OperatorUtils.getReputationNetworkOperators(
+        chainId,
+        reputationOracleAddress,
         Role.ExchangeOracle,
       );
 
-      const jobTypeSet = new Set(jobTypes.map((j) => j.toLowerCase()));
-
-      const oraclesWithRetryData: OracleDiscovered[] = operators
-        .filter(
-          (operator) =>
-            operator.url && this.hasJobTypes(operator.jobTypes, jobTypeSet),
-        )
-        .map(
-          (operator) =>
-            new OracleDiscovered(
-              operator.address,
+      const discoveredOracles: DiscoveredOracle[] = [];
+      for (const exchangeOracle of exchangeOracles) {
+        if (
+          OracleDiscoveryService.checkExpectationsOfDiscoveredOracle(
+            exchangeOracle,
+            reputationOracleJobTypes,
+          )
+        ) {
+          discoveredOracles.push(
+            new DiscoveredOracle({
+              address: exchangeOracle.address,
+              role: exchangeOracle.role,
+              url: exchangeOracle.url,
+              jobTypes: exchangeOracle.jobTypes,
+              registrationNeeded: exchangeOracle.registrationNeeded,
+              registrationInstructions: exchangeOracle.registrationInstructions,
               chainId,
-              operator.role,
-              operator.url,
-              operator.jobTypes,
-              operator.registrationNeeded,
-              operator.registrationInstructions,
-            ),
-        );
+            }),
+          );
+        }
+      }
 
       await this.cacheManager.set(
-        chainId.toString(),
-        oraclesWithRetryData,
+        cacheKey,
+        discoveredOracles,
         this.configService.cacheTtlOracleDiscovery,
       );
 
-      return oraclesWithRetryData;
+      return discoveredOracles;
     } catch (error) {
-      this.logger.error(`Error processing chainId ${chainId}:`, error);
+      this.logger.error(
+        `Failed to discover oracles for chain '${chainId}':`,
+        error,
+      );
       return [];
     }
   }
 
-  private hasJobTypes(
-    oracleJobTypes: string[] | undefined,
-    jobTypeSet: Set<string>,
-  ) {
-    return oracleJobTypes
-      ? oracleJobTypes.some((job) => jobTypeSet.has(job.toLowerCase()))
-      : false;
+  static checkExpectationsOfDiscoveredOracle(
+    operator: IOperator,
+    possibleJobTypes: string[],
+  ): operator is DiscoveredOracle {
+    if (!operator.url) {
+      return false;
+    }
+
+    if (_.intersection(operator.jobTypes, possibleJobTypes).length === 0) {
+      return false;
+    }
+
+    return true;
+  }
+
+  async updateOracleInCache(
+    oracleWithUpdates: DiscoveredOracle,
+  ): Promise<void> {
+    const cacheKey = oracleWithUpdates.chainId.toString();
+
+    const cachedOracles = await this.cacheManager.get<
+      DiscoveredOracle[] | undefined
+    >(cacheKey);
+
+    if (!cachedOracles) {
+      return;
+    }
+
+    const updatedOracles = cachedOracles.map((cachedOracle) =>
+      cachedOracle.address === oracleWithUpdates.address
+        ? oracleWithUpdates
+        : cachedOracle,
+    );
+
+    await this.cacheManager.set(
+      cacheKey,
+      updatedOracles,
+      this.configService.cacheTtlOracleDiscovery,
+    );
   }
 }

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -7,7 +7,7 @@ import { oracleDiscoveryServiceMock } from './oracle-discovery.service.mock';
 import {
   OracleDiscoveryCommand,
   OracleDiscoveryDto,
-  OracleDiscoveryResult,
+  OracleDiscovered,
 } from '../model/oracle-discovery.model';
 import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
@@ -69,7 +69,7 @@ describe('OracleDiscoveryController', () => {
       const commandFixture = {
         selectedJobTypes: ['job-type-1', 'job-type-2'],
       } as OracleDiscoveryCommand;
-      const result: OracleDiscoveryResult[] =
+      const result: OracleDiscovered[] =
         await controller.getOracles(dtoFixture);
       const expectedResponse = generateOracleDiscoveryResponseBody();
       expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.controller.spec.ts
@@ -5,9 +5,8 @@ import { OracleDiscoveryController } from '../oracle-discovery.controller';
 import { OracleDiscoveryService } from '../oracle-discovery.service';
 import { oracleDiscoveryServiceMock } from './oracle-discovery.service.mock';
 import {
-  OracleDiscoveryCommand,
-  OracleDiscoveryDto,
-  OracleDiscovered,
+  GetOraclesQuery,
+  DiscoveredOracle,
 } from '../model/oracle-discovery.model';
 import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 import { OracleDiscoveryProfile } from '../oracle-discovery.mapper.profile';
@@ -62,26 +61,21 @@ describe('OracleDiscoveryController', () => {
   });
 
   describe('oracle discovery', () => {
-    it('oracle discovery should be return OracleDiscoveryData', async () => {
+    it('should return discovered oracles', async () => {
       const dtoFixture = {
         selected_job_types: ['job-type-1', 'job-type-2'],
-      } as OracleDiscoveryDto;
-      const commandFixture = {
-        selectedJobTypes: ['job-type-1', 'job-type-2'],
-      } as OracleDiscoveryCommand;
-      const result: OracleDiscovered[] =
+      } as GetOraclesQuery;
+      const result: DiscoveredOracle[] =
         await controller.getOracles(dtoFixture);
       const expectedResponse = generateOracleDiscoveryResponseBody();
-      expect(serviceMock.processOracleDiscovery).toHaveBeenCalledWith(
-        commandFixture,
-      );
+      expect(serviceMock.getOracles).toHaveBeenCalled();
       expect(result).toEqual(expectedResponse);
     });
 
     it('should throw an error if jobsDiscoveryFlag is disabled', async () => {
       const dtoFixture = {
         selected_job_types: ['job-type-1', 'job-type-2'],
-      } as OracleDiscoveryDto;
+      } as GetOraclesQuery;
 
       (configServiceMock as any).jobsDiscoveryFlag = false;
 

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
@@ -1,10 +1,10 @@
 import { ChainId } from '@human-protocol/sdk';
 import {
   OracleDiscoveryCommand,
-  OracleDiscoveryResult,
+  OracleDiscovered,
 } from '../model/oracle-discovery.model';
 
-const response1: OracleDiscoveryResult = {
+const response1: OracleDiscovered = {
   address: '0xd06eac24a0c47c776Ce6826A93162c4AfC029047',
   chainId: ChainId.POLYGON_AMOY,
   role: 'role1',
@@ -15,7 +15,7 @@ const response1: OracleDiscoveryResult = {
   registrationNeeded: true,
   registrationInstructions: 'https://instructions.com',
 };
-const response2: OracleDiscoveryResult = {
+const response2: OracleDiscovered = {
   address: '0xd10c3402155c058D78e4D5fB5f50E125F06eb39d',
   chainId: ChainId.POLYGON_AMOY,
   role: 'role2',
@@ -25,7 +25,7 @@ const response2: OracleDiscoveryResult = {
   registrationNeeded: false,
   registrationInstructions: undefined,
 };
-const response3: OracleDiscoveryResult = {
+const response3: OracleDiscovered = {
   address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
   chainId: ChainId.POLYGON_AMOY,
   role: 'role3',
@@ -36,7 +36,7 @@ const response3: OracleDiscoveryResult = {
   registrationNeeded: false,
   registrationInstructions: undefined,
 };
-const response4: OracleDiscoveryResult = {
+const response4: OracleDiscovered = {
   address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
   chainId: ChainId.MOONBASE_ALPHA,
   role: 'role3',

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.fixture.ts
@@ -1,10 +1,10 @@
 import { ChainId } from '@human-protocol/sdk';
 import {
-  OracleDiscoveryCommand,
-  OracleDiscovered,
+  GetOraclesCommand,
+  DiscoveredOracle,
 } from '../model/oracle-discovery.model';
 
-const response1: OracleDiscovered = {
+const response1: DiscoveredOracle = {
   address: '0xd06eac24a0c47c776Ce6826A93162c4AfC029047',
   chainId: ChainId.POLYGON_AMOY,
   role: 'role1',
@@ -15,17 +15,18 @@ const response1: OracleDiscovered = {
   registrationNeeded: true,
   registrationInstructions: 'https://instructions.com',
 };
-const response2: OracleDiscovered = {
+const response2: DiscoveredOracle = {
   address: '0xd10c3402155c058D78e4D5fB5f50E125F06eb39d',
   chainId: ChainId.POLYGON_AMOY,
   role: 'role2',
+  url: '',
   jobTypes: ['job-type-1', 'job-type-3', 'job-type-4'],
   retriesCount: 0,
   executionsToSkip: 0,
   registrationNeeded: false,
   registrationInstructions: undefined,
 };
-const response3: OracleDiscovered = {
+const response3: DiscoveredOracle = {
   address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
   chainId: ChainId.POLYGON_AMOY,
   role: 'role3',
@@ -36,7 +37,7 @@ const response3: OracleDiscovered = {
   registrationNeeded: false,
   registrationInstructions: undefined,
 };
-const response4: OracleDiscovered = {
+const response4: DiscoveredOracle = {
   address: '0xd83422155c058D78e4D5fB5f50E125F06eb39d',
   chainId: ChainId.MOONBASE_ALPHA,
   role: 'role3',
@@ -73,12 +74,12 @@ export function generateOracleDiscoveryResponseBodyByJobType(jobType: string) {
   );
 }
 
-export const reputationOracleSupportedJobTypes = 'job-type-1, job-type-4';
+export const reputationOracleSupportedJobTypes = 'job-type-1,job-type-4';
 export const filledCommandFixture = {
   selectedJobTypes: ['job-type-1'],
-} as OracleDiscoveryCommand;
+} as GetOraclesCommand;
 export const emptyCommandFixture = {
   selectedJobTypes: [],
-} as OracleDiscoveryCommand;
-export const notSetCommandFixture = {} as OracleDiscoveryCommand;
+} as GetOraclesCommand;
+export const notSetCommandFixture = {} as GetOraclesCommand;
 export const errorResponse = [];

--- a/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.mock.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/spec/oracle-discovery.service.mock.ts
@@ -1,7 +1,7 @@
 import { generateOracleDiscoveryResponseBody } from './oracle-discovery.fixture';
 
 export const oracleDiscoveryServiceMock = {
-  processOracleDiscovery: jest
+  getOracles: jest
     .fn()
     .mockResolvedValue(generateOracleDiscoveryResponseBody()),
 };


### PR DESCRIPTION
## Issue tracking
Closes #2863 

## Context behind the change
Right now we fetch and cache all jobs for oracle, w/o preliminary filtration by `chainId`, so all visible for user regardless of configuration. The proper way to fix it would be to fetch & store jobs per chain, then also request them per chain, but it involves much more refactoring on BE + changing the UI to support that.

Right now we go simple path an just filter out jobs that do not belong to enable chains when retrieving them for UI.

Also fixed `jobTypes` filter fo `hCaptcha` oracle on UI.

Later we will discuss UI changes and refactor jobs discovery for good.

As a "scout rule" for now refactored "oracle discovery" and "cron" a bit.

## How has this been tested?
- [x] unit tests pass
- [x] have only `POLYGON_AMOY` enabled in chains config; open UI, go to `Fortune` oracle; check it displays only "amoy" jobs
- [x] open oracles page; filter by "job type = "fortune"; make sure only "fortune" is displayed 
- [x] open oracles page; filter by "job type = "points"; make sure only "hCaptcha" and "CVAT" displayed
- [x] regression tests for refactored code 

## Release plan
1. [ ]  Fix values of `job_types` in KV store of Reputation Oracle
2. [ ] Fix values of `jobTypes` in KV store for `Fortune` oracles (in all networks)
3. [ ] Merge & deploy

## Potential risks; What to monitor; Rollback plan
Right now in `Sepolia` test network we have invalid list of `job_types` (they are stored there in human readable format), so because of that we can't discover `Fortune` in this network and it is not displayed, but we still get jobs from Sepolia while doing jobs discovery because it's independent process.
