### PR TITLE
[SDK] fix: date rounding issues

### DIFF
--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -55,7 +55,12 @@ import {
   NetworkData,
   TransactionLikeWithNonce,
 } from './types';
-import { getSubgraphUrl, isValidUrl, throwError } from './utils';
+import {
+  getSubgraphUrl,
+  getUnixTimestamp,
+  isValidUrl,
+  throwError,
+} from './utils';
 
 /**
  * ## Introduction
@@ -1692,10 +1697,8 @@ export class EscrowUtils {
                 ([, value]) => value === filter.status
               )?.[0]
             : undefined,
-        from: filter.from
-          ? Math.floor(filter.from.getTime() / 1000)
-          : undefined,
-        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
+        from: filter.from ? getUnixTimestamp(filter.from) : undefined,
+        to: filter.to ? getUnixTimestamp(filter.to) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -1896,8 +1899,8 @@ export class EscrowUtils {
       GET_STATUS_UPDATES_QUERY(from, to, launcher),
       {
         status: statusNames,
-        from: from ? Math.floor(from.getTime() / 1000) : undefined,
-        to: to ? Math.floor(to.getTime() / 1000) : undefined,
+        from: from ? getUnixTimestamp(from) : undefined,
+        to: to ? getUnixTimestamp(to) : undefined,
         launcher: launcher || undefined,
         orderDirection: orderDirection,
         first: first,

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -1692,8 +1692,10 @@ export class EscrowUtils {
                 ([, value]) => value === filter.status
               )?.[0]
             : undefined,
-        from: filter.from ? +filter.from.getTime() / 1000 : undefined,
-        to: filter.to ? +filter.to.getTime() / 1000 : undefined,
+        from: filter.from
+          ? Math.floor(filter.from.getTime() / 1000)
+          : undefined,
+        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,

--- a/packages/sdk/typescript/human-protocol-sdk/src/statistics.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/statistics.ts
@@ -20,7 +20,7 @@ import {
 } from './graphql';
 import { IHMTHoldersParams, IStatisticsFilter } from './interfaces';
 import { NetworkData } from './types';
-import { getSubgraphUrl, throwError } from './utils';
+import { getSubgraphUrl, getUnixTimestamp, throwError } from './utils';
 import { OrderDirection } from './enums';
 
 /**
@@ -133,10 +133,8 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from
-          ? Math.floor(filter.from.getTime() / 1000)
-          : undefined,
-        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
+        from: filter.from ? getUnixTimestamp(filter.from) : undefined,
+        to: filter.to ? getUnixTimestamp(filter.to) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -215,10 +213,8 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from
-          ? Math.floor(filter.from.getTime() / 1000)
-          : undefined,
-        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
+        from: filter.from ? getUnixTimestamp(filter.from) : undefined,
+        to: filter.to ? getUnixTimestamp(filter.to) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -313,10 +309,8 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from
-          ? Math.floor(filter.from.getTime() / 1000)
-          : undefined,
-        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
+        from: filter.from ? getUnixTimestamp(filter.from) : undefined,
+        to: filter.to ? getUnixTimestamp(filter.to) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -493,10 +487,8 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from
-          ? Math.floor(filter.from.getTime() / 1000)
-          : undefined,
-        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
+        from: filter.from ? getUnixTimestamp(filter.from) : undefined,
+        to: filter.to ? getUnixTimestamp(filter.to) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,

--- a/packages/sdk/typescript/human-protocol-sdk/src/statistics.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/statistics.ts
@@ -133,8 +133,10 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from ? filter.from.getTime() / 1000 : undefined,
-        to: filter.to ? filter.to.getTime() / 1000 : undefined,
+        from: filter.from
+          ? Math.floor(filter.from.getTime() / 1000)
+          : undefined,
+        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -213,8 +215,10 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from ? filter.from.getTime() / 1000 : undefined,
-        to: filter.to ? filter.to.getTime() / 1000 : undefined,
+        from: filter.from
+          ? Math.floor(filter.from.getTime() / 1000)
+          : undefined,
+        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -309,8 +313,10 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from ? filter.from.getTime() / 1000 : undefined,
-        to: filter.to ? filter.to.getTime() / 1000 : undefined,
+        from: filter.from
+          ? Math.floor(filter.from.getTime() / 1000)
+          : undefined,
+        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,
@@ -487,8 +493,10 @@ export class StatisticsClient {
       const { eventDayDatas } = await gqlFetch<{
         eventDayDatas: EventDayData[];
       }>(this.subgraphUrl, GET_EVENT_DAY_DATA_QUERY(filter), {
-        from: filter.from ? filter.from.getTime() / 1000 : undefined,
-        to: filter.to ? filter.to.getTime() / 1000 : undefined,
+        from: filter.from
+          ? Math.floor(filter.from.getTime() / 1000)
+          : undefined,
+        to: filter.to ? Math.floor(filter.to.getTime() / 1000) : undefined,
         orderDirection: orderDirection,
         first: first,
         skip: skip,

--- a/packages/sdk/typescript/human-protocol-sdk/src/transaction.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/transaction.ts
@@ -13,7 +13,7 @@ import {
   GET_TRANSACTION_QUERY,
 } from './graphql/queries/transaction';
 import { ITransaction, ITransactionsFilter } from './interfaces';
-import { getSubgraphUrl } from './utils';
+import { getSubgraphUrl, getUnixTimestamp } from './utils';
 
 export class TransactionUtils {
   /**
@@ -132,11 +132,9 @@ export class TransactionUtils {
       fromAddress: filter?.fromAddress,
       toAddress: filter?.toAddress,
       startDate: filter?.startDate
-        ? Math.floor(filter?.startDate.getTime() / 1000)
+        ? getUnixTimestamp(filter?.startDate)
         : undefined,
-      endDate: filter.endDate
-        ? Math.floor(filter.endDate.getTime() / 1000)
-        : undefined,
+      endDate: filter.endDate ? getUnixTimestamp(filter.endDate) : undefined,
       startBlock: filter.startBlock ? filter.startBlock : undefined,
       endBlock: filter.endBlock ? filter.endBlock : undefined,
       orderDirection: orderDirection,

--- a/packages/sdk/typescript/human-protocol-sdk/src/utils.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/utils.ts
@@ -73,3 +73,13 @@ export const getSubgraphUrl = (networkData: NetworkData) => {
 
   return subgraphUrl;
 };
+
+/**
+ * **Convert a date to Unix timestamp (seconds since epoch).*
+ *
+ * @param {Date} date
+ * @returns {number}
+ */
+export const getUnixTimestamp = (date: Date): number => {
+  return Math.floor(date.getTime() / 1000);
+};

