### PR TITLE
[Human App] fix: unhandled errors from updateAssigmentsCache

### DIFF
--- a/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.gateway.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { AxiosRequestConfig } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import {
@@ -41,6 +41,8 @@ import {
 
 @Injectable()
 export class ExchangeOracleGateway {
+  logger = new Logger(ExchangeOracleGateway.name);
+
   constructor(
     private httpService: HttpService,
     private kvStoreGateway: KvStoreGateway,
@@ -54,7 +56,7 @@ export class ExchangeOracleGateway {
       const response = await lastValueFrom(this.httpService.request(options));
       return response.data as T;
     } catch (e) {
-      console.error(
+      this.logger.error(
         `Error, while executing exchange oracle API call to ${options.url}, error details: ${e.message}`,
       );
       throw e;

--- a/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.service.spec.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/spec/job-assignment.service.spec.ts
@@ -87,6 +87,25 @@ describe('JobAssignmentService', () => {
       ).toHaveBeenCalledWith(command);
       expect(result).toEqual({ assignment_id: '123' });
     });
+
+    it('handles errors when updating cached assignments', async () => {
+      const mockResult = {
+        assignment_id: '123',
+      };
+
+      const command = jobAssignmentCommandFixture;
+      (
+        exchangeOracleGatewayMock.postNewJobAssignment as jest.Mock
+      ).mockResolvedValue(mockResult);
+
+      (
+        exchangeOracleGatewayMock.fetchAssignedJobs as jest.Mock
+      ).mockRejectedValueOnce(new Error('Unhandled error'));
+
+      const result = await service.processJobAssignment(command);
+
+      expect(result).toEqual(mockResult);
+    });
   });
 
   describe('processGetAssignedJobs', () => {
@@ -225,6 +244,23 @@ describe('JobAssignmentService', () => {
       expect(exchangeOracleGatewayMock.resignAssignedJob).toHaveBeenCalledWith(
         command,
       );
+    });
+
+    it('handles errors when updating cached assignments', async () => {
+      const command = new ResignJobCommand();
+
+      const mockResult = { success: true };
+      (
+        exchangeOracleGatewayMock.resignAssignedJob as jest.Mock
+      ).mockResolvedValue(mockResult);
+
+      (
+        exchangeOracleGatewayMock.fetchAssignedJobs as jest.Mock
+      ).mockRejectedValueOnce(new Error('Unhandled error'));
+
+      const result = await service.resignJob(command);
+
+      expect(result).toEqual(mockResult);
     });
   });
 });


### PR DESCRIPTION
## Issue tracking
Fixes #2927 

## Context behind the change
When doing assign/resign job there is a background functionality to update existing assignments cache for the user. To do so it uses jwt token from the request and there can be situations when it's in time to perform main operation, but when updating the cache token expires and it leads to 401 error.

For `resignJob` we had an `await`, so when such error happened it was handled by global exception filter, but for `processJobAssignment` we didn't, so it led to the global unhandled rejection for the app
<img width="1124" alt="Screenshot 2024-12-17 at 15 16 21" src="https://github.com/user-attachments/assets/dd62b77f-82c4-4988-8249-dddec444077a" />

Taking into account that updating cache shouldn't affect the result of assign/resign for the user, now we will be running both in background and handle errors just with logging purpose. Didn't add `try..catch` to `updateAssignmentsCache` itself because it's used in `refreshAssigments` that expects errors to be thrown and handled in global filter.

## How has this been tested?
- [x] unit tests
- [x] reproduce locally with expired token and make sure that app doesn't crash 

## Release plan
Merge, deploy

## Potential risks; What to monitor; Rollback plan
N/A