### PR TITLE
[Human App] fix: add network param to captcha stats request

### DIFF
--- a/packages/apps/human-app/server/src/common/config/gateway-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/gateway-config.service.ts
@@ -128,6 +128,12 @@ export class GatewayConfigService {
               params: {
                 api_key: this.envConfig.hcaptchaLabelingApiKey,
                 actual: false,
+                /**
+                 * Required param.
+                 * Only one value is available for now
+                 * so hardcoded
+                 */
+                network: 'polygon',
               },
             },
           } as Record<HCaptchaLabelingStatsEndpoints, GatewayEndpointConfig>,

--- a/packages/apps/human-app/server/src/integrations/h-captcha-labeling/spec/h-captcha-labeling.gateways.spec.ts
+++ b/packages/apps/human-app/server/src/integrations/h-captcha-labeling/spec/h-captcha-labeling.gateways.spec.ts
@@ -103,7 +103,11 @@ describe('HCaptchaLabelingGateway', () => {
         method: 'GET',
         url: `${environmentConfigServiceMock.hcaptchaLabelingStatsApiUrl}/requester/daily_hmt_spend`,
         headers: {},
-        params: { api_key: 'mock-api-key', actual: false },
+        params: {
+          api_key: 'mock-api-key',
+          actual: false,
+          network: 'polygon',
+        },
       };
       expect(httpServiceMock.request).toHaveBeenCalledWith(expectedOptions);
     });


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Validation schema changed for stats endpoint and now it requires `network` param, so adding it here.
Right now hotfix is deployed as direct deploy of `hotfix/hcaptcha-stats` branch

## How has this been tested?
- [x] locally: open "hCaptcha" tasks page, make sure it can load

## Release plan
1. Simply merge
2. Remove `hotfix/hcaptcha-stats` branch once released

## Potential risks; What to monitor; Rollback plan
N/A