### PR TITLE
[Dashboard] Change third party service to get HMT price

### DIFF
--- a/packages/apps/dashboard/server/src/common/config/env-config.service.ts
+++ b/packages/apps/dashboard/server/src/common/config/env-config.service.ts
@@ -5,7 +5,7 @@ const DEFAULT_CORS_ALLOWED_ORIGIN = 'http://localhost:3001';
 const DEFAULT_CORS_ALLOWED_HEADERS = 'Content-Type, Accept';
 
 const DEFAULT_HMT_PRICE_SOURCE =
-  'https://api.coingecko.com/api/v3/simple/price?ids=human-protocol&vs_currencies=usd';
+  'https://api.coinlore.net/api/ticker/?id=53887';
 const DEFAULT_HMT_PRICE_FROM = 'human-protocol';
 const DEFAULT_HMT_PRICE_TO = 'usd';
 const DEFAULT_HCAPTCHA_STATS_SOURCE =
@@ -53,8 +53,10 @@ export class EnvironmentConfigService {
       DEFAULT_HMT_PRICE_SOURCE,
     );
   }
-  get hmtPriceSourceApiKey(): string {
-    return this.configService.getOrThrow<string>('HMT_PRICE_SOURCE_API_KEY');
+  get hmtPriceSourceApiKey(): string | undefined {
+    return this.configService.get<string | undefined>(
+      'HMT_PRICE_SOURCE_API_KEY',
+    );
   }
   get hmtPriceFromKey(): string {
     return this.configService.get<string>(


### PR DESCRIPTION
## Issue tracking
#3151

## Context behind the change
update HMT price source to CoinLore API and make system compatible with Coingecko and CoinLore in case we need to switch between them

## How has this been tested?
Deployed locally

## Release plan
Update `HMT_PRICE_SOURCE` and remove `HMT_PRICE_SOURCE_API_KEY` from current env to use CoinLore

## Potential risks; What to monitor; Rollback plan
None
 
  How will we handle any issues if they arise? Do we need rollback plan?
Undo env change