### PR TITLE
[Reputation Oracle] refactoring: exception handling for `kyc` module

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -116,16 +116,6 @@ export enum ErrorSendGrid {
   InvalidApiKey = 'Invalid SendGrid API key',
 }
 
-export enum ErrorKyc {
-  NotFound = 'KYC session not found',
-  AlreadyApproved = 'KYC session already approved',
-  VerificationInProgress = 'KYC session verification in progress',
-  Declined = 'KYC session declined',
-  InvalidKycProviderAPIResponse = 'Invalid KYC provider API response',
-  InvalidWebhookSecret = 'Invalid webhook secret',
-  CountryNotSet = 'Сountry is not set for the user',
-}
-
 /**
  * Represents error messages associated with a cron job.
  */

--- a/packages/apps/reputation-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/exceptions/exception.filter.ts
@@ -4,6 +4,7 @@ import {
   ExceptionFilter as IExceptionFilter,
   HttpStatus,
   Logger,
+  HttpException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { DatabaseError } from '../errors/database';
@@ -34,6 +35,11 @@ export class ExceptionFilter implements IExceptionFilter {
         `Database error: ${exception.message}`,
         exception.stack,
       );
+      // Temp hack for the in progress exception handling refactoring
+    } else if (exception instanceof HttpException) {
+      return response
+        .status(exception.getStatus())
+        .json(exception.getResponse());
     } else {
       if (exception.statusCode === HttpStatus.BAD_REQUEST) {
         status = exception.statusCode;

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
@@ -13,6 +13,7 @@ import {
   HttpCode,
   Post,
   Req,
+  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../common/guards';
@@ -20,9 +21,11 @@ import { RequestWithUser } from '../../common/types';
 import { KycSessionDto, KycSignedAddressDto, KycStatusDto } from './kyc.dto';
 import { KycService } from './kyc.service';
 import { KycWebhookAuthGuard } from '../../common/guards/kyc-webhook.auth';
+import { KycErrorFilter } from './kyc.error.filter';
 
 @ApiTags('Kyc')
 @Controller('/kyc')
+@UseFilters(KycErrorFilter)
 export class KycController {
   constructor(private readonly kycService: KycService) {}
 

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.error.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.error.filter.ts
@@ -1,0 +1,34 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+import { KycError, KycErrorMessage } from './kyc.error';
+
+@Catch(KycError)
+export class KycErrorFilter implements ExceptionFilter {
+  private logger = new Logger(KycErrorFilter.name);
+  catch(exception: KycError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    let status = HttpStatus.BAD_REQUEST;
+
+    if (exception.message === KycErrorMessage.INVALID_WEBHOOK_SIGNATURE) {
+      status = HttpStatus.UNAUTHORIZED;
+    }
+
+    this.logger.error(exception.message, exception.stack, exception.userId);
+
+    return response.status(status).json({
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.error.ts
@@ -1,0 +1,23 @@
+import { BaseError } from '../../common/errors/base';
+
+export enum KycErrorMessage {
+  NOT_FOUND = 'KYC session not found',
+  ALREADY_APPROVED = 'KYC session already approved',
+  VERIFICATION_IN_PROGRESS = 'KYC session verification in progress',
+  DECLINED = 'KYC session declined',
+  INVALID_KYC_PROVIDER_API_RESPONSE = 'Invalid KYC provider API response',
+  INVALID_WEBHOOK_SIGNATURE = 'Invalid webhook signature',
+  COUNTRY_NOT_SET = 'Сountry is not set for the user',
+  NO_WALLET_ADDRESS_REGISTERED = 'No wallet address registered on your account',
+  KYC_NOT_APPROVED = 'KYC not approved',
+}
+
+export class KycError extends BaseError {
+  // Despite the fact that we always provide userId, this field is optional due to the tests structure.
+  // TODO: Remove optional once tests are rewritten.
+  userId?: number;
+  constructor(message: KycErrorMessage, userId?: number) {
+    super(message);
+    this.userId = userId;
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.spec.ts
@@ -10,13 +10,13 @@ import { MOCK_ADDRESS, mockConfig } from '../../../test/constants';
 import { HCaptchaConfigService } from '../../common/config/hcaptcha-config.service';
 import { NetworkConfigService } from '../../common/config/network-config.service';
 import { KycConfigService } from '../../common/config/kyc-config.service';
-import { ErrorKyc, ErrorUser } from '../../common/constants/errors';
 import { KycStatus } from '../../common/enums/user';
 import { ControlledError } from '../../common/errors/controlled';
 import { Web3Service } from '../web3/web3.service';
 import { KycEntity } from './kyc.entity';
 import { KycRepository } from './kyc.repository';
 import { KycService } from './kyc.service';
+import { KycError, KycErrorMessage } from './kyc.error';
 
 describe('Kyc Service', () => {
   let kycService: KycService;
@@ -136,9 +136,7 @@ describe('Kyc Service', () => {
 
       await expect(
         kycService.initSession(mockUserEntity as any),
-      ).rejects.toThrow(
-        new ControlledError(ErrorKyc.AlreadyApproved, HttpStatus.BAD_REQUEST),
-      );
+      ).rejects.toThrow(new KycError(KycErrorMessage.ALREADY_APPROVED));
     });
 
     it("Should throw an error if user already has an active Kyc session, but it's in review", async () => {
@@ -152,12 +150,7 @@ describe('Kyc Service', () => {
 
       await expect(
         kycService.initSession(mockUserEntity as any),
-      ).rejects.toThrow(
-        new ControlledError(
-          ErrorKyc.VerificationInProgress,
-          HttpStatus.BAD_REQUEST,
-        ),
-      );
+      ).rejects.toThrow(new KycError(KycErrorMessage.VERIFICATION_IN_PROGRESS));
     });
 
     it("Should throw an error if user already has an active Kyc session, but it's declined", async () => {
@@ -172,12 +165,7 @@ describe('Kyc Service', () => {
 
       await expect(
         kycService.initSession(mockUserEntity as any),
-      ).rejects.toThrow(
-        new ControlledError(
-          `${ErrorKyc.Declined}. Reason: ${mockUserEntity.kyc.message}`,
-          HttpStatus.BAD_REQUEST,
-        ),
-      );
+      ).rejects.toThrow(new KycError(KycErrorMessage.DECLINED));
     });
 
     it('Should start a Kyc session for the user', async () => {
@@ -271,10 +259,7 @@ describe('Kyc Service', () => {
       await expect(
         kycService.getSignedAddress(mockUserEntity as any),
       ).rejects.toThrow(
-        new ControlledError(
-          ErrorUser.NoWalletAddresRegistered,
-          HttpStatus.BAD_REQUEST,
-        ),
+        new KycError(KycErrorMessage.NO_WALLET_ADDRESS_REGISTERED),
       );
     });
 
@@ -288,9 +273,7 @@ describe('Kyc Service', () => {
 
       await expect(
         kycService.getSignedAddress(mockUserEntity as any),
-      ).rejects.toThrow(
-        new ControlledError(ErrorUser.KycNotApproved, HttpStatus.BAD_REQUEST),
-      );
+      ).rejects.toThrow(new KycError(KycErrorMessage.KYC_NOT_APPROVED));
     });
 
     it('Should return the signed address', async () => {


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->
Part of the #2928 

## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->

1. Created a module specific error: `KycError`.
2. Module specific error and filter moved to the `kyc` module.
3. Guard now directly throws an httpexception simply because it happens even before request comes to the controller. Added logging.

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

Locally

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

N/A

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->

Nothing specific but it would good to monitor exceptions from `kyc` module for a while.