### PR TITLE
[Reputation Oracle] refactor: get rid of controlled error in escrow completion

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/errors.ts
@@ -1,15 +1,4 @@
 /**
- * Represents error messages related to escrow completion.
- */
-export enum ErrorEscrowCompletion {
-  NotFound = 'Escrow completion not found',
-  NotCreated = 'Escrow completion has not been created',
-  PendingProcessingFailed = 'Failed to process pending escrow completion',
-  PaidProcessingFailed = 'Failed to process paid escrow completion',
-  AwaitingPayoutsProcessingFailed = 'Failed to process payouts for escrow completion',
-}
-
-/**
  * Represents error messages related to results.
  */
 export enum ErrorResults {

--- a/packages/apps/reputation-oracle/server/src/common/constants/networks.ts
+++ b/packages/apps/reputation-oracle/server/src/common/constants/networks.ts
@@ -6,9 +6,6 @@ export const TESTNET_CHAIN_IDS = [
   ChainId.SEPOLIA,
 ];
 
-export const MAINNET_CHAIN_IDS = [
-  ChainId.BSC_MAINNET,
-  ChainId.POLYGON,
-];
+export const MAINNET_CHAIN_IDS = [ChainId.BSC_MAINNET, ChainId.POLYGON];
 
 export const LOCALHOST_CHAIN_IDS = [ChainId.LOCALHOST];

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.spec.ts
@@ -368,7 +368,7 @@ describe('escrowCompletionService', () => {
         }),
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`Message: ${error.message}`),
+        expect.stringContaining(`Error message: ${error.message}`),
       );
     });
 
@@ -514,7 +514,7 @@ describe('escrowCompletionService', () => {
         }),
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`Message: ${error.message}`),
+        expect.stringContaining(`Error message: ${error.message}`),
       );
     });
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.spec.ts
@@ -270,7 +270,7 @@ describe('WebhookIncomingService', () => {
         }),
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`Message: ${error.message}`),
+        expect.stringContaining(`Error message: ${error.message}`),
       );
     });
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.ts
@@ -28,7 +28,7 @@ export class WebhookIncomingService {
    * Creates an incoming webhook entry in the repository.
    * Validates that the event type is 'JOB_COMPLETED' and sets initial status to 'PENDING'.
    * @param {IncomingWebhookDto} dto - Contains webhook details like chain ID and escrow address.
-   * @throws {ControlledError} If the event type is invalid or the webhook cannot be created.
+   * @throws {IncomingWebhookError} If the event type is invalid or the webhook cannot be created.
    */
   public async createIncomingWebhook(dto: IncomingWebhookDto): Promise<void> {
     if (dto.eventType !== EventType.JOB_COMPLETED) {

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Injectable, Logger } from '@nestjs/common';
-import { v4 as uuidv4 } from 'uuid';
 import { ServerConfigService } from '../../common/config/server-config.service';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { BACKOFF_INTERVAL_SECONDS } from '../../common/constants';
@@ -91,20 +90,15 @@ export class WebhookIncomingService {
         webhookEntity.status = WebhookIncomingStatus.COMPLETED;
         await this.webhookIncomingRepository.updateOne(webhookEntity);
       } catch (err) {
-        const errorId = uuidv4();
-        const failureDetail = `${WebhookErrorMessage.PENDING_PROCESSING_FAILED} (Error ID: ${errorId})`;
-
         if (isDuplicatedError(err)) {
-          // Handle duplicated error: log and mark as completed
-          this.logger.warn(
-            `Duplicate tracking entity for escrowAddress: ${webhookEntity.escrowAddress}. Marking webhook as completed.`,
-          );
           webhookEntity.status = WebhookIncomingStatus.COMPLETED;
           await this.webhookIncomingRepository.updateOne(webhookEntity);
         } else {
           // Handle other errors (general failure)
+          const failureDetail = `Error message: ${err.message}`;
+
           this.logger.error(
-            `Error processing webhook. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
+            `Error processing incoming webhook. Webhook ID: ${webhookEntity.id}. ${failureDetail}.`,
           );
           await this.handleWebhookIncomingError(webhookEntity, failureDetail);
         }

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-outgoing.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-outgoing.service.spec.ts
@@ -284,7 +284,7 @@ describe('WebhookOutgoingService', () => {
         }),
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`Message: ${error.message}`),
+        expect.stringContaining(`Error message: ${error.message}`),
       );
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-outgoing.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-outgoing.service.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { v4 as uuidv4 } from 'uuid';
 import * as crypto from 'crypto';
 import stringify from 'json-stable-stringify';
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
@@ -122,10 +121,9 @@ export class WebhookOutgoingService {
       try {
         await this.sendWebhook(webhookEntity);
       } catch (err) {
-        const errorId = uuidv4();
-        const failureDetail = `${WebhookErrorMessage.PENDING_PROCESSING_FAILED} (Error ID: ${errorId})`;
+        const failureDetail = `Error message: ${err.message}`;
         this.logger.error(
-          `Error processing pending outgoing webhook. Error ID: ${errorId}, Webhook ID: ${webhookEntity.id}, Reason: ${failureDetail}, Message: ${err.message}`,
+          `Error processing outgoing webhook. Webhook ID: ${webhookEntity.id}. ${failureDetail}`,
         );
         await this.handleWebhookOutgoingError(webhookEntity, failureDetail);
         continue;

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-outgoing.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-outgoing.service.ts
@@ -87,7 +87,7 @@ export class WebhookOutgoingService {
    * Converts payload to snake_case, signs it, and sends it to the specified URL.
    * @param {string} url - The target URL to which the webhook is sent.
    * @param {object} payload - The data payload to send.
-   * @throws {ControlledError} If the webhook request fails.
+   * @throws {OutgoingWebhookError} If the webhook request fails.
    */
   public async sendWebhook(
     outgoingWebhook: WebhookOutgoingEntity,

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook.error.ts
@@ -2,10 +2,8 @@ import { ChainId } from '@human-protocol/sdk';
 import { BaseError } from '../../common/errors/base';
 
 export enum WebhookErrorMessage {
-  URL_NOT_FOUND = 'Webhook url not found',
   INVALID_EVENT_TYPE = 'Invalid event type',
   NOT_SENT = 'Webhook was not sent',
-  PENDING_PROCESSING_FAILED = 'Failed to process pending webhook',
 }
 
 export class IncomingWebhookError extends BaseError {


### PR DESCRIPTION
## Issue tracking
Part of #2928 

## Context behind the change
Removing `ControlledError` from escrow-completion module as per refactoring plan.
WIth this module it was decided to not create custom error classes because there is no need to control execution flow based on specific error type, it's enough to just throw and log details in place.

## How has this been tested?
- [x] just replacing existing errors, so lint + build
- [x] existing unit tests pass 

## Release plan
Simply merge.

## Potential risks; What to monitor; Rollback plan
Can't think of any