### PR TITLE
Allow direct call to complete after bulkPayOut

### DIFF
--- a/packages/core/.openzeppelin/bsc-testnet.json
+++ b/packages/core/.openzeppelin/bsc-testnet.json
@@ -1709,6 +1709,155 @@
         },
         "namespaces": {}
       }
+    },
+    "2d3fa01245b44969a8c2cf6a33f29f8d0e0c52f7b212797f69eb642a0697ba95": {
+      "address": "0xb9D3688D0ECE314c1bDAf14BeD36eD589c8d31A5",
+      "txHash": "0xb69e2d7a7f390b636f597358c41ecc377fdbdd250b04cba0d16f06aad1b9aae8",
+      "layout": {
+        "solcVersion": "0.8.23",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:169"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:111"
+          },
+          {
+            "label": "counter",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:16"
+          },
+          {
+            "label": "escrowCounters",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:17"
+          },
+          {
+            "label": "lastEscrow",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_address",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:18"
+          },
+          {
+            "label": "staking",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:19"
+          },
+          {
+            "label": "minimumStake",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_uint256",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:117"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/core/.openzeppelin/sepolia.json
+++ b/packages/core/.openzeppelin/sepolia.json
@@ -876,6 +876,155 @@
         },
         "namespaces": {}
       }
+    },
+    "2d3fa01245b44969a8c2cf6a33f29f8d0e0c52f7b212797f69eb642a0697ba95": {
+      "address": "0x683874D7578f480f48CE2fA1C13fCBC621C2e7c8",
+      "txHash": "0x47651e1b2a3c6985251125ccdffaeb2b70e176861c2250b7a21f23382fa40778",
+      "layout": {
+        "solcVersion": "0.8.23",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:169"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:111"
+          },
+          {
+            "label": "counter",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:16"
+          },
+          {
+            "label": "escrowCounters",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:17"
+          },
+          {
+            "label": "lastEscrow",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_address",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:18"
+          },
+          {
+            "label": "staking",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:19"
+          },
+          {
+            "label": "minimumStake",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_uint256",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:117"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/core/.openzeppelin/unknown-80002.json
+++ b/packages/core/.openzeppelin/unknown-80002.json
@@ -876,6 +876,155 @@
         },
         "namespaces": {}
       }