--- a/packages/sdk/typescript/human-protocol-sdk/test/statistics.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/statistics.test.ts
@@ -69,8 +69,8 @@ describe('StatisticsClient', () => {
         'https://api.studio.thegraph.com/query/74256/polygon/version/latest',
         GET_EVENT_DAY_DATA_QUERY({ from, to }),
         {
-          from: from.getTime() / 1000,
-          to: to.getTime() / 1000,
+          from: Math.floor(from.getTime() / 1000),
+          to: Math.floor(to.getTime() / 1000),
           orderDirection: OrderDirection.ASC,
           first: 10,
           skip: 0,
@@ -131,8 +131,8 @@ describe('StatisticsClient', () => {
         'https://api.studio.thegraph.com/query/74256/polygon/version/latest',
         GET_EVENT_DAY_DATA_QUERY({ from, to }),
         {
-          from: from.getTime() / 1000,
-          to: to.getTime() / 1000,
+          from: Math.floor(from.getTime() / 1000),
+          to: Math.floor(to.getTime() / 1000),
           orderDirection: OrderDirection.ASC,
           first: 10,
           skip: 0,
@@ -190,8 +190,8 @@ describe('StatisticsClient', () => {
         'https://api.studio.thegraph.com/query/74256/polygon/version/latest',
         GET_EVENT_DAY_DATA_QUERY({ from, to }),
         {
-          from: from.getTime() / 1000,
-          to: to.getTime() / 1000,
+          from: Math.floor(from.getTime() / 1000),
+          to: Math.floor(to.getTime() / 1000),
           orderDirection: OrderDirection.ASC,
           first: 10,
           skip: 0,
@@ -444,8 +444,8 @@ describe('StatisticsClient', () => {
         'https://api.studio.thegraph.com/query/74256/polygon/version/latest',
         GET_EVENT_DAY_DATA_QUERY({ from, to }),
         {
-          from: from.getTime() / 1000,
-          to: to.getTime() / 1000,
+          from: Math.floor(from.getTime() / 1000),
+          to: Math.floor(to.getTime() / 1000),
           orderDirection: OrderDirection.ASC,
           first: 10,
           skip: 0,


### PR DESCRIPTION
## Issue tracking
#2912

## Context behind the change
1. Updated all instances of getTime() / 1000 to use Math.floor to ensure dates are rounded to the nearest second.
2. Updated tests to round also expected values

## How has this been tested?
Ran examples and tests with different dates.

## Release plan
Deploy new SDK version

## Potential risks; What to monitor; None