### PR TITLE
[Dashboard client] Show only enabled networks

### DIFF
--- a/packages/apps/dashboard/server/src/modules/networks/network.service.spec.ts
+++ b/packages/apps/dashboard/server/src/modules/networks/network.service.spec.ts
@@ -9,6 +9,7 @@ import { ChainId, NETWORKS } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { NetworksService } from './networks.service';
+import { NetworkConfigService } from '../../common/config/network-config.service';
 
 jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
@@ -21,6 +22,7 @@ describe('NetworksService', () => {
 
   beforeAll(async () => {
     process.env.RPC_URL_POLYGON = 'https://testrpc.com';
+    process.env.RPC_URL_BSC_MAINNET = 'https://testrpc.com';
     process.env.RPC_URL_ETHEREUM = 'https://testrpc.com';
     process.env.WEB3_ENV = 'mainnet';
   });
@@ -44,6 +46,7 @@ describe('NetworksService', () => {
             networkOperatingCacheTtl: 1000,
           },
         },
+        NetworkConfigService,
         ConfigService,
         Logger,
       ],
@@ -56,8 +59,8 @@ describe('NetworksService', () => {
   it('should regenerate network list when cache TTL expires', async () => {
     const mockNetworkList = [
       ChainId.MAINNET,
-      ChainId.BSC_MAINNET,
       ChainId.POLYGON,
+      ChainId.BSC_MAINNET,
     ];
 
     // Step 1: Initial request - populate cache

--- a/packages/apps/dashboard/server/src/modules/networks/networks.service.ts
+++ b/packages/apps/dashboard/server/src/modules/networks/networks.service.ts
@@ -8,7 +8,7 @@ import {
   MINIMUM_HMT_TRANSFERS,
 } from '../../common/config/env-config.service';
 import { OPERATING_NETWORKS_CACHE_KEY } from '../../common/config/redis-config.service';
-import { MAINNET_CHAIN_IDS } from '../../common/utils/constants';
+import { NetworkConfigService } from '../../common/config/network-config.service';
 
 @Injectable()
 export class NetworksService {
@@ -16,6 +16,7 @@ export class NetworksService {
   constructor(
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly envConfigService: EnvironmentConfigService,
+    private readonly networkConfigService: NetworkConfigService,
   ) {}
 
   public async getOperatingNetworks(): Promise<ChainId[]> {
@@ -38,8 +39,8 @@ export class NetworksService {
 
     const availableNetworks = [];
 
-    for (const chainId of Object.values(MAINNET_CHAIN_IDS)) {
-      const networkConfig = NETWORKS[chainId];
+    for (const network of Object.values(this.networkConfigService.networks)) {
+      const networkConfig = NETWORKS[network.chainId];
       if (!networkConfig) continue;
 
       const statisticsClient = new StatisticsClient(networkConfig);
@@ -64,11 +65,11 @@ export class NetworksService {
           totalTransactionCount > MINIMUM_HMT_TRANSFERS;
 
         if (recentEscrowsCreated && sufficientHMTTransfers) {
-          availableNetworks.push(chainId);
+          availableNetworks.push(network.chainId);
         }
       } catch (error) {
         this.logger.error(
-          `Error processing network ${chainId}: ${error.message}`,
+          `Error processing network ${network.chainId}: ${error.message}`,
         );
       }
     }

--- a/packages/apps/dashboard/ui-2024/src/features/Leaderboard/components/SelectNetwork.tsx
+++ b/packages/apps/dashboard/ui-2024/src/features/Leaderboard/components/SelectNetwork.tsx
@@ -4,12 +4,11 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
 import HumanIcon from '@components/Icons/HumanIcon';
-import {
-  leaderboardSearchSelectConfig,
-  useLeaderboardSearch,
-} from '@utils/hooks/use-leaderboard-search';
+import { useLeaderboardSearch } from '@utils/hooks/use-leaderboard-search';
+import { useFilteredNetworks } from '@utils/hooks/use-filtered-networks';
 import { useBreakPoints } from '@utils/hooks/use-is-mobile';
 import { NetworkIcon } from '@components/NetworkIcon';
+import CircularProgress from '@mui/material/CircularProgress';
 
 export const SelectNetwork = () => {
   const {
@@ -17,16 +16,28 @@ export const SelectNetwork = () => {
     filterParams: { chainId },
   } = useLeaderboardSearch();
 
+  const { filteredNetworks, isLoading } = useFilteredNetworks();
   const {
     mobile: { isMobile },
   } = useBreakPoints();
 
   const handleChange = (event: SelectChangeEvent<number>) => {
-    const value = event.target.value;
-    if (typeof value === 'number') {
-      setChainId(value);
-    }
+    const value = Number(event.target.value);
+    setChainId(value);
   };
+
+  if (isLoading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        height="40px"
+      >
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
 
   return (
     <FormControl
@@ -42,38 +53,28 @@ export const SelectNetwork = () => {
         label="By Network"
         onChange={handleChange}
       >
-        {leaderboardSearchSelectConfig.map((selectItem) => {
-          if ('allNetworksId' in selectItem) {
-            return (
-              <MenuItem
-                key={selectItem.name}
-                className="select-item"
-                value={-1}
-              >
-                <HumanIcon />
-                All Networks
-              </MenuItem>
-            );
-          }
-
-          return (
-            <MenuItem
-              key={selectItem.id}
-              value={selectItem.id}
-              sx={{
-                display: 'flex',
-                gap: '10px',
-              }}
-            >
-              <Box sx={{ svg: { width: '24px', height: '24px' } }}>
-                <NetworkIcon chainId={selectItem.id} />
-              </Box>
-
-              {selectItem.name}
-            </MenuItem>
-          );
-        })}
+        <MenuItem key="all-networks" className="select-item" value={-1}>
+          <HumanIcon />
+          All Networks
+        </MenuItem>
+        {filteredNetworks.map((network) => (
+          <MenuItem
+            key={network.id}
+            value={network.id}
+            sx={{
+              display: 'flex',
+              gap: '10px',
+            }}
+          >
+            <Box sx={{ svg: { width: '24px', height: '24px' } }}>
+              <NetworkIcon chainId={network.id} />
+            </Box>
+            {network.name}
+          </MenuItem>
+        ))}
       </Select>
     </FormControl>
   );
 };
+
+export default SelectNetwork;

--- a/packages/apps/dashboard/ui-2024/src/services/api-paths.ts
+++ b/packages/apps/dashboard/ui-2024/src/services/api-paths.ts
@@ -29,4 +29,7 @@ export const apiPaths = {
   escrowDetails: {
     path: '/details/escrows',
   },
+  enabledChains: {
+    path: '/networks/operating',
+  },
 } as const;

--- a/packages/apps/dashboard/ui-2024/src/utils/hooks/use-filtered-networks.ts
+++ b/packages/apps/dashboard/ui-2024/src/utils/hooks/use-filtered-networks.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+import { networks as allNetworks } from '@utils/config/networks';
+import { httpService } from '@services/http-service';
+import { apiPaths } from '@services/api-paths';
+
+const enabledChainsSchema = z.array(z.number());
+
+export const useFilteredNetworks = () => {
+  const {
+    data: enabledChains,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['enabledChains'],
+    queryFn: async () => {
+      const response = await httpService.get(apiPaths.enabledChains.path);
+      return enabledChainsSchema.parse(response.data);
+    },
+  });
+
+  const filteredNetworks = enabledChains
+    ? allNetworks.filter((network) => enabledChains.includes(network.id))
+    : [];
+
+  return { filteredNetworks, isLoading, error };
+};

--- a/packages/apps/dashboard/ui-2024/src/utils/hooks/use-leaderboard-search.ts
+++ b/packages/apps/dashboard/ui-2024/src/utils/hooks/use-leaderboard-search.ts
@@ -1,11 +1,4 @@
-import { networks } from '@utils/config/networks';
 import { create } from 'zustand';
-import type { Chain } from 'viem/chains';
-
-export const leaderboardSearchSelectConfig: (
-  | Chain
-  | { name: 'All Networks'; allNetworksId: -1 }
-)[] = [{ name: 'All Networks', allNetworksId: -1 }, ...networks];
 
 export interface LeaderboardSearchStore {
   filterParams: {

--- a/packages/apps/dashboard/ui-2024/src/utils/hooks/use-wallet-search.ts
+++ b/packages/apps/dashboard/ui-2024/src/utils/hooks/use-wallet-search.ts
@@ -1,4 +1,3 @@
-import { networks } from '../config/networks';
 import { create } from 'zustand';
 
 export interface WalletSearchStore {
@@ -13,7 +12,7 @@ export interface WalletSearchStore {
 export const useWalletSearch = create<WalletSearchStore>((set) => ({
   filterParams: {
     address: '',
-    chainId: networks[0].id,
+    chainId: -1,
   },
   setAddress: (address) => {
     set((state) => ({


### PR DESCRIPTION
## Issue tracking
#2855 #2972

## Context behind the change
- Updated the frontend to dynamically fetch active networks from the backend.
- Ensured that only active networks are displayed in all select inputs across the application (e.g., SearchBar and Leaderboard components).
- Modified data querying logic to restrict API calls to enabled networks only, improving reliability and efficiency.


## How has this been tested?
- Deployed the changes locally.
- Set up a test environment with predefined active networks from the backend.
- Verified the following:
  - Active networks are correctly displayed in the SearchBar select input.
  - Data filtering and display in the Leaders table function as expected.
- Network-related navigation and data fetching work as intended.


## Release plan
Deploy frontend and backend.

## Potential risks; What to monitor; Rollback plan
None