### PR TITLE
[Reputation Oracle] Error handling for webhook module

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -1,17 +1,4 @@
 /**
- * Represents error messages related to webhook.
- */
-export enum ErrorWebhook {
-  NotFound = 'Webhook not found',
-  UrlNotFound = 'Webhook url not found',
-  NotCreated = 'Webhook has not been created',
-  InvalidEventType = 'Invalid event type',
-  NotSent = 'Webhook was not sent',
-  PendingProcessingFailed = 'Failed to process pending webhook',
-  PaidProcessingFailed = 'Failed to process paid webhook',
-}
-
-/**
  * Represents error messages related to escrow completion.
  */
 export enum ErrorEscrowCompletion {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -15,7 +15,6 @@ import {
   UseGuards,
   UseInterceptors,
   Logger,
-  Ip,
   UseFilters,
 } from '@nestjs/common';
 import { Public } from '../../common/decorators';

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -21,7 +21,6 @@ import { ErrorEscrowCompletion } from '../../common/constants/errors';
 import { ControlledError } from '../../common/errors/controlled';
 import { WebhookOutgoingService } from '../webhook/webhook-outgoing.service';
 import { isDuplicatedError } from '../../common/utils/database';
-import { WebhookErrorMessage } from '../webhook/webhook.error';
 
 @Injectable()
 export class EscrowCompletionService {
@@ -204,7 +203,8 @@ export class EscrowCompletionService {
         for (const url of callbackUrls) {
           if (!url) {
             throw new ControlledError(
-              WebhookErrorMessage.URL_NOT_FOUND,
+              // This is a temporary solution during the refactoring phase.
+              'Webhook url not found',
               HttpStatus.NOT_FOUND,
             );
           }

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -17,13 +17,11 @@ import { WebhookIncomingService } from '../webhook/webhook-incoming.service';
 import { PayoutService } from '../payout/payout.service';
 import { ReputationService } from '../reputation/reputation.service';
 import { Web3Service } from '../web3/web3.service';
-import {
-  ErrorEscrowCompletion,
-  ErrorWebhook,
-} from '../../common/constants/errors';
+import { ErrorEscrowCompletion } from '../../common/constants/errors';
 import { ControlledError } from '../../common/errors/controlled';
 import { WebhookOutgoingService } from '../webhook/webhook-outgoing.service';
 import { isDuplicatedError } from '../../common/utils/database';
+import { WebhookErrorMessage } from '../webhook/webhook.error';
 
 @Injectable()
 export class EscrowCompletionService {
@@ -206,7 +204,7 @@ export class EscrowCompletionService {
         for (const url of callbackUrls) {
           if (!url) {
             throw new ControlledError(
-              ErrorWebhook.UrlNotFound,
+              WebhookErrorMessage.URL_NOT_FOUND,
               HttpStatus.NOT_FOUND,
             );
           }

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.spec.ts
@@ -16,11 +16,8 @@ import { WebhookOutgoingRepository } from './webhook-outgoing.repository';
 import { WebhookIncomingService } from './webhook-incoming.service';
 import { WebhookIncomingEntity } from './webhook-incoming.entity';
 import { IncomingWebhookDto } from './webhook.dto';
-import { ErrorWebhook } from '../../common/constants/errors';
-import { HttpStatus } from '@nestjs/common';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ServerConfigService } from '../../common/config/server-config.service';
-import { ControlledError } from '../../common/errors/controlled';
 import { ReputationService } from '../reputation/reputation.service';
 import { EscrowCompletionRepository } from '../escrow-completion/escrow-completion.repository';
 import { EscrowCompletionService } from '../escrow-completion/escrow-completion.service';
@@ -33,6 +30,7 @@ import { ReputationRepository } from '../reputation/reputation.repository';
 import { ReputationConfigService } from '../../common/config/reputation-config.service';
 import { S3ConfigService } from '../../common/config/s3-config.service';
 import { PGPConfigService } from '../../common/config/pgp-config.service';
+import { IncomingWebhookError, WebhookErrorMessage } from './webhook.error';
 
 describe('WebhookIncomingService', () => {
   let webhookIncomingService: WebhookIncomingService,
@@ -167,9 +165,10 @@ describe('WebhookIncomingService', () => {
       await expect(
         webhookIncomingService.createIncomingWebhook(invalidDto),
       ).rejects.toThrow(
-        new ControlledError(
-          ErrorWebhook.InvalidEventType,
-          HttpStatus.BAD_REQUEST,
+        new IncomingWebhookError(
+          WebhookErrorMessage.INVALID_EVENT_TYPE,
+          invalidDto.chainId,
+          invalidDto.escrowAddress,
         ),
       );
     });

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Headers, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Headers,
+  Post,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -12,10 +19,12 @@ import { Public } from '../../common/decorators';
 import { WebhookIncomingService } from './webhook-incoming.service';
 import { AuthSignatureRole } from '../../common/enums/role';
 import { IncomingWebhookDto } from './webhook.dto';
+import { IncomingWebhookErrorFilter } from './webhook.error.filter';
 
 @Public()
 @ApiTags('Webhook')
 @Controller('/webhook')
+@UseFilters(IncomingWebhookErrorFilter)
 export class WebhookController {
   constructor(
     private readonly webhookIncomingService: WebhookIncomingService,

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.error.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.error.filter.ts
@@ -1,0 +1,33 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+import { IncomingWebhookError } from './webhook.error';
+
+@Catch(IncomingWebhookError)
+export class IncomingWebhookErrorFilter implements ExceptionFilter {
+  private logger = new Logger(IncomingWebhookErrorFilter.name);
+  catch(exception: IncomingWebhookError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const status = HttpStatus.BAD_REQUEST;
+
+    this.logger.error(
+      exception.message,
+      exception.stack,
+      `${exception.chainId} - ${exception.address}`,
+    );
+
+    return response.status(status).json({
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.error.ts
@@ -1,0 +1,27 @@
+import { ChainId } from '@human-protocol/sdk';
+import { BaseError } from '../../common/errors/base';
+
+export enum WebhookErrorMessage {
+  URL_NOT_FOUND = 'Webhook url not found',
+  INVALID_EVENT_TYPE = 'Invalid event type',
+  NOT_SENT = 'Webhook was not sent',
+  PENDING_PROCESSING_FAILED = 'Failed to process pending webhook',
+}
+
+export class IncomingWebhookError extends BaseError {
+  chainId: ChainId;
+  address: string;
+  constructor(message: WebhookErrorMessage, chainId: ChainId, address: string) {
+    super(message);
+    this.chainId = chainId;
+    this.address = address;
+  }
+}
+
+export class OutgoingWebhookError extends BaseError {
+  hash: string;
+  constructor(message: WebhookErrorMessage, hash: string) {
+    super(message);
+    this.hash = hash;
+  }
+}


### PR DESCRIPTION
## Issue tracking
#2928

## Context behind the change
- Refactored error handling for webhook module.
- Removed some unused imports.

## How has this been tested?
- Setup a local postgres database, apply migrations.
- Deploy reputation oracle locally.
- Send webhook with an invalid event type.

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None