### PR TITLE
Feature/dashboard/leaderboard

### DIFF
--- a/packages/apps/dashboard/ui-2024/src/pages/Home/Leaderboard.tsx
+++ b/packages/apps/dashboard/ui-2024/src/pages/Home/Leaderboard.tsx
@@ -3,11 +3,11 @@ import { Leaderboard as LeaderboardFeature } from '../../features/Leaderboard';
 
 export const Leaderboard = () => {
   const { data, status, error } = useLeaderboardDetails();
-  const isMoreThatFiveEntries = data?.length && data.length > 5;
+  const isMoreThatFourEntries = data?.length && data.length > 4;
 
   return (
     <LeaderboardFeature
-      data={isMoreThatFiveEntries ? data.slice(0, 5) : data}
+      data={isMoreThatFourEntries ? data.slice(0, 4) : data}
       status={status}
       error={error}
       viewAllBanner

--- a/packages/apps/dashboard/ui-2024/src/pages/Leaderboard/index.tsx
+++ b/packages/apps/dashboard/ui-2024/src/pages/Leaderboard/index.tsx
@@ -7,7 +7,6 @@ import { LeaderboardIcon } from '@components/Icons/LeaderboardIcon';
 
 export const LeaderBoard = () => {
   const { data, status, error } = useLeaderboardDetails();
-  const isMoreThatFiveEntries = data?.length && data.length > 5;
 
   return (
     <PageWrapper className="standard-background">
@@ -18,7 +17,7 @@ export const LeaderBoard = () => {
         img={<LeaderboardIcon />}
       />
       <Leaderboard
-        data={isMoreThatFiveEntries ? data.slice(0, 5) : data}
+        data={data}
         status={status}
         error={error}
       />

--- a/packages/apps/dashboard/ui-2024/src/pages/Leaderboard/index.tsx
+++ b/packages/apps/dashboard/ui-2024/src/pages/Leaderboard/index.tsx
@@ -16,11 +16,7 @@ export const LeaderBoard = () => {
         title="Leaderboard"
         img={<LeaderboardIcon />}
       />
-      <Leaderboard
-        data={data}
-        status={status}
-        error={error}
-      />
+      <Leaderboard data={data} status={status} error={error} />
     </PageWrapper>
   );
 };


### PR DESCRIPTION
### Describe the bug
The leaderboard on the landing page currently displays more than 4 leaders, which is not the expected behavior. This issue is caused by changes introduced in [Dashboard] Leaderboard in the landing page should show only 4 leaders
[#2993](https://github.com/humanprotocol/human-protocol/issues/2993).

### To reproduce
Steps to reproduce the behavior:
1. Go to [[Testnet Dashboard](https://testnet-dashboard.humanprotocol.org/)](https://testnet-dashboard.humanprotocol.org/).
2. Observe that the leaderboard displays more than 4 leaders.

### Expected Behavior
The leaderboard should display only 4 elements.

## Issue tracking
This issue originated from [Dashboard] Leaderboard in the landing page should show only 4 leaders
[#2993](https://github.com/humanprotocol/human-protocol/issues/2993).

## Context behind the change
The goal of this pull request is to limit the number of leaders displayed on the leaderboard to 4.

## How has this been tested?
- The changes were tested by accessing the leaderboard and verifying that only 4 leaders are displayed.