### PR TITLE
[Job Launcher] Check that the user has a credit card during job creation

### DIFF
--- a/packages/apps/job-launcher/server/src/common/constants/errors.ts
+++ b/packages/apps/job-launcher/server/src/common/constants/errors.ts
@@ -5,6 +5,7 @@ export enum ErrorJob {
   NotFound = 'Job not found',
   NotCreated = 'Job has not been created',
   NotEnoughFunds = 'Not enough funds',
+  NotActiveCard = 'Credit card not found',
   ManifestNotFound = 'Manifest not found',
   ManifestValidationFailed = 'Manifest validation failed',
   ResultNotFound = 'Result not found',

--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.spec.ts
@@ -54,6 +54,7 @@ import { StatusEvent } from '@human-protocol/sdk/dist/graphql';
 import { ethers } from 'ethers';
 import { NetworkConfigService } from '../../common/config/network-config.service';
 import { QualificationService } from '../qualification/qualification.service';
+import { WhitelistService } from '../whitelist/whitelist.service';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -135,6 +136,7 @@ describe('CronJobService', () => {
         },
         { provide: StorageService, useValue: createMock<StorageService>() },
         { provide: PaymentService, useValue: createMock<PaymentService>() },
+        { provide: WhitelistService, useValue: createMock<WhitelistService>() },
         { provide: ConfigService, useValue: mockConfigService },
         {
           provide: RoutingProtocolService,

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.spec.ts
@@ -91,7 +91,7 @@ describe('JobController', () => {
       const result = await jobController.quickLaunch(jobDto, mockRequest);
 
       expect(mockJobService.createJob).toHaveBeenCalledWith(
-        mockRequest.user.id,
+        mockRequest.user,
         jobDto.requestType,
         jobDto,
       );
@@ -192,7 +192,7 @@ describe('JobController', () => {
         expect.any(Function),
       );
       expect(mockJobService.createJob).toHaveBeenCalledWith(
-        mockRequest.user.id,
+        mockRequest.user,
         JobRequestType.FORTUNE,
         jobFortuneDto,
       );
@@ -295,7 +295,7 @@ describe('JobController', () => {
         expect.any(Function),
       );
       expect(mockJobService.createJob).toHaveBeenCalledWith(
-        mockRequest.user.id,
+        mockRequest.user,
         JobRequestType.IMAGE_BOXES,
         jobCvatDto,
       );

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -85,7 +85,7 @@ export class JobController {
       MUTEX_TIMEOUT,
       async () => {
         return await this.jobService.createJob(
-          req.user.id,
+          req.user,
           data.requestType,
           data,
         );
@@ -125,7 +125,7 @@ export class JobController {
       MUTEX_TIMEOUT,
       async () => {
         return await this.jobService.createJob(
-          req.user.id,
+          req.user,
           JobRequestType.FORTUNE,
           data,
         );
@@ -164,7 +164,7 @@ export class JobController {
       { id: `user${req.user.id}` },
       MUTEX_TIMEOUT,
       async () => {
-        return await this.jobService.createJob(req.user.id, data.type, data);
+        return await this.jobService.createJob(req.user, data.type, data);
       },
     );
   }
@@ -205,7 +205,7 @@ export class JobController {
       MUTEX_TIMEOUT,
       async () => {
         return await this.jobService.createJob(
-          req.user.id,
+          req.user,
           JobRequestType.HCAPTCHA,
           data,
         );

--- a/packages/apps/job-launcher/server/src/modules/job/job.module.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.module.ts
@@ -17,6 +17,7 @@ import { WebhookEntity } from '../webhook/webhook.entity';
 import { WebhookRepository } from '../webhook/webhook.repository';
 import { MutexManagerService } from '../mutex/mutex-manager.service';
 import { QualificationModule } from '../qualification/qualification.module';
+import { WhitelistModule } from '../whitelist/whitelist.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { QualificationModule } from '../qualification/qualification.module';
     EncryptionModule,
     StorageModule,
     QualificationModule,
+    WhitelistModule,
   ],
   controllers: [JobController],
   providers: [

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -122,6 +122,8 @@ import { CronJobType } from '../../common/enums/cron-job';
 import { CronJobRepository } from '../cron-job/cron-job.repository';
 import { ModuleRef } from '@nestjs/core';
 import { QualificationService } from '../qualification/qualification.service';
+import { WhitelistService } from '../whitelist/whitelist.service';
+import { UserEntity } from '../user/user.entity';
 
 @Injectable()
 export class JobService {
@@ -144,6 +146,7 @@ export class JobService {
     private readonly routingProtocolService: RoutingProtocolService,
     private readonly storageService: StorageService,
     private readonly rateService: RateService,
+    private readonly whitelistService: WhitelistService,
     private moduleRef: ModuleRef,
     @Inject(Encryption) private readonly encryption: Encryption,
     private readonly qualificationService: QualificationService,
@@ -772,12 +775,12 @@ export class JobService {
   }
 
   public async createJob(
-    userId: number,
-    jobRequestType: JobRequestType,
+    user: UserEntity,
+    requestType: JobRequestType,
     dto: CreateJob,
   ): Promise<number> {
     let { chainId, reputationOracle, exchangeOracle, recordingOracle } = dto;
-    if (!Object.values(JobRequestType).includes(jobRequestType)) {
+    if (!Object.values(JobRequestType).includes(requestType)) {
       throw new ControlledError(
         ErrorJob.InvalidRequestType,
         HttpStatus.BAD_REQUEST,
@@ -788,11 +791,25 @@ export class JobService {
     chainId = chainId || this.routingProtocolService.selectNetwork();
     this.web3Service.validateChainId(chainId);
 
+    // Check if not whitelisted user has an active payment method
+    const whitelisted = await this.whitelistService.isUserWhitelisted(user.id);
+    if (!whitelisted) {
+      if (
+        !(await this.paymentService.getDefaultPaymentMethod(
+          user.stripeCustomerId,
+        ))
+      )
+        throw new ControlledError(
+          ErrorJob.NotActiveCard,
+          HttpStatus.BAD_REQUEST,
+        );
+    }
+
     // Select oracles
     if (!reputationOracle || !exchangeOracle || !recordingOracle) {
       const selectedOracles = await this.routingProtocolService.selectOracles(
         chainId,
-        jobRequestType,
+        requestType,
       );
 
       exchangeOracle = exchangeOracle || selectedOracles.exchangeOracle;
@@ -802,7 +819,7 @@ export class JobService {
       // Validate if all oracles are provided
       await this.routingProtocolService.validateOracles(
         chainId,
-        jobRequestType,
+        requestType,
         reputationOracle,
         exchangeOracle,
         recordingOracle,
@@ -829,10 +846,10 @@ export class JobService {
 
     const rate = await this.rateService.getRate(Currency.USD, TokenId.HMT);
     const { calculateFundAmount, createManifest } =
-      this.createJobSpecificActions[jobRequestType];
+      this.createJobSpecificActions[requestType];
 
     const userBalance = await this.paymentService.getUserBalance(
-      userId,
+      user.id,
       div(1, rate),
     );
     const feePercentage = Number(
@@ -901,12 +918,12 @@ export class JobService {
     } else {
       const manifestOrigin = await createManifest(
         dto,
-        jobRequestType,
+        requestType,
         tokenFundAmount,
       );
 
       const { url, hash } = await this.uploadManifest(
-        jobRequestType,
+        requestType,
         chainId,
         manifestOrigin,
       );
@@ -919,8 +936,8 @@ export class JobService {
     jobEntity.reputationOracle = reputationOracle;
     jobEntity.exchangeOracle = exchangeOracle;
     jobEntity.recordingOracle = recordingOracle;
-    jobEntity.userId = userId;
-    jobEntity.requestType = jobRequestType;
+    jobEntity.userId = user.id;
+    jobEntity.requestType = requestType;
     jobEntity.fee = tokenFee;
     jobEntity.fundAmount = tokenFundAmount;
     jobEntity.status = JobStatus.PENDING;
@@ -929,7 +946,7 @@ export class JobService {
     jobEntity = await this.jobRepository.createUnique(jobEntity);
 
     const paymentEntity = new PaymentEntity();
-    paymentEntity.userId = userId;
+    paymentEntity.userId = user.id;
     paymentEntity.jobId = jobEntity.id;
     paymentEntity.source = PaymentSource.BALANCE;
     paymentEntity.type = PaymentType.WITHDRAWAL;

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
@@ -639,9 +639,7 @@ export class PaymentService {
     });
   }
 
-  private async getDefaultPaymentMethod(
-    customerId: string,
-  ): Promise<string | null> {
+  async getDefaultPaymentMethod(customerId: string): Promise<string | null> {
     if (!customerId) {
       throw new ControlledError(
         ErrorPayment.CustomerNotFound,


### PR DESCRIPTION
## Issue tracking
#2931

## Context behind the change
Check that the user has a credit card during job creation, so we can slash him in case of abuse.
This check does not apply to whitelisted users

## How has this been tested?
Deployed locally and launched tests

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None