### PR TITLE
[Reputation Oracle] test: cover health controller with unit tests

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/health/health.controller.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/health/health.controller.spec.ts
@@ -1,0 +1,136 @@
+import { faker } from '@faker-js/faker';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  HealthIndicatorResult,
+  HealthIndicatorStatus,
+  TerminusModule,
+  TypeOrmHealthIndicator,
+} from '@nestjs/terminus';
+import { nestLoggerOverride } from '../../logger';
+import { ServerConfigService } from '../../config/server-config.service';
+import { HealthController } from './health.controller';
+
+const mockServerConfigService = {
+  gitHash: faker.git.commitSha(),
+};
+
+const mockTypeOrmPingCheck = jest.fn();
+
+function generateMockHealthIndicatorResult(
+  testKey: string,
+  status: HealthIndicatorStatus,
+): HealthIndicatorResult {
+  return {
+    [testKey]: {
+      status,
+    },
+  };
+}
+
+describe('HealthController', () => {
+  let healthController: HealthController;
+
+  beforeAll(async () => {
+    const moduleBuilder = Test.createTestingModule({
+      imports: [TerminusModule],
+      controllers: [HealthController],
+      providers: [
+        {
+          provide: ServerConfigService,
+          useValue: mockServerConfigService,
+        },
+        {
+          provide: TypeOrmHealthIndicator,
+          useValue: {
+            pingCheck: mockTypeOrmPingCheck,
+          },
+        },
+      ],
+    });
+
+    /**
+     * Terminus uses nest logger internaly,
+     * so override to omit logs in tests
+     */
+    moduleBuilder.setLogger(nestLoggerOverride);
+
+    const moduleRef = await moduleBuilder.compile();
+
+    healthController = moduleRef.get(HealthController);
+  });
+
+  it('/ping should return proper info', async () => {
+    await expect(healthController.ping()).resolves.toEqual({
+      appName: '@human-protocol/reputation-oracle',
+      gitHash: mockServerConfigService.gitHash,
+      nodeEnv: 'test',
+    });
+  });
+
+  describe('/check', () => {
+    const expectedDbTestKey = 'database';
+    const expectedPingCheckOptions = {
+      timeout: 5000,
+    };
+
+    afterEach(() => {
+      mockTypeOrmPingCheck.mockReset();
+    });
+
+    it(`returns 'up' status when db is up`, async () => {
+      const statusUp = 'up';
+      mockTypeOrmPingCheck.mockResolvedValueOnce(
+        generateMockHealthIndicatorResult(expectedDbTestKey, statusUp),
+      );
+
+      await expect(healthController.check()).resolves.toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          info: {
+            [expectedDbTestKey]: {
+              status: statusUp,
+            },
+          },
+        }),
+      );
+      expect(mockTypeOrmPingCheck).toHaveBeenCalledTimes(1);
+      expect(mockTypeOrmPingCheck).toHaveBeenCalledWith(
+        expectedDbTestKey,
+        expectedPingCheckOptions,
+      );
+    });
+
+    it(`returns 'down' status when db is down`, async () => {
+      const statusDown = 'down';
+
+      mockTypeOrmPingCheck.mockResolvedValueOnce(
+        generateMockHealthIndicatorResult(expectedDbTestKey, statusDown),
+      );
+      let thrownError;
+      try {
+        await healthController.check();
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(ServiceUnavailableException);
+      expect(thrownError.response).toEqual(
+        expect.objectContaining({
+          status: 'error',
+          info: {},
+          error: {
+            [expectedDbTestKey]: {
+              status: statusDown,
+            },
+          },
+        }),
+      );
+      expect(mockTypeOrmPingCheck).toHaveBeenCalledTimes(1);
+      expect(mockTypeOrmPingCheck).toHaveBeenCalledWith(
+        expectedDbTestKey,
+        expectedPingCheckOptions,
+      );
+    });
+  });
+});

--- a/packages/apps/reputation-oracle/server/src/modules/health/health.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/health/health.controller.ts
@@ -52,7 +52,7 @@ export class HealthController {
   })
   @HealthCheck()
   @Get('/check')
-  readiness(): Promise<HealthCheckResult> {
+  check(): Promise<HealthCheckResult> {
     return this.health.check([
       async (): Promise<HealthIndicatorResult> =>
         this.db.pingCheck('database', {


### PR DESCRIPTION
## Issue tracking
Part of #3084 

## Context behind the change
`health` module doesn't have much business logic, so just covering controller with unit tests to make sure we will get what we expect in health checks.

## How has this been tested?
- [x] Run new unit tests locally, they should pass and write 0 extra logs

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
No