### PR TITLE
fix: add network param to captcha stats request

### DIFF
--- a/packages/apps/human-app/server/src/common/config/gateway-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/gateway-config.service.ts
@@ -128,6 +128,7 @@ export class GatewayConfigService {
               params: {
                 api_key: this.envConfig.hcaptchaLabelingApiKey,
                 actual: false,
+                network: 'polygon',
               },
             },
           } as Record<HCaptchaLabelingStatsEndpoints, GatewayEndpointConfig>,


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Validation schema changed for stats endpoint and now it requires `network` param, so adding it as a hotfix.

## How has this been tested?
- [x] locally: open "hCaptcha" tasks page, make sure it can load

## Release plan
Release from this branch, no need to merge.

## Potential risks; What to monitor; Rollback plan
Monitor the deployment & double-check on PRD. Rollback is simply to deploy `main`