### PR TITLE
[Job Launcher] fix: get rid of job types mapping in job creation

### DIFF
--- a/packages/apps/job-launcher/server/src/common/utils/index.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/index.ts
@@ -2,7 +2,6 @@ import { HttpStatus } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { Readable } from 'stream';
 import { ControlledError } from '../errors/controlled';
-import { JobRequestType } from '../enums/job';
 
 export const parseUrl = (
   url: string,
@@ -116,20 +115,3 @@ export function isPGPMessage(str: string): boolean {
     /-----BEGIN PGP MESSAGE-----\n\n[\s\S]+?\n-----END PGP MESSAGE-----/;
   return pattern.test(str);
 }
-
-export const mapJobType = (requestType: JobRequestType): string => {
-  switch (requestType) {
-    case JobRequestType.IMAGE_POINTS:
-      return 'Points';
-    case JobRequestType.IMAGE_POLYGONS:
-      return 'Polygons';
-    case JobRequestType.IMAGE_BOXES:
-      return 'Bounding Boxes';
-    case JobRequestType.IMAGE_BOXES_FROM_POINTS:
-      return 'Bounding Boxes from Points';
-    case JobRequestType.IMAGE_SKELETONS_FROM_BOXES:
-      return 'Skeletons from Bounding Boxes';
-    default:
-      return 'Fortune';
-  }
-};

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -119,7 +119,6 @@ import { QualificationService } from '../qualification/qualification.service';
 import { NetworkConfigService } from '../../common/config/network-config.service';
 
 const rate = 1.5;
-const mappedJobType = 'mappedType';
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
   EscrowClient: {
@@ -154,7 +153,6 @@ jest.mock('../../common/utils', () => ({
       bucket: MOCK_BUCKET_NAME,
     };
   }),
-  mapJobType: jest.fn().mockImplementation(() => 'mappedType'),
 }));
 
 jest.mock('../../common/utils/storage', () => ({
@@ -344,7 +342,7 @@ describe('JobService', () => {
 
       expect(routingProtocolService.validateOracles).toHaveBeenCalledWith(
         MOCK_CHAIN_ID,
-        mappedJobType,
+        JobRequestType.FORTUNE,
         providedReputationOracle,
         providedExchangeOracle,
         providedRecordingOracle,

--- a/packages/apps/job-launcher/server/src/modules/job/routing-protocol.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/routing-protocol.service.spec.ts
@@ -8,6 +8,7 @@ import { NetworkConfigService } from '../../common/config/network-config.service
 import { Web3Service } from '../web3/web3.service';
 import { ConfigService } from '@nestjs/config';
 import { ControlledError } from '../../common/errors/controlled';
+import { JobRequestType } from '../../common/enums/job';
 import { ErrorRoutingProtocol } from '../../common/constants/errors';
 import { HttpStatus } from '@nestjs/common';
 import { hashString } from '../../common/utils';
@@ -353,7 +354,7 @@ describe('RoutingProtocolService', () => {
 
       const result = await routingProtocolService.selectOracles(
         ChainId.POLYGON_AMOY,
-        'jobType',
+        JobRequestType.FORTUNE,
       );
       expect(result.reputationOracle).toBeDefined();
       expect(result.exchangeOracle).toBe('0xExchangeOracle1');
@@ -365,7 +366,7 @@ describe('RoutingProtocolService', () => {
 
       const result = await routingProtocolService.selectOracles(
         ChainId.POLYGON_AMOY,
-        'jobType',
+        JobRequestType.FORTUNE,
       );
       expect(result.exchangeOracle).toBe('');
       expect(result.recordingOracle).toBe('');
@@ -375,7 +376,6 @@ describe('RoutingProtocolService', () => {
   describe('validateOracles', () => {
     it('should validate oracles successfully', async () => {
       const chainId = ChainId.POLYGON_AMOY;
-      const jobType = 'someJobType';
       const reputationOracle = '0xReputationOracle';
       const exchangeOracle = '0xExchangeOracle';
       const recordingOracle = '0xRecordingOracle';
@@ -395,7 +395,7 @@ describe('RoutingProtocolService', () => {
       await expect(
         routingProtocolService.validateOracles(
           chainId,
-          jobType,
+          JobRequestType.FORTUNE,
           reputationOracle,
           exchangeOracle,
           recordingOracle,
@@ -405,7 +405,6 @@ describe('RoutingProtocolService', () => {
 
     it('should throw error if reputation oracle not found', async () => {
       const chainId = ChainId.POLYGON_AMOY;
-      const jobType = 'someJobType';
       const invalidReputationOracle = 'invalidOracle';
 
       jest
@@ -419,7 +418,7 @@ describe('RoutingProtocolService', () => {
       await expect(
         routingProtocolService.validateOracles(
           chainId,
-          jobType,
+          JobRequestType.FORTUNE,
           invalidReputationOracle,
         ),
       ).rejects.toThrow(
@@ -432,7 +431,6 @@ describe('RoutingProtocolService', () => {
 
     it('should throw error if exchange oracle not found', async () => {
       const chainId = ChainId.POLYGON_AMOY;
-      const jobType = 'someJobType';
       const reputationOracle = '0xReputationOracle';
 
       jest
@@ -451,7 +449,7 @@ describe('RoutingProtocolService', () => {
       await expect(
         routingProtocolService.validateOracles(
           chainId,
-          jobType,
+          JobRequestType.FORTUNE,
           reputationOracle,
           'invalidExchangeOracle',
         ),
@@ -465,7 +463,6 @@ describe('RoutingProtocolService', () => {
 
     it('should throw error if recording oracle not found', async () => {
       const chainId = ChainId.POLYGON_AMOY;
-      const jobType = 'someJobType';
       const reputationOracle = '0xReputationOracle';
 
       jest
@@ -484,7 +481,7 @@ describe('RoutingProtocolService', () => {
       await expect(
         routingProtocolService.validateOracles(
           chainId,
-          jobType,
+          JobRequestType.FORTUNE,
           reputationOracle,
           undefined,
           'invalidRecordingOracle',

--- a/packages/apps/job-launcher/server/src/modules/job/routing-protocol.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/routing-protocol.service.ts
@@ -4,6 +4,7 @@ import { Web3Service } from '../web3/web3.service';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { hashString } from '../../common/utils';
 import { ErrorRoutingProtocol } from '../../common/constants/errors';
+import { JobRequestType } from '../../common/enums/job';
 import { ControlledError } from '../../common/errors/controlled';
 import { NetworkConfigService } from '../../common/config/network-config.service';
 import {
@@ -148,7 +149,7 @@ export class RoutingProtocolService {
 
   public async selectOracles(
     chainId: ChainId,
-    jobType: string,
+    jobType: JobRequestType,
   ): Promise<{
     reputationOracle: string;
     exchangeOracle: string;
@@ -181,7 +182,7 @@ export class RoutingProtocolService {
 
   public async validateOracles(
     chainId: ChainId,
-    jobType: string,
+    jobType: JobRequestType,
     reputationOracle: string,
     exchangeOracle?: string | null,
     recordingOracle?: string | null,


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When creation job in Job Launcher, we send `jobType` value in snake case from UI, but later on BE map it to human readable values that are used for getting oracles from network. However, it's expected that oracles have `jobTypes` as snake cased value, not human-readable, so fixing it here.

## How has this been tested?
- [x] Unit tests

## Release plan
1. [ ] Merge this PR
2. [ ] Fix `job_types` in Reputation Oracle KV in mainnet
3. [ ] Deploy this PR

## Potential risks; What to monitor; Rollback plan
That we might not able to run jobs on JL in the time window between step 2 and 3 of the release plan. However, we were able to run jobs while having snake cased values on staging: because when setting up escrow we use values from env config ([ref](https://github.com/humanprotocol/human-protocol/blob/efc80d3114bfd050bbf3a58537822567afa6fb00/packages/apps/job-launcher/server/src/modules/job/job.service.ts#L1055))