### PR TITLE
docs: add table of contents to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,48 @@
 | [![Core NPM Publish](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-core.yaml/badge.svg?event=release)](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-core.yaml) | [![Python SDK Publish](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-python-sdk.yaml/badge.svg?event=release)](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-python-sdk.yaml) | [![Node.js SDK Publish](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-node-sdk.yaml/badge.svg?event=release)](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-node-sdk.yaml) | [![Subgraph Deploy](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-subgraph.yaml/badge.svg?branch=main)](https://github.com/humanprotocol/human-protocol/actions/workflows/cd-subgraph.yaml) |
 
 
+## Table of Contents
+- [Overview](#overview)
+- [Quick Start](#quick-start) 
+- [Documentation](#documentation)
+- [Project Structure](#project-structure)
+- [Smart Contracts](#smart-contracts)
+- [Contributing](#contributing-to-this-repository)
+- [Legal Notice](#legal-notice)
+
+## Overview
+
+HUMAN Protocol is a permissionless infrastructure that facilitates the exchange of HUMAN work, knowledge, and contribution. The protocol enables the creation of decentralized job markets where:
+
+- **Task Creators** can create and distribute work
+- **Workers** can complete tasks and earn rewards
+- **Validators** can verify work quality
+- **Operators** can run network infrastructure
+
+Current use cases include:
+
+* [Data Labeling](https://app.humanprotocol.org/) - Over 20M images labeled monthly
+* [IMOO](https://www.humanprotocol.org/imoo) - Decentralized prediction market oracle
+* [POH](https://www.humanprotocol.org/proof-of-humanity) - On-chain bot detection
+* [Fortune](https://fortune.humanprotocol.org/) - Decentralized data labeling platform
+
+## Quick Start
+
+1. **Install Dependencies**
+```bash
+npm install
+# or
+yarn install
+```
+
+2. **Supported Networks**
+- Ethereum Mainnet
+- Polygon
+- BSC
+- Moonbeam
+- Goerli (testnet)
+- Mumbai (testnet)
+
 ## All work on-chain
 
 Tokenized, verified, rewarded.


### PR DESCRIPTION
Add table of contents to improve README.md navigation.
This change helps users quickly find relevant sections
of the documentation without changing any existing content.