### PR TITLE
[Reputation Oracle] fix: add nda_url as required env

### DIFF
--- a/packages/apps/reputation-oracle/server/src/config/env-schema.ts
+++ b/packages/apps/reputation-oracle/server/src/config/env-schema.ts
@@ -8,6 +8,7 @@ export const envValidator = Joi.object({
   FE_URL: Joi.string(),
   MAX_RETRY_COUNT: Joi.number(),
   QUALIFICATION_MIN_VALIDITY: Joi.number(),
+  NDA_URL: Joi.string().required(),
   // Auth
   JWT_PRIVATE_KEY: Joi.string().required(),
   JWT_PUBLIC_KEY: Joi.string().required(),
@@ -15,6 +16,7 @@ export const envValidator = Joi.object({
   JWT_REFRESH_TOKEN_EXPIRES_IN: Joi.number(),
   VERIFY_EMAIL_TOKEN_EXPIRES_IN: Joi.number(),
   FORGOT_PASSWORD_TOKEN_EXPIRES_IN: Joi.number(),
+  // hCaptcha
   HCAPTCHA_SITE_KEY: Joi.string().required(),
   HCAPTCHA_SECRET: Joi.string().required(),
   HCAPTCHA_PROTECTION_URL: Joi.string().description(

--- a/scripts/cvat/docker-compose.local.yml
+++ b/scripts/cvat/docker-compose.local.yml
@@ -245,7 +245,6 @@ services:
       PORT: *backend_apps_internal_port
       POSTGRES_DATABASE: reputation-oracle
       S3_BUCKET: *bucket_name_rep_o
-      KYC_API_PRIVATE_KEY: ${KYC_API_PRIVATE_KEY:-none}
       HUMAN_APP_EMAIL: *human_app_email
       # It is accessed by user, not from container
       # so put here exposed port, not internal

--- a/scripts/cvat/env-files/.env.reputation-oracle
+++ b/scripts/cvat/env-files/.env.reputation-oracle
@@ -46,3 +46,6 @@ HKqYWMMM1e3JmFkHwmMXy03bpuWjDe3GAg==
 -----END PGP PUBLIC KEY BLOCK-----"
 
 KYC_API_KEY=disabled
+KYC_API_PRIVATE_KEY=none
+
+NDA_URL=https://humanprotocol.org


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Right now if `NDA_URL` is not provided app can start but it's not possible to sign-in. So we need to add `NDA_URL` as `reuiqred` var in env schema validation to avoid it.

## How has this been tested?
- [x] run RepO with and without `NDA_URL` specified in env variables

## Release plan
`NDA_URL` must be added to list of env vars

## Potential risks; What to monitor; Rollback plan
No