### PR TITLE
fix: broken dependency causing Docker builds to fail

### DIFF
--- a/.github/workflows/ci-test-cvat-recording-oracle.yaml
+++ b/.github/workflows/ci-test-cvat-recording-oracle.yaml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'packages/examples/cvat/recording-oracle/**'
-      - 'packages/sdk/python/human-protocol-sdk/**'
+      - 'packages/core/**'
 
 jobs:
   cvat-exo-test:

--- a/packages/examples/cvat/recording-oracle/docker-compose.test.yml
+++ b/packages/examples/cvat/recording-oracle/docker-compose.test.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_USER: 'test'
       POSTGRES_DB: 'recording_oracle_test'
       PGDATA: '/var/lib/postgresql/data/pgdata'
-    ports:
-      - 5434:5432
     command: ["postgres", "-c", "log_statement=all"]
     networks:
       - test-network
@@ -19,19 +17,16 @@ services:
       dockerfile: packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
     healthcheck:
       # Using a magic nubmer of 23 here because this is a block number when blockchain-node container is ready to use
-      test: if [ $(( $(wget -q --post-data='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' -O- http://blockchain-node:8545 | grep -o '"result":"[^"]*"' | awk -F'"' '{print $4}' ) )) -ge 23 ]; then exit 0; else exit 1; fi
+      test: if [ $(( $(wget -q --post-data='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' -O- http://localhost:8545 | grep -o '"result":"[^"]*"' | awk -F'"' '{print $4}' ) )) -ge 23 ]; then exit 0; else exit 1; fi
       interval: 15s
       timeout: 5s
-      retries: 15
+      retries: 5
     networks:
       - test-network
 
   minio:
     container_name: minio
     image: minio/minio:RELEASE.2022-05-26T05-48-41Z
-    ports:
-      - 9001:9001
-      - 9000:9000
     environment:
       MINIO_ROOT_USER: dev
       MINIO_ROOT_PASSWORD: devdevdev
@@ -63,7 +58,6 @@ services:
       "
     networks:
       - test-network
-
 
   test:
     build:

--- a/packages/examples/cvat/recording-oracle/docker-compose.test.yml
+++ b/packages/examples/cvat/recording-oracle/docker-compose.test.yml
@@ -15,8 +15,8 @@ services:
 
   blockchain-node:
     build: 
-      context: ./
-      dockerfile: dockerfiles/blockchain-node.Dockerfile
+      context: ../../../../
+      dockerfile: packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
     healthcheck:
       # Using a magic nubmer of 23 here because this is a block number when blockchain-node container is ready to use
       test: if [ $(( $(wget -q --post-data='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' -O- http://blockchain-node:8545 | grep -o '"result":"[^"]*"' | awk -F'"' '{print $4}' ) )) -ge 23 ]; then exit 0; else exit 1; fi

--- a/packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
+++ b/packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
@@ -1,6 +1,9 @@
 # TODO: make this shared and part of local setup
 FROM node:18-slim
 
+# wget is needed for healthcheck
+RUN apt-get update && apt-get install -y wget
+
 WORKDIR /usr/src/app
 
 # Copy expected yarn dist

--- a/packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
+++ b/packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
@@ -1,12 +1,17 @@
-FROM node:18-alpine
+# TODO: make this shared and part of local setup
+FROM node:18-slim
 
-RUN apk add git
+WORKDIR /usr/src/app
 
-RUN git clone https://github.com/humanprotocol/human-protocol.git
+# Copy expected yarn dist
+COPY .yarn ./.yarn
+COPY .yarnrc ./
+# Copy files for deps installation
+COPY package.json yarn.lock ./
 
-WORKDIR /human-protocol
-
+COPY tsconfig.json ./
+COPY packages/core ./packages/core
+RUN yarn workspace @human-protocol/core install --ignore-scripts
 EXPOSE 8545
 
-RUN yarn workspace @human-protocol/core install --ignore-scripts
 CMD yarn workspace @human-protocol/core local

--- a/packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
+++ b/packages/examples/cvat/recording-oracle/dockerfiles/blockchain-node.Dockerfile
@@ -12,6 +12,7 @@ COPY package.json yarn.lock ./
 COPY tsconfig.json ./
 COPY packages/core ./packages/core
 RUN yarn workspace @human-protocol/core install --ignore-scripts
-EXPOSE 8545
+RUN yarn workspace @human-protocol/core build
 
+EXPOSE 8545
 CMD yarn workspace @human-protocol/core local

--- a/yarn.lock
+++ b/yarn.lock
@@ -4260,12 +4260,12 @@
     undici "^6.11.1"
 
 "@openzeppelin/upgrades-core@^1.32.2", "@openzeppelin/upgrades-core@^1.41.0":
-  version "1.42.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.42.1.tgz#a2784e8d9c09f4a79b7e5cbb11933062ad709835"
-  integrity sha512-8qnz2XfQrco8R8u9NjV+KiSLrVn7DnWFd+3BuhTUjhVy0bzCSu2SMKCVpZLtXbxf4f2dpz8jYPQYRa6s23PhLA==
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.41.0.tgz#3a5e044cf53acd50c392f3297e7c37e4ff8f8355"
+  integrity sha512-+oryinqZnxkiZvg7bWqWX4Ki/CNwVUZEqC6Elpi5PQoahpL3/6Sq9xjIozD5AiI2O61h8JHQ+A//5NtczyavJw==
   dependencies:
     "@nomicfoundation/slang" "^0.18.3"
-    cbor "^10.0.0"
+    cbor "^9.0.0"
     chalk "^4.1.0"
     compare-versions "^6.0.0"
     debug "^4.1.1"
@@ -9040,13 +9040,6 @@ caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
-
-cbor@^10.0.0:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/cbor/-/cbor-10.0.3.tgz#202d79cd696f408700af51b0c9771577048a860e"
-  integrity sha512-72Jnj81xMsqepqdcSdf2+fflz/UDsThOHy5hj2MW5F5xzHL8Oa0KQ6I6V9CwVUPxg5pf+W9xp6W2KilaRXWWtw==
-  dependencies:
-    nofilter "^3.0.2"
 
 cbor@^8.1.0:
   version "8.1.0"
@@ -15913,7 +15906,7 @@ node-stdlib-browser@^1.2.0:
     util "^0.12.4"
     vm-browserify "^1.0.1"
 
-nofilter@^3.0.2, nofilter@^3.1.0:
+nofilter@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
   integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/1128
After recent deps update we got one dependency with the issue, so rolling it back.
Also refactored Docker file for CVAT tests bloackchain node to be build from the pulled code, not `develop`

## How has this been tested?
- [x] `docker-compose -f docker-compose.test.yml up blockchain-node --build` successful
- [x] running any service in `scripts/cvat` (local docker setup) successful 

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
No