### PR TITLE
[HUMAN App] Fix to use CACHE_TTL_JOB_TYPES in seconds

### DIFF
--- a/packages/apps/human-app/server/src/common/config/environment-config.service.ts
+++ b/packages/apps/human-app/server/src/common/config/environment-config.service.ts
@@ -223,9 +223,11 @@ export class EnvironmentConfigService {
    * Default: 24 hours
    */
   get cacheTtlJobTypes(): number {
-    return this.configService.get<number>(
-      'CACHE_TTL_JOB_TYPES',
-      DEFAULT_CACHE_TTL_JOB_TYPES,
+    return (
+      this.configService.get<number>(
+        'CACHE_TTL_JOB_TYPES',
+        DEFAULT_CACHE_TTL_JOB_TYPES,
+      ) * 1000
     );
   }
 


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
Fix to use `CACHE_TTL_JOB_TYPES` in seconds instead of miliseconds

## How has this been tested?
Locally

## Release plan
Set `CACHE_TTL_JOB_TYPES` in seconds

## Potential risks; What to monitor; Rollback plan
NA