### PR TITLE
[SDK] Change python sdk name to be PEP 625 compliance

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/pyproject.toml
+++ b/packages/sdk/python/human-protocol-sdk/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "human-protocol-sdk"
+name = "human_protocol_sdk"
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Issue tracking
Closes #2857 

## Context behind the change
Change python sdk name to be PEP 625 compliance

## How has this been tested?
Cannot be tested until deployment is triggered.

## Release plan
- Trigger release
- Check if sdk with old name is linked to the new released version: https://pypi.org/project/human-protocol-sdk/

## Potential risks; What to monitor; Rollback plan
- Pypi might consider them as different packages.