### PR TITLE
[HUMAN App] fix: show governance banner only for workers

### DIFF
--- a/packages/apps/human-app/frontend/src/router/router.tsx
+++ b/packages/apps/human-app/frontend/src/router/router.tsx
@@ -69,6 +69,7 @@ export function Router() {
                   renderHCaptchaStatisticsDrawer={(isOpen) => (
                     <UserStatsDrawer isOpen={isOpen} />
                   )}
+                  renderGovernanceBanner
                 />
               </RequireAuth>
             }

--- a/packages/apps/human-app/frontend/src/shared/components/layout/protected/layout.tsx
+++ b/packages/apps/human-app/frontend/src/shared/components/layout/protected/layout.tsx
@@ -38,6 +38,7 @@ export function Layout({
   pageHeaderProps,
   renderDrawer,
   renderHCaptchaStatisticsDrawer,
+  renderGovernanceBanner,
 }: {
   pageHeaderProps: PageHeaderProps;
   renderDrawer: (
@@ -45,6 +46,7 @@ export function Layout({
     setDrawerOpen: Dispatch<SetStateAction<boolean>>
   ) => JSX.Element;
   renderHCaptchaStatisticsDrawer?: (isOpen: boolean) => JSX.Element;
+  renderGovernanceBanner?: boolean;
 }) {
   const layoutElementRef = useRef<HTMLDivElement>();
   const isHCaptchaLabelingPage = useIsHCaptchaLabelingPage();
@@ -118,7 +120,7 @@ export function Layout({
             },
           }}
         >
-          <GovernanceBanner />
+          {renderGovernanceBanner && <GovernanceBanner />}
           <Grid item>
             <PageHeader {...pageHeaderProps} />
           </Grid>


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Operator UI is currently broken because we attempt to render `GovernanceBanner` that uses `useWorkerKycStatus` -> `useAuthenticatedUser` -> `AuthenticatedUserContext`, which is available only for worker user, not operator.
Fixing it by displaying banner only for worker layout

## How has this been tested?
- [x] logic as an operator, profile info should be displayed

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
No