### PR TITLE
Update deployed subgraph ids and update deployment workflow

### DIFF
--- a/.github/workflows/cd-subgraph.yaml
+++ b/.github/workflows/cd-subgraph.yaml
@@ -6,6 +6,9 @@ on:
       label:
         description: 'New version label'
         required: true
+      networks:
+        description: 'Comma-separated list of networks to deploy'
+        required: true
 
 jobs:
   subgraph:
@@ -28,24 +31,46 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.20.1'
+      - name: Filter Networks
+        id: filter_networks
+        run: |
+          INPUT_NETWORKS="${{ github.event.inputs.networks }}"
+          IFS=',' read -ra NETWORK_LIST <<< "$INPUT_NETWORKS"
+          echo "Input networks: $INPUT_NETWORKS"
+          echo "Current matrix network: ${{ matrix.network.name }}"
+          MATCH=false
+          for network in "${NETWORK_LIST[@]}"; do
+            if [[ "${network}" == "${{ matrix.network.name }}" ]]; then
+              MATCH=true
+              break
+            fi
+          done
+          echo "Match found: $MATCH"
+          echo "::set-output name=continue::$MATCH"
       - run: npm install --global yarn && yarn
         name: Install dependencies
+        if: steps.filter_networks.outputs.continue == 'true'
       - run: yarn build
         name: Build core package
         working-directory: ./packages/core
+        if: steps.filter_networks.outputs.continue == 'true'
       - run: yarn global add @graphprotocol/graph-cli@0.71.2
         name: Install Graph CLI
+        if: steps.filter_networks.outputs.continue == 'true'
       - run: graph auth --studio ${API_KEY}
         name: Authenticate Graph CLI
         env:
           API_KEY: ${{ secrets.HP_GRAPH_API_KEY }}
+        if: steps.filter_networks.outputs.continue == 'true'
       - run: yarn generate && yarn build
         name: Generate and build Subgraph
         working-directory: ./packages/sdk/typescript/subgraph
         env:
           NETWORK: ${{ matrix.network.name }}
+        if: steps.filter_networks.outputs.continue == 'true'
       - run: graph deploy --studio ${NETWORK} -l ${{ github.event.inputs.label }}
         name: Deploy Subgraph
         working-directory: ./packages/sdk/typescript/subgraph
         env:
           NETWORK: ${{ matrix.network.name }}
+        if: steps.filter_networks.outputs.continue == 'true'

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -36,7 +36,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/ethereum/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmNTdYHpQLW4sbrCxihXNdQwhxa2zdyu1yPkCUuTbqESba"
+            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmWeaETaRqxX2eiFpPPpdn3q75fUKPzXzq32HR1MQPHsQh"
         ),
         "hmt_address": "0xd1ba9BAC957322D6e8c07a160a3A8dA11A0d2867",
         "factory_address": "0xD9c75a1Aa4237BB72a41E5E26bd8384f10c1f55a",
@@ -45,14 +45,14 @@ NETWORKS = {
         "old_subgraph_url": "",
         "old_factory_address": "",
     },
-    ChainId.LOCALHOST: {
+    ChainId.SEPOLIA: {
         "title": "Sepolia",
         "scan_url": "https://sepolia.etherscan.io",
         "subgraph_url": (
             "https://api.studio.thegraph.com/query/74256/sepolia/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmXVFVCLm2XxupxdKgnLRzvmkPJnpRbcoe4RNXoTqSRHsg"
+            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/Qme5eCUKPuLbEoYTj7QKXWgkFLebc9BePe8QFtT7VBu1az"
         ),
         "hmt_address": "0x792abbcC99c01dbDec49c9fa9A828a186Da45C33",
         "factory_address": "0x5987A5558d961ee674efe4A8c8eB7B1b5495D3bf",
@@ -68,7 +68,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/bsc/version/latest"
         ),
         "subgraph_url_api_key": (
-            "hthttps://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmPMS6G5evLm5ZpbnmpCfUy8bHJPwzPkZTv9DgfNdFfrCM"
+            "hthttps://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmafB8bJn2FRPT8d8HoB7ENy9pckSon8cKxfc5hJUsCz6r"
         ),
         "hmt_address": "0x711Fd6ab6d65A98904522d4e3586F492B989c527",
         "factory_address": "0x92FD968AcBd521c232f5fB8c33b342923cC72714",
@@ -84,7 +84,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/bsc-testnet/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmW6JqXvhDnhRVHU6ixKVSD65U1GKWUf3xwJo8E6mTBsAu"
+            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmZcWc6hKUHvV12kggKcDXkNpe1LXvHoeU2fo26HU1VjAm"
         ),
         "hmt_address": "0xE3D74BBFa45B4bCa69FF28891fBE392f4B4d4e4d",
         "factory_address": "0x2bfA592DBDaF434DDcbb893B1916120d181DAD18",
