### PR TITLE
[Reputation Oracle] refactor: auth module error handling

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -22,15 +22,6 @@ export enum ErrorEscrowCompletion {
 }
 
 /**
- * Represents error messages related to credential.
- */
-export enum ErrorCredential {
-  NotFound = 'Credential not found',
-  NotCreated = 'Credential has not been created',
-  InvalidCredential = 'Invalid credential',
-}
-
-/**
  * Represents error messages related to results.
  */
 export enum ErrorResults {
@@ -68,36 +59,17 @@ export enum ErrorUser {
   AlreadyAssigned = 'User already has an address assigned.',
   NoWalletAddresRegistered = 'No wallet address registered on your account.',
   KycNotApproved = 'KYC not approved.',
-  UserNotActive = 'User not active',
   LabelingEnableFailed = 'Failed to enable labeling for this account.',
   InvalidType = 'User has invalid type.',
-  DuplicatedEmail = 'The email you are trying to use already exists. Please check that the email is correct or use a different email.',
   DuplicatedAddress = 'The address you are trying to use already exists. Please check that the address is correct or use a different address.',
 }
 
 /**
- * Represents error messages related to auth.
+ * Represents error messages related to captcha.
  */
-export enum ErrorAuth {
-  NotFound = 'Auth not found',
-  InvalidEmailOrPassword = 'Invalid email or password',
-  RefreshTokenHasExpired = 'Refresh token has expired',
-  TokenExpired = 'Token has expired',
-  UserNotActive = 'User not active',
-  InvalidSignature = 'Invalid signature',
-  InvalidRole = 'Invalid role in KVStore',
-  PasswordIsNotStrongEnough = 'Password is not strong enough. Password must be at least 8 characters long and contain 1 upper, 1 lowercase, 1 number and 1 special character. (!@#$%^&*()_+={}|\'"/`[]:;<>,.?~-])',
-  InvalidToken = 'Invalid token',
-  InvalidJobType = 'Invalid operator job type',
-  InvalidUrl = 'Invalid operator URL',
-  InvalidFee = 'Invalid operator fee',
-}
-
-/**
- * Represents error messages related to token.
- */
-export enum ErrorToken {
-  NotFound = 'Token not found',
+export enum ErrorCapthca {
+  InvalidToken = 'Invalid captcha token provided',
+  VerificationFailed = 'Captcha verification failed',
 }
 
 /**

--- a/packages/apps/reputation-oracle/server/src/common/constants/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/index.ts
@@ -5,6 +5,7 @@ export const NS = 'hmt';
 export const RETRIES_COUNT_THRESHOLD = 3;
 export const INITIAL_REPUTATION = 0;
 export const JWT_PREFIX = 'bearer ';
+export const JWT_STRATEGY_NAME = 'jwt-http';
 export const SENDGRID_API_KEY_REGEX =
   /^SG\.[A-Za-z0-9-_]{22}\.[A-Za-z0-9-_]{43}$/;
 export const SENDGRID_API_KEY_DISABLED = 'sendgrid-disabled';

--- a/packages/apps/reputation-oracle/server/src/common/guards/jwt.auth.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/jwt.auth.ts
@@ -7,9 +7,13 @@ import {
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { ControlledError } from '../errors/controlled';
+import { JWT_STRATEGY_NAME } from '../constants';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt-http') implements CanActivate {
+export class JwtAuthGuard
+  extends AuthGuard(JWT_STRATEGY_NAME)
+  implements CanActivate
+{
   constructor(private readonly reflector: Reflector) {
     super();
   }

--- a/packages/apps/reputation-oracle/server/src/common/utils/signature.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/common/utils/signature.spec.ts
@@ -1,6 +1,6 @@
 import { verifySignature, recoverSigner, signMessage } from './signature';
 import { MOCK_ADDRESS, MOCK_PRIVATE_KEY } from '../../../test/constants';
-import { ErrorAuth, ErrorSignature } from '../constants/errors';
+import { ErrorSignature } from '../constants/errors';
 import { ControlledError } from '../errors/controlled';
 import { HttpStatus } from '@nestjs/common';
 
@@ -13,7 +13,7 @@ jest.doMock('ethers', () => {
             return 'recovered-address';
           } else {
             throw new ControlledError(
-              ErrorAuth.InvalidSignature,
+              ErrorSignature.InvalidSignature,
               HttpStatus.UNAUTHORIZED,
             );
           }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -81,11 +81,8 @@ export class AuthJwtController {
     status: 400,
     description: 'Bad Request. Invalid input parameters.',
   })
-  public async signup(
-    @Body() data: UserCreateDto,
-    @Ip() ip: string,
-  ): Promise<void> {
-    await this.authService.signup(data, ip);
+  public async signup(@Body() data: UserCreateDto): Promise<void> {
+    await this.authService.signup(data);
     return;
   }
 
@@ -110,8 +107,8 @@ export class AuthJwtController {
     status: 404,
     description: 'Not Found. Could not find the requested content.',
   })
-  public signin(@Body() data: SignInDto, @Ip() ip: string): Promise<AuthDto> {
-    return this.authService.signin(data, ip);
+  public signin(@Body() data: SignInDto): Promise<AuthDto> {
+    return this.authService.signin(data);
   }
 
   @Public()
@@ -230,11 +227,8 @@ export class AuthJwtController {
     status: 404,
     description: 'Not Found. Could not find the requested content.',
   })
-  public restorePassword(
-    @Body() data: RestorePasswordDto,
-    @Ip() ip: string,
-  ): Promise<void> {
-    return this.authService.restorePassword(data, ip);
+  public restorePassword(@Body() data: RestorePasswordDto): Promise<void> {
+    return this.authService.restorePassword(data);
   }
 
   @Public()

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -16,6 +16,7 @@ import {
   UseInterceptors,
   Logger,
   Ip,
+  UseFilters,
 } from '@nestjs/common';
 import { Public } from '../../common/decorators';
 import { UserCreateDto } from '../user/user.dto';
@@ -35,6 +36,7 @@ import { JwtAuthGuard } from '../../common/guards';
 import { RequestWithUser } from '../../common/types';
 import { TokenRepository } from './token.repository';
 import { TokenType } from './token.entity';
+import { AuthControllerErrorsFilter } from './auth.error-filter';
 
 @ApiTags('Auth')
 @ApiResponse({
@@ -54,6 +56,7 @@ import { TokenType } from './token.entity';
   description: 'Unprocessable entity.',
 })
 @Controller('/auth')
+@UseFilters(AuthControllerErrorsFilter)
 export class AuthJwtController {
   private readonly logger = new Logger(AuthJwtController.name);
 

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.error-filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.error-filter.ts
@@ -29,7 +29,7 @@ export class AuthControllerErrorsFilter implements ExceptionFilter {
 
     let logContext: string | undefined;
     if (exception instanceof DuplicatedUserError) {
-      status = HttpStatus.BAD_REQUEST;
+      status = HttpStatus.CONFLICT;
       logContext = exception.email;
     } else if (exception instanceof InvalidOperatorSignupDataError) {
       status = HttpStatus.BAD_REQUEST;

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.error-filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.error-filter.ts
@@ -1,0 +1,47 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+import {
+  AuthError,
+  DuplicatedUserError,
+  InvalidOperatorSignupDataError,
+} from './auth.errors';
+
+type AuthControllerError =
+  | AuthError
+  | DuplicatedUserError
+  | InvalidOperatorSignupDataError;
+
+@Catch(AuthError, DuplicatedUserError)
+export class AuthControllerErrorsFilter implements ExceptionFilter {
+  private logger = new Logger(AuthControllerErrorsFilter.name);
+  catch(exception: AuthControllerError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    let status = HttpStatus.UNAUTHORIZED;
+
+    let logContext: string | undefined;
+    if (exception instanceof DuplicatedUserError) {
+      status = HttpStatus.BAD_REQUEST;
+      logContext = exception.email;
+    } else if (exception instanceof InvalidOperatorSignupDataError) {
+      status = HttpStatus.BAD_REQUEST;
+      logContext = exception.detail;
+    }
+
+    this.logger.error(exception.message, exception.stack, logContext);
+
+    return response.status(status).json({
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.error-filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.error-filter.ts
@@ -18,7 +18,7 @@ type AuthControllerError =
   | DuplicatedUserError
   | InvalidOperatorSignupDataError;
 
-@Catch(AuthError, DuplicatedUserError)
+@Catch(AuthError, DuplicatedUserError, InvalidOperatorSignupDataError)
 export class AuthControllerErrorsFilter implements ExceptionFilter {
   private logger = new Logger(AuthControllerErrorsFilter.name);
   catch(exception: AuthControllerError, host: ArgumentsHost) {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.errors.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.errors.ts
@@ -1,0 +1,53 @@
+import { ErrorCapthca } from '../../common/constants/errors';
+import { BaseError } from '../../common/errors/base';
+
+export enum AuthErrorMessage {
+  INVALID_CREDENTIALS = 'Invalid email or password',
+  INVALID_REFRESH_TOKEN = 'Refresh token is not valid',
+  REFRESH_TOKEN_EXPIRED = 'Refresh token expired',
+  INVALID_WEB3_SIGNATURE = 'Invalid signature',
+}
+
+export class AuthError extends BaseError {
+  constructor(message: AuthErrorMessage | ErrorCapthca) {
+    super(message);
+  }
+}
+
+export class InvalidOperatorSignupDataError extends BaseError {
+  constructor(public readonly detail: string) {
+    super('Invalid operator signup data');
+  }
+}
+
+export class InvalidOperatorRoleError extends InvalidOperatorSignupDataError {
+  constructor(role: string) {
+    super(`Invalid role: ${role}`);
+  }
+}
+
+export class InvalidOperatorFeeError extends InvalidOperatorSignupDataError {
+  constructor(fee: string) {
+    super(`Invalid fee: ${fee}`);
+  }
+}
+
+export class InvalidOperatorUrlError extends InvalidOperatorSignupDataError {
+  constructor(url: string) {
+    super(`Invalid url: ${url}`);
+  }
+}
+
+export class InvalidOperatorJobTypesError extends InvalidOperatorSignupDataError {
+  constructor(url: string) {
+    super(`Invalid job types: ${url}`);
+  }
+}
+
+export class DuplicatedUserError extends BaseError {
+  constructor(public readonly email: string) {
+    super(
+      'The email you are trying to use already exists. Please check that the email is correct or use a different email.',
+    );
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/credentials/credential.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/credentials/credential.service.ts
@@ -5,7 +5,7 @@ import { CredentialEntity } from './credential.entity';
 import { CredentialStatus } from '../../common/enums/credential';
 import { Web3Service } from '../web3/web3.service';
 import { verifySignature } from '../../common/utils/signature';
-import { ErrorAuth } from '../../common/constants/errors';
+import { ErrorSignature } from '../../common/constants/errors';
 import { ChainId, KVStoreClient } from '@human-protocol/sdk';
 import { SignatureType, Web3Env } from '../../common/enums/web3';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
@@ -142,7 +142,7 @@ export class CredentialService {
 
     if (!verifySignature(signatureBody.contents, signature, [workerAddress])) {
       throw new ControlledError(
-        ErrorAuth.InvalidSignature,
+        ErrorSignature.InvalidSignature,
         HttpStatus.UNAUTHORIZED,
       );
     }

--- a/packages/apps/reputation-oracle/server/test/constants.ts
+++ b/packages/apps/reputation-oracle/server/test/constants.ts
@@ -194,7 +194,8 @@ FjGp13DtiY8P2zNL5eMxGiMTp8xQJ7jC3HVZROqUOujcdLPglfE7b5n/Ao9TBwFO
 export const MOCK_PGP_PASSPHRASE = 'secure-passphrase';
 export const MOCK_EMAIL = 'test@example.com';
 export const MOCK_PASSWORD = 'password123';
-export const MOCK_HASHED_PASSWORD = 'hashedPassword';
+export const MOCK_HASHED_PASSWORD =
+  '$2b$12$Z02o9/Ay7CT0n99icApZYORH8iJI9VGtl3mju7d0c4SdDDujhSzOa';
 export const MOCK_ACCESS_TOKEN = 'access_token';
 export const MOCK_REFRESH_TOKEN = 'refresh_token';
 export const MOCK_ACCESS_TOKEN_HASHED = 'access_token_hashed';


### PR DESCRIPTION
## Issue tracking
Part of #2928

## Context behind the change
- refactored error handling of `auth` module.
- removed `getByCredentials` from `UserService` because in fact it did auth check and shouldn't live there; instead introduced `checkPasswordMatchesHash`  and use it for auth checks
- in methods where we send emails (e.g. forgotPassword) now we won't throw when user is not found, but just return; previously it was `ControlledError` with `204` status code, so result is expected to be the same

## How has this been tested?
- [x] unit tests
- [x] locally trigger `auth/signup`; make sure it can create user
- [x] locally trigger `auth/signup` with same email; make sure it returns duplicated error message and 409 code
- [x] locally trigger `auth/sigin` with valid password; make sure it returns jwt
- [x] locally trigger `auth/sigin` with invalid password; make sure it returns 400
- [x] locally trigger `user/exchange-oracle-registration` with invalid jwt; make sure it returns 401
- [x] locally trigger `user/exchange-oracle-registration` with valid jwt; make sure it returns 200

## Release plan
Simply merge & deploy

## Potential risks; What to monitor; Rollback plan
It might be that there is some client implicitly relying on returned error message/code that changed in this PR. To monitor it we can check logs.