### PR TITLE
[Reputation Oracle] Added role to reputation endpoint

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.dto.ts
@@ -84,4 +84,8 @@ export class ReputationDto {
   @IsEnumCaseInsensitive(ReputationLevel)
   @Transform(({ value }) => Number(value))
   reputation: ReputationLevel;
+
+  @ApiProperty({ enum: ReputationEntityType })
+  @IsEnumCaseInsensitive(ReputationEntityType)
+  role: ReputationEntityType;
 }

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
@@ -382,6 +382,7 @@ describe('ReputationService', () => {
       const reputationEntity: Partial<ReputationEntity> = {
         address,
         reputationPoints: 1,
+        type: ReputationEntityType.RECORDING_ORACLE,
         save: jest.fn(),
       };
 
@@ -427,6 +428,7 @@ describe('ReputationService', () => {
       const reputationEntity: Partial<ReputationEntity> = {
         address,
         reputationPoints: 1,
+        type: ReputationEntityType.RECORDING_ORACLE,
         save: jest.fn(),
       };
 
@@ -447,6 +449,7 @@ describe('ReputationService', () => {
       const reputationEntity: Partial<ReputationEntity> = {
         address,
         reputationPoints: 701,
+        type: ReputationEntityType.RECORDING_ORACLE,
         save: jest.fn(),
       };
 
@@ -496,6 +499,7 @@ describe('ReputationService', () => {
         chainId,
         address,
         reputationPoints: 1,
+        type: ReputationEntityType.RECORDING_ORACLE,
       };
 
       jest
@@ -508,6 +512,7 @@ describe('ReputationService', () => {
         chainId,
         address,
         reputation: ReputationLevel.HIGH,
+        role: ReputationEntityType.REPUTATION_ORACLE,
       };
 
       expect(result).toEqual(resultReputation);
@@ -519,6 +524,7 @@ describe('ReputationService', () => {
         chainId,
         address: NOT_ORACLE_ADDRESS,
         reputationPoints: 1,
+        type: ReputationEntityType.RECORDING_ORACLE,
       };
 
       jest
@@ -534,6 +540,7 @@ describe('ReputationService', () => {
         chainId,
         address: NOT_ORACLE_ADDRESS,
         reputation: ReputationLevel.LOW,
+        role: ReputationEntityType.RECORDING_ORACLE,
       };
 
       expect(
@@ -553,6 +560,7 @@ describe('ReputationService', () => {
         chainId,
         address,
         reputationPoints: 1,
+        type: ReputationEntityType.RECORDING_ORACLE,
       };
 
       jest
@@ -565,6 +573,7 @@ describe('ReputationService', () => {
         chainId,
         address,
         reputation: ReputationLevel.LOW,
+        role: ReputationEntityType.RECORDING_ORACLE,
       };
 
       expect(reputationRepository.findByChainIdAndTypes).toHaveBeenCalled();

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -346,6 +346,7 @@ export class ReputationService {
         chainId,
         address,
         reputation: ReputationLevel.HIGH,
+        role: ReputationEntityType.REPUTATION_ORACLE,
       };
     }
 
@@ -366,6 +367,7 @@ export class ReputationService {
       chainId: reputationEntity.chainId,
       address: reputationEntity.address,
       reputation: this.getReputationLevel(reputationEntity.reputationPoints),
+      role: reputationEntity.type,
     };
   }
 
@@ -404,6 +406,7 @@ export class ReputationService {
       chainId: reputation.chainId,
       address: reputation.address,
       reputation: this.getReputationLevel(reputation.reputationPoints),
+      role: reputation.type,
     }));
   }
 }


### PR DESCRIPTION
## Issue tracking
The progress of this issue is being tracked in [Reputation Oracle] Add role to /reputation
[#2916](https://github.com/humanprotocol/human-protocol/issues/2916). The origin of this issue stems from a feature request to include the user role in the `GET /reputation` API response.

## Context behind the change
This change updates the `GET /reputation` API response to include the `role` field for users.

Key changes:
- Modified the response schema for `GET /reputation` to include the `role` field.
- Updated service method.
- Updated unit tests to reflect the change.

## How has this been tested?
- Unit tests: Updated test cases to validate the presence and correctness of the `role` field in the API response.
- Manual testing: Verified the response structure and data in local and staging environments.