+    },
+    "2d3fa01245b44969a8c2cf6a33f29f8d0e0c52f7b212797f69eb642a0697ba95": {
+      "address": "0xF70D3dF4Dd79Bb679Bea3C88689c9758D57c3556",
+      "txHash": "0x1384d3805b2b53d7db38c56b87f5526eec32a5b6c31ee094953449d1ec89d3b2",
+      "layout": {
+        "solcVersion": "0.8.23",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:169"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:111"
+          },
+          {
+            "label": "counter",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:16"
+          },
+          {
+            "label": "escrowCounters",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:17"
+          },
+          {
+            "label": "lastEscrow",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_address",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:18"
+          },
+          {
+            "label": "staking",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_address",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:19"
+          },
+          {
+            "label": "minimumStake",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_uint256",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "EscrowFactory",
+            "src": "contracts/EscrowFactory.sol:117"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/core/contracts/Escrow.sol
+++ b/packages/core/contracts/Escrow.sol
@@ -354,7 +354,6 @@ contract Escrow is IEscrow, ReentrancyGuard {
 
         remainingFunds = cachedRemainingFunds;
 
-        // Check the forceComplete flag and transfer remaining funds if true
         if (cachedRemainingFunds == 0 || forceComplete) {
             emit BulkTransferV2(
                 _txId,

--- a/packages/core/test/Escrow.ts
+++ b/packages/core/test/Escrow.ts
@@ -833,7 +833,7 @@ describe('Escrow', function () {
           (finalBalanceExchangeOracle - initialBalanceExchangeOracle).toString()
         ).to.equal('6');
 
-        expect(await escrow.remainingFunds()).to.equal('40');
+        expect(await escrow.remainingFunds()).to.equal('0');
       });
 
       it('Should runs from setup to bulkPayOut to complete correctly', async () => {
@@ -898,6 +898,89 @@ describe('Escrow', function () {
             'bulkPayOut(address[],uint256[],string,string,uint256)'
           ](recepients, amounts, MOCK_URL, MOCK_HASH, '000');
         expect(await escrow.status()).to.equal(Status.Partial);
+      });
+    });
+  });
+  describe('complete', () => {
+    describe('Validations', function () {
+      beforeEach(async () => {
+        await deployEscrow();
+        await fundEscrow();
+        await setupEscrow();
+      });
+
+      it('Should revert with the right error if escrow not in Paid or Partial state', async function () {
+        await expect(escrow.connect(owner).complete()).to.be.revertedWith(
+          'Escrow not in Paid or Partial state'
+        );
+      });
+    });
+
+    describe('Events', function () {
+      beforeEach(async () => {
+        await deployEscrow();
+        await fundEscrow();
+        await setupEscrow();
+      });
+
+      it('Should emit a Completed event when escrow is completed', async function () {
+        const recipients = [await restAccounts[0].getAddress()];
+        const amounts = [10];
+
+        await escrow
+          .connect(owner)
+          [
+            'bulkPayOut(address[],uint256[],string,string,uint256,bool)'
+          ](recipients, amounts, MOCK_URL, MOCK_HASH, '000', false);
+
+        await expect(escrow.connect(owner).complete()).to.emit(
+          escrow,
+          'Completed'
+        );
+      });
+    });
+
+    describe('Complete escrow', async function () {
+      beforeEach(async () => {
+        await deployEscrow();
+        await fundEscrow();
+        await setupEscrow();
+      });
+
+      it('Should succeed if escrow is in Partial state', async function () {
+        const recipients = [await restAccounts[0].getAddress()];
+        const amounts = [10];
+        await escrow
+          .connect(owner)
+          [
+            'bulkPayOut(address[],uint256[],string,string,uint256,bool)'
+          ](recipients, amounts, MOCK_URL, MOCK_HASH, '000', false);
+        expect(await escrow.status()).to.equal(Status.Partial);
+
+        await escrow.connect(owner).complete();
+        expect(await escrow.status()).to.equal(Status.Complete);
+        expect(await escrow.remainingFunds()).to.equal('0');
+      });
+
+      it('Should transfer remaining funds to launcher on complete', async function () {
+        const initialLauncherBalance = await token
+          .connect(owner)
+          .balanceOf(await launcher.getAddress());
+
+        const recipients = [await restAccounts[0].getAddress()];
+        const amounts = [10];
+        await escrow
+          .connect(owner)
+          [
+            'bulkPayOut(address[],uint256[],string,string,uint256,bool)'
+          ](recipients, amounts, MOCK_URL, MOCK_HASH, '000', false);
+        await escrow.connect(owner).complete();
+
+        const finalLauncherBalance = await token
+          .connect(owner)
+          .balanceOf(await launcher.getAddress());
+
+        expect(finalLauncherBalance - initialLauncherBalance).to.equal('90');
       });
     });
   });


### PR DESCRIPTION
## Issue tracking
#2895

## Context behind the change
This pull request modifies the complete function to allow direct invocation for finalizing the escrow after the bulkPayOut function has already been executed. Previously, the complete function is just for compatibility with old escrows. The goal of this change is to simplify the workflow, enhance user experience, and reduce unnecessary steps.
The following parts of the code were updated:

- complete function: Updated logic to support direct completion from Paid or Partial states.
- bulkPayOut function: Integrated with the new logic for seamless transition.
- Test cases: Added and updated tests to validate the updated behavior of the complete function.

## How has this been tested?
Deployed locally testing some edge cases and unit tests 

## Release plan
Deploy contracts.

## Potential risks; What to monitor; Rollback plan
Check if payments are being made properly to the launcher address and the Completed event is emitted. 