@@ -102,7 +102,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/polygon/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmTyCQMQd5QtogeTEuiqxnGQZa2PtgpUBsWLYwPCCFPbUe"
+            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmNkup687LE9KS85cGGaBLu7FmwP73RVqqY2NKeHUaEYjz"
         ),
         "hmt_address": "0xc748B2A084F8eFc47E086ccdDD9b7e67aEb571BF",
         "factory_address": "0xBDBfD2cC708199C5640C6ECdf3B0F4A4C67AdfcB",
@@ -120,7 +120,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/amoy/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmawobiPUYsGNK9chtb5PvicUtaa8Jsjpwvv8dNyMVXQ9r"
+            "https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmTdEpKGntDfxxNXddJ62dNpBSo8mBU4VihesVnqK6WLq4"
         ),
         "hmt_address": "0x792abbcC99c01dbDec49c9fa9A828a186Da45C33",
         "factory_address": "0xAFf5a986A530ff839d49325A5dF69F96627E8D29",

--- a/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
@@ -36,7 +36,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/ethereum/version/latest',
     subgraphUrlApiKey:
-      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmNTdYHpQLW4sbrCxihXNdQwhxa2zdyu1yPkCUuTbqESba',
+      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmWeaETaRqxX2eiFpPPpdn3q75fUKPzXzq32HR1MQPHsQh',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
   },
@@ -51,7 +51,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/sepolia/version/latest',
     subgraphUrlApiKey:
-      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmXVFVCLm2XxupxdKgnLRzvmkPJnpRbcoe4RNXoTqSRHsg',
+      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/Qme5eCUKPuLbEoYTj7QKXWgkFLebc9BePe8QFtT7VBu1az',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
   },
@@ -66,7 +66,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/bsc/version/latest',
     subgraphUrlApiKey:
-      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmPMS6G5evLm5ZpbnmpCfUy8bHJPwzPkZTv9DgfNdFfrCM',
+      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmafB8bJn2FRPT8d8HoB7ENy9pckSon8cKxfc5hJUsCz6r',
     oldSubgraphUrl: 'https://api.thegraph.com/subgraphs/name/humanprotocol/bsc',
     oldFactoryAddress: '0xc88bC422cAAb2ac8812de03176402dbcA09533f4',
   },
@@ -81,7 +81,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/bsc-testnet/version/latest',
     subgraphUrlApiKey:
-      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmW6JqXvhDnhRVHU6ixKVSD65U1GKWUf3xwJo8E6mTBsAu',
+      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmZcWc6hKUHvV12kggKcDXkNpe1LXvHoeU2fo26HU1VjAm',
     oldSubgraphUrl:
       'https://api.thegraph.com/subgraphs/name/humanprotocol/bsctest',
     oldFactoryAddress: '0xaae6a2646c1f88763e62e0cd08ad050ea66ac46f',
@@ -97,7 +97,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/polygon/version/latest',
     subgraphUrlApiKey:
-      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmTyCQMQd5QtogeTEuiqxnGQZa2PtgpUBsWLYwPCCFPbUe',
+      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmNkup687LE9KS85cGGaBLu7FmwP73RVqqY2NKeHUaEYjz',
     oldSubgraphUrl:
       'https://api.thegraph.com/subgraphs/name/humanprotocol/polygon',
     oldFactoryAddress: '0x45eBc3eAE6DA485097054ae10BA1A0f8e8c7f794',
@@ -113,7 +113,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/amoy/version/latest',
     subgraphUrlApiKey:
-      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmawobiPUYsGNK9chtb5PvicUtaa8Jsjpwvv8dNyMVXQ9r',
+      'https://gateway-arbitrum.network.thegraph.com/api/[SUBGRAPH_API_KEY]/deployments/id/QmTdEpKGntDfxxNXddJ62dNpBSo8mBU4VihesVnqK6WLq4',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
   },


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
- Update deployed subgraph ids for beta version
- Update deployment workflow to allow passing the networks to be deployed in a comma separated list.

## How has this been tested?
Workflow used to upgrade subraphs from local

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA