### PR TITLE
[Human App] fix: operator signup keys form

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/operator/views/sign-up/add-keys.page.tsx
+++ b/packages/apps/human-app/frontend/src/modules/operator/views/sign-up/add-keys.page.tsx
@@ -60,10 +60,21 @@ export function Form({
 }: {
   keysData: GetEthKVStoreValuesSuccessResponse;
 }) {
-  const areSomeExistingKeys = Object.values(keysData).filter(Boolean).length;
-  const areSomePendingKeys = Object.entries(keysData).filter(
-    ([key, values]) => key && !values.length
-  ).length;
+  const hasSomeNotEmptyKeys =
+    Object.values(keysData).filter(Boolean).length > 0;
+  const hasSomePendingKeys =
+    Object.values(keysData).filter((value) => {
+      /**
+       * This check is necessary because TS can't infer
+       * "undefined" from optional object's property
+       */
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (value === undefined) {
+        return false;
+      }
+
+      return value.length === 0;
+    }).length > 0;
 
   return (
     <Grid container gap="2rem">
@@ -75,9 +86,9 @@ export function Form({
           gap: '3rem',
         }}
       >
-        {areSomeExistingKeys ? <ExistingKeysForm keysData={keysData} /> : null}
-        {areSomePendingKeys ? <PendingKeysForm keysData={keysData} /> : null}
-        {areSomeExistingKeys && !areSomePendingKeys ? (
+        {hasSomeNotEmptyKeys ? <ExistingKeysForm keysData={keysData} /> : null}
+        {hasSomePendingKeys ? <PendingKeysForm keysData={keysData} /> : null}
+        {hasSomeNotEmptyKeys && !hasSomePendingKeys ? (
           <Button
             component={Link}
             to={routerPaths.operator.editExistingKeysSuccess}


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When operator attempts to sign up and opens add/edit keys form the page is blank and app crashes. It's a [regression introduced by this line](https://github.com/humanprotocol/human-protocol/pull/2933/files#diff-e7638f3c31c56213c2663c5fbbc165cf41aef63fa17375b27456af39b71d50b4R65).

There is a "peculiarity" in TypeScript in how it infers types of "optional properties" when used with generic types (which is the case for `Object.values`/`Object.entires`), e.g.:
```
ype Test = { a?: string | undefined };

const test: Test = { a: undefined };
Object.values(test).filter((value) => value?.length); // 'value' typed as 'string'

function demo<T>(object: Record<string, T>): T {
  return object.a;
}

const value = demo(test); // 'value' typed as 'string'
```
but if you remove `?` from the type - it works as expected.

Such situations can be avoided if you sanitize your objects to not have keys with `undefined` values in it, so property is indeed optional. We don't got this way for now because it's about bigger refactoring

## How has this been tested?
- [x] Run locally, open "add keys" form, ensure it's rendered

## Release plan
Merge together with parent PR.

## Potential risks; What to monitor; Rollback plan
No