### PR TITLE
Add website to Leader fragment for subgraph queries

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/operator.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/operator.py
@@ -18,6 +18,7 @@ fragment LeaderFields on Leader {
     publicKey
     webhookUrl
     url
+    website
     jobTypes
     registrationNeeded
     registrationInstructions


### PR DESCRIPTION
## Issue tracking
#2992

## Context behind the change
Missing website value in Leader entity. 
Added website value in leader_fragment for solving it.

## How has this been tested?
Made some requests locally. Also ran some tests

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None