### PR TITLE
[Reputation Oracle] Error handling for `reputation`module

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -22,14 +22,6 @@ export enum ErrorEscrowCompletion {
 }
 
 /**
- * Represents error messages related to reputation.
- */
-export enum ErrorReputation {
-  NotFound = 'Reputation not found',
-  NotCreated = 'Reputation has not been created',
-}
-
-/**
  * Represents error messages related to credential.
  */
 export enum ErrorCredential {

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.controller.ts
@@ -14,12 +14,12 @@ import {
   ReputationGetParamsDto,
   ReputationGetQueryDto,
 } from './reputation.dto';
-import { KycErrorFilter } from '../kyc/kyc.error.filter';
+import { ReputationErrorFilter } from './reputation.error.filter';
 
 @Public()
 @ApiTags('Reputation')
 @Controller('reputation')
-@UseFilters(KycErrorFilter)
+@UseFilters(ReputationErrorFilter)
 export class ReputationController {
   constructor(private readonly reputationService: ReputationService) {}
 

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseFilters } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -14,10 +14,12 @@ import {
   ReputationGetParamsDto,
   ReputationGetQueryDto,
 } from './reputation.dto';
+import { KycErrorFilter } from '../kyc/kyc.error.filter';
 
 @Public()
 @ApiTags('Reputation')
 @Controller('reputation')
+@UseFilters(KycErrorFilter)
 export class ReputationController {
   constructor(private readonly reputationService: ReputationService) {}
 

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.filter.ts
@@ -1,0 +1,38 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+import { ReputationError, ReputationErrorMessage } from './reputation.error';
+
+@Catch(ReputationError)
+export class ReputationErrorFilter implements ExceptionFilter {
+  private logger = new Logger(ReputationErrorFilter.name);
+  catch(exception: ReputationError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    let status = HttpStatus.BAD_REQUEST;
+
+    if (exception.message === ReputationErrorMessage.NOT_FOUND) {
+      status = HttpStatus.NOT_FOUND;
+    }
+
+    this.logger.error(
+      exception.message,
+      exception.stack,
+      exception.chainId,
+      exception.address,
+    );
+
+    return response.status(status).json({
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.filter.ts
@@ -25,8 +25,7 @@ export class ReputationErrorFilter implements ExceptionFilter {
     this.logger.error(
       exception.message,
       exception.stack,
-      exception.chainId,
-      exception.address,
+      `${exception.chainId} - ${exception.address}`,
     );
 
     return response.status(status).json({

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.error.ts
@@ -1,0 +1,20 @@
+import { ChainId } from '@human-protocol/sdk';
+import { BaseError } from '../../common/errors/base';
+
+export enum ReputationErrorMessage {
+  NOT_FOUND = 'Reputation not found',
+}
+
+export class ReputationError extends BaseError {
+  chainId: ChainId;
+  address: string;
+  constructor(
+    message: ReputationErrorMessage,
+    chainId: ChainId,
+    address: string,
+  ) {
+    super(message);
+    this.chainId = chainId;
+    this.address = address;
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.spec.ts
@@ -24,11 +24,9 @@ import {
 import { ConfigModule, ConfigService, registerAs } from '@nestjs/config';
 import { Web3Service } from '../web3/web3.service';
 import { StorageService } from '../storage/storage.service';
-import { ErrorManifest, ErrorResults } from '../../common/constants/errors';
 import { EscrowClient } from '@human-protocol/sdk';
 import { ReputationConfigService } from '../../common/config/reputation-config.service';
-import { ControlledError } from '../../common/errors/controlled';
-import { HttpStatus } from '@nestjs/common';
+import { ReputationError, ReputationErrorMessage } from './reputation.error';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -107,54 +105,7 @@ describe('ReputationService', () => {
     const chainId = ChainId.LOCALHOST;
     const escrowAddress = 'mockEscrowAddress';
 
-    it('should handle manifest URL not found', async () => {
-      (EscrowClient.build as any).mockImplementation(() => ({
-        getManifestUrl: jest.fn().mockResolvedValue(null),
-      }));
-
-      await expect(
-        reputationService.assessReputationScores(chainId, escrowAddress),
-      ).rejects.toThrow(
-        new ControlledError(
-          ErrorManifest.ManifestUrlDoesNotExist,
-          HttpStatus.BAD_REQUEST,
-        ),
-      );
-    });
-
     describe('fortune', () => {
-      it('should handle no verified results', async () => {
-        (EscrowClient.build as any).mockImplementation(() => ({
-          getJobLauncherAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-          getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-          getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-          getResultsUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
-          getManifestUrl: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-        }));
-
-        const manifest = {
-          requestType: JobRequestType.FORTUNE,
-        };
-
-        jest
-          .spyOn(storageService, 'downloadJsonLikeData')
-          .mockResolvedValueOnce(manifest) // Mock manifest
-          .mockResolvedValueOnce([]); // Mock final results
-
-        jest
-          .spyOn(reputationService, 'increaseReputation')
-          .mockResolvedValueOnce();
-
-        await expect(
-          reputationService.assessReputationScores(chainId, escrowAddress),
-        ).rejects.toThrow(
-          new ControlledError(
-            ErrorResults.NoResultsHaveBeenVerified,
-            HttpStatus.BAD_REQUEST,
-          ),
-        );
-      });
-
       it('should assess reputation scores', async () => {
         const manifest = {
           requestType: JobRequestType.FORTUNE,
@@ -227,34 +178,14 @@ describe('ReputationService', () => {
         job_bounty: '10',
       };
 
-      it('should handle annotation meta does not exist', async () => {
-        (EscrowClient.build as any).mockImplementation(() => ({
-          getJobLauncherAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-          getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-          getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-          getResultsUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
-          getIntermediateResultsUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
-          getManifestUrl: jest.fn().mockResolvedValue(MOCK_ADDRESS),
-        }));
-
-        jest
-          .spyOn(storageService, 'downloadJsonLikeData')
-          .mockResolvedValueOnce(manifest) // Mock manifest
-          .mockResolvedValueOnce([]); // Mock final results
-
-        jest
-          .spyOn(reputationService, 'increaseReputation')
-          .mockResolvedValueOnce();
-
-        await expect(
-          reputationService.assessReputationScores(chainId, escrowAddress),
-        ).rejects.toThrow(
-          new ControlledError(
-            ErrorResults.NoAnnotationsMetaFound,
-            HttpStatus.BAD_REQUEST,
-          ),
-        );
-      });
+      (EscrowClient.build as any).mockImplementation(() => ({
+        getJobLauncherAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+        getExchangeOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+        getRecordingOracleAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+        getResultsUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
+        getIntermediateResultsUrl: jest.fn().mockResolvedValue(MOCK_FILE_URL),
+        getManifestUrl: jest.fn().mockResolvedValue(MOCK_ADDRESS),
+      }));
 
       it('should assess reputation scores', async () => {
         const annotationMeta = {
@@ -548,6 +479,19 @@ describe('ReputationService', () => {
       ).toHaveBeenCalledWith(NOT_ORACLE_ADDRESS, chainId);
 
       expect(result).toEqual(resultReputation);
+    });
+
+    it('should handle reputation not found', async () => {
+      const NOT_ORACLE_ADDRESS = '0x0000000000000000000000000000000000000000';
+      jest
+        .spyOn(reputationRepository, 'findOneByAddressAndChainId')
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        reputationService.getReputation(chainId, NOT_ORACLE_ADDRESS),
+      ).rejects.toThrow(
+        new ReputationError(ReputationErrorMessage.NOT_FOUND, chainId, address),
+      );
     });
   });
 

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ChainId } from '@human-protocol/sdk';
 import {
   CVAT_VALIDATION_META_FILENAME,
@@ -11,11 +11,6 @@ import {
   SolutionError,
 } from '../../common/enums';
 import { ReputationRepository } from './reputation.repository';
-import {
-  ErrorManifest,
-  ErrorReputation,
-  ErrorResults,
-} from '../../common/constants/errors';
 import { ReputationDto } from './reputation.dto';
 import { StorageService } from '../storage/storage.service';
 import { Web3Service } from '../web3/web3.service';
@@ -30,7 +25,7 @@ import { getRequestType } from '../../common/utils';
 import { CvatManifestDto } from '../../common/dto/manifest';
 import { ReputationConfigService } from '../../common/config/reputation-config.service';
 import { ReputationEntity } from './reputation.entity';
-import { ControlledError } from '../../common/errors/controlled';
+import { ReputationError, ReputationErrorMessage } from './reputation.error';
 
 @Injectable()
 export class ReputationService {
@@ -58,12 +53,6 @@ export class ReputationService {
     const escrowClient = await EscrowClient.build(signer);
 
     const manifestUrl = await escrowClient.getManifestUrl(escrowAddress);
-    if (!manifestUrl) {
-      throw new ControlledError(
-        ErrorManifest.ManifestUrlDoesNotExist,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
 
     const manifest =
       await this.storageService.downloadJsonLikeData(manifestUrl);
@@ -171,13 +160,6 @@ export class ReputationService {
     const finalResults =
       await this.storageService.downloadJsonLikeData(finalResultsUrl);
 
-    if (finalResults.length === 0) {
-      throw new ControlledError(
-        ErrorResults.NoResultsHaveBeenVerified,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
     // Assess reputation scores for workers based on the final results of a job.
     // Decreases or increases worker reputation based on the success or failure of their contributions.
     await Promise.all(
@@ -215,14 +197,6 @@ export class ReputationService {
       await this.storageService.downloadJsonLikeData(
         `${intermediateResultsUrl}/${CVAT_VALIDATION_META_FILENAME}`,
       );
-
-    // If annotation meta does not exist
-    if (annotations && Array.isArray(annotations) && annotations.length === 0) {
-      throw new ControlledError(
-        ErrorResults.NoAnnotationsMetaFound,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
 
     // Assess reputation scores for workers based on the annoation quality.
     // Decreases or increases worker reputation based on comparison annoation quality to minimum threshold.
@@ -357,9 +331,10 @@ export class ReputationService {
       );
 
     if (!reputationEntity) {
-      throw new ControlledError(
-        ErrorReputation.NotFound,
-        HttpStatus.BAD_REQUEST,
+      throw new ReputationError(
+        ReputationErrorMessage.NOT_FOUND,
+        chainId,
+        address,
       );
     }
 


### PR DESCRIPTION
## Issue tracking
#2928

## Context behind the change
- Refactored error handling for reputation module.
- Minor fixes in business logic for unused errors

## How has this been tested?
1. Setup a local postgres database, apply migrations.
2. Deploy reputation oracle locally.
3. Get reputation of any address not used for any process. 

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None