### PR TITLE
[Job Launcher Server] Move withdrawal creation logic to payments module

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -3,12 +3,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { Encryption } from '@human-protocol/sdk';
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
-import {
-  PaymentCurrency,
-  PaymentSource,
-  PaymentStatus,
-  PaymentType,
-} from '../../common/enums/payment';
+import { PaymentCurrency } from '../../common/enums/payment';
 import {
   JobRequestType,
   JobStatus,
@@ -39,7 +34,6 @@ import { mul } from '../../common/utils/decimal';
 describe('JobService', () => {
   let jobService: JobService,
     paymentService: PaymentService,
-    paymentRepository: PaymentRepository,
     jobRepository: JobRepository,
     rateService: RateService;
 
@@ -110,7 +104,6 @@ describe('JobService', () => {
 
     jobService = moduleRef.get<JobService>(JobService);
     paymentService = moduleRef.get<PaymentService>(PaymentService);
-    paymentRepository = moduleRef.get<PaymentRepository>(PaymentRepository);
     rateService = moduleRef.get<RateService>(RateService);
     jobRepository = moduleRef.get<JobRepository>(JobRepository);
   });
@@ -163,19 +156,16 @@ describe('JobService', () => {
             fortuneJobDto,
           );
 
-          expect(paymentRepository.createUnique).toHaveBeenCalledWith({
-            userId: userMock.id,
-            jobId: jobEntityMock.id,
-            source: PaymentSource.BALANCE,
-            type: PaymentType.WITHDRAWAL,
-            currency: fortuneJobDto.paymentCurrency,
-            amount: expect.any(Number),
-            rate: await rateService.getRate(
+          expect(paymentService.createWithdrawalPayment).toHaveBeenCalledWith(
+            userMock.id,
+            jobEntityMock.id,
+            expect.any(Number),
+            fortuneJobDto.paymentCurrency,
+            await rateService.getRate(
               fortuneJobDto.paymentCurrency,
               PaymentCurrency.USD,
             ),
-            status: PaymentStatus.SUCCEEDED,
-          });
+          );
           expect(jobRepository.createUnique).toHaveBeenCalledWith({
             chainId: fortuneJobDto.chainId,
             userId: userMock.id,
@@ -234,16 +224,13 @@ describe('JobService', () => {
             fortuneJobDto,
           );
 
-          expect(paymentRepository.createUnique).toHaveBeenCalledWith({
-            userId: userMock.id,
-            jobId: jobEntityMock.id,
-            source: PaymentSource.BALANCE,
-            type: PaymentType.WITHDRAWAL,
-            currency: fortuneJobDto.paymentCurrency,
-            amount: expect.any(Number),
-            rate: paymentToUsdRate,
-            status: PaymentStatus.SUCCEEDED,
-          });
+          expect(paymentService.createWithdrawalPayment).toHaveBeenCalledWith(
+            userMock.id,
+            jobEntityMock.id,
+            expect.any(Number),
+            fortuneJobDto.paymentCurrency,
+            paymentToUsdRate,
+          );
           expect(jobRepository.createUnique).toHaveBeenCalledWith({
             chainId: fortuneJobDto.chainId,
             userId: userMock.id,

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.spec.ts
@@ -1529,4 +1529,61 @@ describe('PaymentService', () => {
       );
     });
   });
+
+  describe('createWithdrawalPayment', () => {
+    it('should create a withdrawal payment successfully', async () => {
+      const userId = 1;
+      const jobId = 2;
+      const amount = 100;
+      const currency = PaymentCurrency.USD;
+      const rate = 1;
+
+      jest
+        .spyOn(paymentRepository, 'createUnique')
+        .mockResolvedValueOnce(undefined as any);
+
+      await expect(
+        paymentService.createWithdrawalPayment(
+          userId,
+          jobId,
+          amount,
+          currency,
+          rate,
+        ),
+      ).resolves.not.toThrow();
+
+      expect(paymentRepository.createUnique).toHaveBeenCalledWith({
+        userId,
+        jobId,
+        source: PaymentSource.BALANCE,
+        type: PaymentType.WITHDRAWAL,
+        amount: -amount,
+        currency,
+        rate,
+        status: PaymentStatus.SUCCEEDED,
+      });
+    });
+
+    it('should throw an error if the payment creation fails', async () => {
+      const userId = 1;
+      const jobId = 2;
+      const amount = 100;
+      const currency = PaymentCurrency.USD;
+      const rate = 1;
+
+      jest
+        .spyOn(paymentRepository, 'createUnique')
+        .mockRejectedValueOnce(new Error('Database error'));
+
+      await expect(
+        paymentService.createWithdrawalPayment(
+          userId,
+          jobId,
+          amount,
+          currency,
+          rate,
+        ),
+      ).rejects.toThrow('Database error');
+    });
+  });
 });

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
@@ -518,6 +518,26 @@ export class PaymentService {
   //   return;
   // }
 
+  public async createWithdrawalPayment(
+    userId: number,
+    jobId: number,
+    amount: number,
+    currency: string,
+    rate: number,
+  ): Promise<void> {
+    const paymentEntity = new PaymentEntity();
+    paymentEntity.userId = userId;
+    paymentEntity.jobId = jobId;
+    paymentEntity.source = PaymentSource.BALANCE;
+    paymentEntity.type = PaymentType.WITHDRAWAL;
+    paymentEntity.amount = -amount; // In the currency used for the payment.
+    paymentEntity.currency = currency;
+    paymentEntity.rate = rate;
+    paymentEntity.status = PaymentStatus.SUCCEEDED;
+
+    await this.paymentRepository.createUnique(paymentEntity);
+  }
+
   async listUserPaymentMethods(user: UserEntity): Promise<CardDto[]> {
     const cards: CardDto[] = [];
     if (!user.stripeCustomerId) {


### PR DESCRIPTION
## Issue tracking
#3137

## Context behind the change
Move the withdrawal creation logic to the payments module

## How has this been tested?
Deployed locally and launched one new escrow

## Release plan
None

## Potential risks; What to monitor; Rollback plan
Check payment creation in DB