### PR TITLE
[Reputation Oracle] refactor: properly use auth strategies

### DIFF
--- a/packages/apps/reputation-oracle/server/src/app.module.ts
+++ b/packages/apps/reputation-oracle/server/src/app.module.ts
@@ -1,22 +1,27 @@
 import { Module } from '@nestjs/common';
-import { APP_FILTER, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
+
+import { envValidator } from './config';
+import { EnvConfigModule } from './config/config.module';
+
 import { DatabaseModule } from './database/database.module';
+
+import { JwtAuthGuard } from './common/guards';
+import { ExceptionFilter } from './common/filters/exception.filter';
+import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { HttpValidationPipe } from './common/pipes';
+
 import { HealthModule } from './modules/health/health.module';
 import { ReputationModule } from './modules/reputation/reputation.module';
 import { Web3Module } from './modules/web3/web3.module';
-import { envValidator } from './config';
 import { AuthModule } from './modules/auth/auth.module';
-import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { KycModule } from './modules/kyc/kyc.module';
 import { CronJobModule } from './modules/cron-job/cron-job.module';
 import { PayoutModule } from './modules/payout/payout.module';
-import { EnvConfigModule } from './config/config.module';
-import { ExceptionFilter } from './common/filters/exception.filter';
 import { QualificationModule } from './modules/qualification/qualification.module';
 import { EscrowCompletionModule } from './modules/escrow-completion/escrow-completion.module';
 import { WebhookIncomingModule } from './modules/webhook/webhook-incoming.module';
@@ -25,10 +30,15 @@ import { UserModule } from './modules/user/user.module';
 import { EmailModule } from './modules/email/module';
 import { NDAModule } from './modules/nda/nda.module';
 import { StorageModule } from './modules/storage/storage.module';
+
 import Environment from './utils/environment';
 
 @Module({
   providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
     {
       provide: APP_PIPE,
       useClass: HttpValidationPipe,

--- a/packages/apps/reputation-oracle/server/src/app.module.ts
+++ b/packages/apps/reputation-oracle/server/src/app.module.ts
@@ -26,7 +26,7 @@ import { QualificationModule } from './modules/qualification/qualification.modul
 import { EscrowCompletionModule } from './modules/escrow-completion/escrow-completion.module';
 import { WebhookIncomingModule } from './modules/webhook/webhook-incoming.module';
 import { WebhookOutgoingModule } from './modules/webhook/webhook-outgoing.module';
-import { UserModule } from './modules/user/user.module';
+import { UserModule } from './modules/user';
 import { EmailModule } from './modules/email/module';
 import { NDAModule } from './modules/nda/nda.module';
 import { StorageModule } from './modules/storage/storage.module';

--- a/packages/apps/reputation-oracle/server/src/common/decorators/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/decorators/index.ts
@@ -1,8 +1,11 @@
-import { SetMetadata } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { UserRole } from '../../modules/user';
 
-export const Public = (): ((target: any, key?: any, descriptor?: any) => any) =>
-  SetMetadata('isPublic', true);
+export const Public = Reflector.createDecorator<boolean>({
+  key: 'isPublic',
+  transform: () => true,
+});
 
-export const ROLES_KEY = 'roles';
-export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
+export const Roles = Reflector.createDecorator<UserRole[]>({
+  key: 'roles',
+});

--- a/packages/apps/reputation-oracle/server/src/common/decorators/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/decorators/index.ts
@@ -1,8 +1,8 @@
 import { SetMetadata } from '@nestjs/common';
-import { Role } from '../enums/user';
+import { UserRole } from '../../modules/user';
 
 export const Public = (): ((target: any, key?: any, descriptor?: any) => any) =>
   SetMetadata('isPublic', true);
 
 export const ROLES_KEY = 'roles';
-export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/packages/apps/reputation-oracle/server/src/common/enums/user.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/user.ts
@@ -1,16 +1,3 @@
-export enum UserStatus {
-  ACTIVE = 'active',
-  INACTIVE = 'inactive',
-  PENDING = 'pending',
-}
-
-export enum Role {
-  OPERATOR = 'operator',
-  WORKER = 'worker',
-  HUMAN_APP = 'human_app',
-  ADMIN = 'admin',
-}
-
 export enum KycStatus {
   NONE = 'none',
   APPROVED = 'approved',

--- a/packages/apps/reputation-oracle/server/src/common/guards/roles.auth.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/roles.auth.ts
@@ -6,7 +6,7 @@ import {
   HttpException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Role } from '../enums/user';
+import { UserRole } from '../../modules/user';
 import { ROLES_KEY } from '../decorators';
 
 @Injectable()
@@ -14,10 +14,10 @@ export class RolesAuthGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
 
     if (!requiredRoles) {
       return true;

--- a/packages/apps/reputation-oracle/server/src/common/guards/roles.auth.ts
+++ b/packages/apps/reputation-oracle/server/src/common/guards/roles.auth.ts
@@ -6,30 +6,34 @@ import {
   HttpException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { UserRole } from '../../modules/user';
-import { ROLES_KEY } from '../decorators';
+import { Roles } from '../decorators';
 
 @Injectable()
 export class RolesAuthGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
-      ROLES_KEY,
-      [context.getHandler(), context.getClass()],
-    );
+    const allowedRoles = this.reflector.getAllAndOverride(Roles, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
 
-    if (!requiredRoles) {
-      return true;
+    /**
+     * We don't use this guard globally, only on specific routes,
+     * so it's just a safety belt
+     */
+    if (!allowedRoles?.length) {
+      throw new Error(
+        'Allowed roles must be specified when using RolesAuthGuard',
+      );
     }
 
     const { user } = context.switchToHttp().getRequest();
-    const isAllowed = requiredRoles.some((role) => user.role === role);
 
-    if (isAllowed) {
+    if (allowedRoles.includes(user.role)) {
       return true;
     }
 
-    throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
   }
 }

--- a/packages/apps/reputation-oracle/server/src/common/interfaces/user.ts
+++ b/packages/apps/reputation-oracle/server/src/common/interfaces/user.ts
@@ -1,9 +1,0 @@
-import { UserStatus, Role } from '../enums/user';
-import { IBase } from './base';
-
-export interface IUser extends IBase {
-  password: string;
-  email: string;
-  status: UserStatus;
-  role: Role;
-}

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -1,9 +1,9 @@
 import {
-  ApiBearerAuth,
   ApiOperation,
   ApiResponse,
   ApiTags,
   ApiBody,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import {
   Body,
@@ -18,7 +18,6 @@ import {
 } from '@nestjs/common';
 import { Public } from '../../common/decorators';
 import { AuthService } from './auth.service';
-import { JwtAuthGuard } from '../../common/guards';
 import { RequestWithUser } from '../../common/interfaces/request';
 import { HCaptchaGuard } from '../../integrations/hcaptcha/hcaptcha.guard';
 import { TokenRepository } from './token.repository';
@@ -147,7 +146,7 @@ export class AuthController {
     description: 'Verification email resent successfully',
   })
   @ApiBearerAuth()
-  @UseGuards(HCaptchaGuard, JwtAuthGuard)
+  @UseGuards(HCaptchaGuard)
   @Post('/web2/resend-verification-email')
   @HttpCode(200)
   async resendEmailVerification(
@@ -223,7 +222,6 @@ export class AuthController {
     description: 'User logged out successfully',
   })
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
   @Post('/logout')
   @HttpCode(200)
   async logout(@Req() request: RequestWithUser): Promise<void> {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.module.ts
@@ -4,7 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { AuthConfigService } from '../../config/auth-config.service';
 import { HCaptchaModule } from '../../integrations/hcaptcha/hcaptcha.module';
 import { EmailModule } from '../email/module';
-import { UserModule } from '../user/user.module';
+import { UserModule } from '../user';
 import { Web3Module } from '../web3/web3.module';
 
 import { JwtHttpStrategy } from './strategy';

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -27,7 +27,6 @@ import { HCaptchaConfigService } from '../../config/hcaptcha-config.service';
 import { ServerConfigService } from '../../config/server-config.service';
 import { Web3ConfigService } from '../../config/web3-config.service';
 import { JobRequestType } from '../../common/enums';
-import { Role, UserStatus } from '../../common/enums/user';
 import { SignatureType } from '../../common/enums/web3';
 import {
   generateNonce,
@@ -37,9 +36,13 @@ import {
 import { HCaptchaService } from '../../integrations/hcaptcha/hcaptcha.service';
 import { SiteKeyRepository } from '../user/site-key.repository';
 import { PrepareSignatureDto } from '../user/user.dto';
-import { UserEntity } from '../user/user.entity';
-import { UserRepository } from '../user/user.repository';
-import { UserService } from '../user/user.service';
+import {
+  UserStatus,
+  UserRole,
+  UserEntity,
+  UserRepository,
+  UserService,
+} from '../user';
 import { Web3Service } from '../web3/web3.service';
 import {
   AuthError,
@@ -730,7 +733,7 @@ describe('AuthService', () => {
 
           const result = await authService.web3Signup({
             address: web3PreSignUpDto.address,
-            type: Role.WORKER,
+            type: UserRole.WORKER,
             signature,
           });
 
@@ -754,7 +757,7 @@ describe('AuthService', () => {
           await expect(
             authService.web3Signup({
               ...web3PreSignUpDto,
-              type: Role.WORKER,
+              type: UserRole.WORKER,
               signature: invalidSignature,
             }),
           ).rejects.toThrow(
@@ -769,7 +772,7 @@ describe('AuthService', () => {
           await expect(
             authService.web3Signup({
               ...web3PreSignUpDto,
-              type: Role.WORKER,
+              type: UserRole.WORKER,
               signature: signature,
             }),
           ).rejects.toThrow(new InvalidOperatorRoleError(''));
@@ -784,7 +787,7 @@ describe('AuthService', () => {
           await expect(
             authService.web3Signup({
               ...web3PreSignUpDto,
-              type: Role.WORKER,
+              type: UserRole.WORKER,
               signature: signature,
             }),
           ).rejects.toThrow(new InvalidOperatorFeeError(''));
@@ -800,7 +803,7 @@ describe('AuthService', () => {
           await expect(
             authService.web3Signup({
               ...web3PreSignUpDto,
-              type: Role.WORKER,
+              type: UserRole.WORKER,
               signature: signature,
             }),
           ).rejects.toThrow(new InvalidOperatorUrlError(''));
@@ -817,7 +820,7 @@ describe('AuthService', () => {
           await expect(
             authService.web3Signup({
               ...web3PreSignUpDto,
-              type: Role.WORKER,
+              type: UserRole.WORKER,
               signature: signature,
             }),
           ).rejects.toThrow(new InvalidOperatorJobTypesError(''));

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -8,14 +8,19 @@ import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 
 import { OperatorStatus } from '../../common/enums/user';
-import { UserStatus, UserRole, UserEntity, UserService } from '../user';
+import {
+  UserStatus,
+  UserRole,
+  UserEntity,
+  UserRepository,
+  UserService,
+} from '../user';
 import { TokenEntity, TokenType } from './token.entity';
 import { TokenRepository } from './token.repository';
 import { verifySignature } from '../../utils/web3';
 import { Web3Service } from '../web3/web3.service';
 import { SignatureType } from '../../common/enums/web3';
 import { prepareSignatureBody } from '../../utils/web3';
-import { UserRepository } from '../user/user.repository';
 import { AuthConfigService } from '../../config/auth-config.service';
 import { ServerConfigService } from '../../config/server-config.service';
 import { Web3ConfigService } from '../../config/web3-config.service';

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -7,13 +7,8 @@ import {
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 
-import {
-  OperatorStatus,
-  Role as UserRole,
-  UserStatus,
-} from '../../common/enums/user';
-import { UserEntity } from '../user/user.entity';
-import { UserService } from '../user/user.service';
+import { OperatorStatus } from '../../common/enums/user';
+import { UserStatus, UserRole, UserEntity, UserService } from '../user';
 import { TokenEntity, TokenType } from './token.entity';
 import { TokenRepository } from './token.repository';
 import { verifySignature } from '../../utils/web3';

--- a/packages/apps/reputation-oracle/server/src/modules/auth/dto/sign-up.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/dto/sign-up.dto.ts
@@ -6,7 +6,7 @@ import {
   IsLowercasedEnum,
   IsValidWeb3Signature,
 } from '../../../common/validators';
-import { Role } from '../../../common/enums/user';
+import { UserRole } from '../../user';
 
 export class Web2SignUpDto {
   @ApiProperty()
@@ -28,10 +28,10 @@ export class Web3SignUpDto {
   public signature: string;
 
   @ApiProperty({
-    enum: Role,
+    enum: UserRole,
   })
-  @IsLowercasedEnum(Role)
-  public type: Role;
+  @IsLowercasedEnum(UserRole)
+  public type: UserRole;
 
   @ApiProperty()
   @IsEthereumAddress()

--- a/packages/apps/reputation-oracle/server/src/modules/auth/strategy/jwt.http.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/strategy/jwt.http.ts
@@ -2,14 +2,12 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, Req, UnauthorizedException } from '@nestjs/common';
 
-import { UserEntity } from '../../user/user.entity';
 import {
   JWT_STRATEGY_NAME,
   LOGOUT_PATH,
   RESEND_EMAIL_VERIFICATION_PATH,
 } from '../../../common/constants';
-import { UserStatus } from '../../../common/enums/user';
-import { UserRepository } from '../../user/user.repository';
+import { UserEntity, UserStatus, UserRepository } from '../../user';
 import { AuthConfigService } from '../../../config/auth-config.service';
 import { TokenRepository } from '../token.repository';
 import { TokenType } from '../token.entity';

--- a/packages/apps/reputation-oracle/server/src/modules/auth/strategy/jwt.http.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/strategy/jwt.http.ts
@@ -20,7 +20,7 @@ export class JwtHttpStrategy extends PassportStrategy(
   constructor(
     private readonly userRepository: UserRepository,
     private readonly tokenRepository: TokenRepository,
-    private readonly authConfigService: AuthConfigService,
+    authConfigService: AuthConfigService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -30,7 +30,7 @@ export class JwtHttpStrategy extends PassportStrategy(
     });
   }
 
-  public async validate(
+  async validate(
     @Req() request: any,
     payload: { userId: number },
   ): Promise<UserEntity> {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/token.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/token.entity.ts
@@ -6,7 +6,10 @@ import {
   JoinColumn,
   ManyToOne,
 } from 'typeorm';
-
+/**
+ * TODO: Leave fix follow-up refactoring
+ * Importing from '../user' causes circular import error here.
+ */
 import { UserEntity } from '../user/user.entity';
 import { BaseEntity } from '../../database/base.entity';
 import { DATABASE_SCHEMA_NAME } from '../../common/constants';

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
@@ -16,7 +16,7 @@ import {
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
-import { JwtAuthGuard } from '../../common/guards';
+import { Public } from '../../common/decorators';
 import { RequestWithUser } from '../../common/interfaces/request';
 import { KycSessionDto, KycSignedAddressDto, KycStatusDto } from './kyc.dto';
 import { KycService } from './kyc.service';
@@ -39,7 +39,6 @@ export class KycController {
     type: KycSessionDto,
   })
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
   @Post('/start')
   @HttpCode(200)
   async startKyc(@Req() request: RequestWithUser): Promise<KycSessionDto> {
@@ -72,6 +71,7 @@ export class KycController {
     status: 200,
     description: 'Kyc status updated successfully',
   })
+  @Public()
   @Post('/update')
   @UseGuards(KycWebhookAuthGuard)
   @HttpCode(200)
@@ -89,7 +89,6 @@ export class KycController {
     type: KycSignedAddressDto,
   })
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
   @Get('/on-chain')
   @HttpCode(200)
   async getSignedAddress(

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.entity.ts
@@ -3,6 +3,10 @@ import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
 import { KycStatus } from '../../common/enums/user';
 import { DATABASE_SCHEMA_NAME } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
+/**
+ * TODO: Leave fix follow-up refactoring
+ * Importing from '../user' causes circular import error here.
+ */
 import { UserEntity } from '../user/user.entity';
 
 @Entity({ schema: DATABASE_SCHEMA_NAME, name: 'kycs' })

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.module.ts
@@ -1,7 +1,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 
-import { UserModule } from '../user/user.module';
+import { UserModule } from '../user';
 import { Web3Module } from '../web3/web3.module';
 
 import { KycService } from './kyc.service';

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { UserEntity } from '../user/user.entity';
+import { UserEntity } from '../user';
 import { HttpService } from '@nestjs/axios';
 import { KycSessionDto, KycSignedAddressDto, KycStatusDto } from './kyc.dto';
 import { KycRepository } from './kyc.repository';

--- a/packages/apps/reputation-oracle/server/src/modules/nda/nda.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/nda.controller.ts
@@ -5,7 +5,6 @@ import {
   Body,
   Req,
   UseFilters,
-  UseGuards,
   HttpCode,
 } from '@nestjs/common';
 import { NDAService } from './nda.service';
@@ -16,16 +15,14 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { JwtAuthGuard } from 'src/common/guards';
 import { RequestWithUser } from 'src/common/interfaces/request';
 import { NDAErrorFilter } from './nda.error.filter';
 import { AuthConfigService } from 'src/config/auth-config.service';
 import { NDASignatureDto } from './nda.dto';
 
 @ApiTags('NDA')
-@UseFilters(NDAErrorFilter)
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseFilters(NDAErrorFilter)
 @Controller('nda')
 export class NDAController {
   constructor(

--- a/packages/apps/reputation-oracle/server/src/modules/nda/nda.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/nda.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { NDAController } from './nda.controller';
 import { NDAService } from './nda.service';
-import { UserModule } from '../user/user.module';
+import { UserModule } from '../user';
 
 @Module({
   imports: [UserModule],

--- a/packages/apps/reputation-oracle/server/src/modules/nda/nda.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/nda.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { AuthConfigService } from '../../config/auth-config.service';
-import { UserEntity } from '../user/user.entity';
-import { UserRepository } from '../user/user.repository';
+import { UserEntity, UserRepository } from '../user';
 import { NDASignatureDto } from './nda.dto';
 import { NDAError, NDAErrorMessage } from './nda.error';
 

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.controller.ts
@@ -24,14 +24,13 @@ import {
   QualificationDto,
 } from './qualification.dto';
 import { QualificationErrorFilter } from './qualification.error.filter';
-import { JwtAuthGuard, RolesAuthGuard } from '../../common/guards';
+import { RolesAuthGuard } from '../../common/guards';
 import { QualificationService } from './qualification.service';
-import { Roles } from '../../common/decorators';
+import { Public, Roles } from '../../common/decorators';
 import { UserRole } from '../user';
 
 @ApiTags('Qualification')
 @Controller('qualifications')
-@ApiBearerAuth()
 @UseFilters(QualificationErrorFilter)
 export class QualificationController {
   constructor(private readonly qualificationService: QualificationService) {}
@@ -43,8 +42,9 @@ export class QualificationController {
     description: 'Qualification created successfully',
     type: QualificationDto,
   })
-  @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @UseGuards(RolesAuthGuard)
+  @Roles([UserRole.ADMIN])
   @Post()
   @HttpCode(201)
   /**
@@ -67,6 +67,7 @@ export class QualificationController {
     type: QualificationDto,
     isArray: true,
   })
+  @Public()
   @Get()
   @HttpCode(200)
   async getQualifications(): Promise<QualificationDto[]> {
@@ -86,8 +87,9 @@ export class QualificationController {
     status: 422,
     description: 'Cannot delete qualification',
   })
-  @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @UseGuards(RolesAuthGuard)
+  @Roles([UserRole.ADMIN])
   @Delete('/:reference')
   @HttpCode(204)
   async deleteQualification(
@@ -103,8 +105,9 @@ export class QualificationController {
     description: 'Qualification assigned successfully',
   })
   @ApiResponse({ status: 422, description: 'No users found for operation' })
-  @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @UseGuards(RolesAuthGuard)
+  @Roles([UserRole.ADMIN])
   @Post('/:reference/assign')
   @HttpCode(200)
   async assign(
@@ -124,8 +127,9 @@ export class QualificationController {
     description: 'Qualification unassigned successfully',
   })
   @ApiResponse({ status: 422, description: 'No users found for operation' })
-  @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @UseGuards(RolesAuthGuard)
+  @Roles([UserRole.ADMIN])
   @Post('/:reference/unassign')
   @HttpCode(200)
   async unassign(

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.controller.ts
@@ -27,7 +27,7 @@ import { QualificationErrorFilter } from './qualification.error.filter';
 import { JwtAuthGuard, RolesAuthGuard } from '../../common/guards';
 import { QualificationService } from './qualification.service';
 import { Roles } from '../../common/decorators';
-import { Role } from '../../common/enums/user';
+import { UserRole } from '../user';
 
 @ApiTags('Qualification')
 @Controller('qualifications')
@@ -44,7 +44,7 @@ export class QualificationController {
     type: QualificationDto,
   })
   @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(Role.ADMIN)
+  @Roles(UserRole.ADMIN)
   @Post()
   @HttpCode(201)
   /**
@@ -87,7 +87,7 @@ export class QualificationController {
     description: 'Cannot delete qualification',
   })
   @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(Role.ADMIN)
+  @Roles(UserRole.ADMIN)
   @Delete('/:reference')
   @HttpCode(204)
   async deleteQualification(
@@ -104,7 +104,7 @@ export class QualificationController {
   })
   @ApiResponse({ status: 422, description: 'No users found for operation' })
   @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(Role.ADMIN)
+  @Roles(UserRole.ADMIN)
   @Post('/:reference/assign')
   @HttpCode(200)
   async assign(
@@ -125,7 +125,7 @@ export class QualificationController {
   })
   @ApiResponse({ status: 422, description: 'No users found for operation' })
   @UseGuards(JwtAuthGuard, RolesAuthGuard)
-  @Roles(Role.ADMIN)
+  @Roles(UserRole.ADMIN)
   @Post('/:reference/unassign')
   @HttpCode(200)
   async unassign(

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 
-import { UserModule } from '../user/user.module';
+import { UserModule } from '../user';
 
 import { QualificationService } from './qualification.service';
 import { QualificationRepository } from './qualification.repository';

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BaseRepository } from '../../database/base.repository';
 import { DataSource, In, IsNull, MoreThan } from 'typeorm';
 import { QualificationEntity } from './qualification.entity';
-import { UserEntity } from '../user/user.entity';
+import { UserEntity } from '../user';
 import { UserQualificationEntity } from './user-qualification.entity';
 
 @Injectable()

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.ts
@@ -2,9 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateQualificationDto, QualificationDto } from './qualification.dto';
 import { QualificationEntity } from './qualification.entity';
 import { QualificationRepository } from './qualification.repository';
-import { UserEntity } from '../user/user.entity';
-import { UserRepository } from '../user/user.repository';
-import { UserStatus, Role } from '../../common/enums/user';
+import { UserEntity, UserRepository, UserStatus, UserRole } from '../user';
 import { UserQualificationEntity } from './user-qualification.entity';
 import { ServerConfigService } from '../../config/server-config.service';
 import {
@@ -184,7 +182,7 @@ export class QualificationService {
   public async getWorkers(addresses: string[]): Promise<UserEntity[]> {
     const users = await this.userRepository.findByAddress(
       addresses,
-      Role.WORKER,
+      UserRole.WORKER,
       UserStatus.ACTIVE,
     );
 

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/user-qualification.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/user-qualification.entity.ts
@@ -1,6 +1,10 @@
 import { Entity, ManyToOne } from 'typeorm';
 import { DATABASE_SCHEMA_NAME } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
+/**
+ * TODO: Leave fix follow-up refactoring
+ * Importing from '../user' causes circular import error here.
+ */
 import { UserEntity } from '../user/user.entity';
 import { QualificationEntity } from '../qualification/qualification.entity';
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/index.ts
@@ -1,0 +1,4 @@
+export { UserEntity, UserStatus, Role as UserRole } from './user.entity';
+export { UserRepository } from './user.repository';
+export { UserService } from './user.service';
+export { UserModule } from './user.module';

--- a/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/site-key.entity.ts
@@ -1,6 +1,10 @@
 import { Entity, Column, JoinColumn, ManyToOne, Unique } from 'typeorm';
 import { DATABASE_SCHEMA_NAME } from '../../common/constants';
 import { BaseEntity } from '../../database/base.entity';
+/**
+ * TODO: Leave fix follow-up refactoring
+ * Importing from '../user' causes circular import error here.
+ */
 import { UserEntity } from './user.entity';
 import { SiteKeyType } from '../../common/enums';
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -17,7 +17,6 @@ import {
   UseFilters,
 } from '@nestjs/common';
 import { Public } from '../../common/decorators';
-import { JwtAuthGuard } from '../../common/guards';
 import { SignatureType } from '../../common/enums/web3';
 import { RequestWithUser } from '../../common/interfaces/request';
 import { Web3ConfigService } from '../../config/web3-config.service';
@@ -47,9 +46,9 @@ import { UserErrorFilter } from './user.error.filter';
  * 2) Move "prepare-signature" out of this module
  */
 @ApiTags('User')
+@ApiBearerAuth()
 @Controller('/user')
 @UseFilters(UserErrorFilter)
-@ApiBearerAuth()
 export class UserController {
   constructor(
     private readonly userService: UserService,
@@ -66,7 +65,6 @@ export class UserController {
     description: 'Labeler registered successfully',
     type: RegisterLabelerResponseDto,
   })
-  @UseGuards(JwtAuthGuard)
   @Post('/register-labeler')
   @HttpCode(200)
   async registerLabeler(
@@ -90,7 +88,6 @@ export class UserController {
     status: 409,
     description: 'Provided address already registered',
   })
-  @UseGuards(JwtAuthGuard)
   @Post('/register-address')
   @HttpCode(200)
   async registerAddress(
@@ -109,7 +106,6 @@ export class UserController {
     status: 200,
     description: 'Operator enabled succesfully',
   })
-  @UseGuards(JwtAuthGuard)
   @Post('/enable-operator')
   @HttpCode(200)
   async enableOperator(
@@ -128,7 +124,6 @@ export class UserController {
     status: 200,
     description: 'Operator disabled succesfully',
   })
-  @UseGuards(JwtAuthGuard)
   @Post('/disable-operator')
   @HttpCode(200)
   async disableOperator(
@@ -181,7 +176,7 @@ export class UserController {
     description: 'Oracle registered successfully',
     type: RegistrationInExchangeOracleDto,
   })
-  @UseGuards(HCaptchaGuard, JwtAuthGuard)
+  @UseGuards(HCaptchaGuard)
   @Post('/exchange-oracle-registration')
   @HttpCode(200)
   async registrationInExchangeOracle(
@@ -210,7 +205,6 @@ export class UserController {
     status: 401,
     description: 'Unauthorized. Missing or invalid credentials.',
   })
-  @UseGuards(JwtAuthGuard)
   @Get('/exchange-oracle-registration')
   async getRegistrationInExchangeOracles(
     @Req() request: RequestWithUser,

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.entity.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.entity.ts
@@ -2,16 +2,27 @@ import { Exclude } from 'class-transformer';
 import { Column, Entity, OneToMany, OneToOne } from 'typeorm';
 
 import { DATABASE_SCHEMA_NAME } from '../../common/constants';
-import { UserStatus, Role } from '../../common/enums/user';
-import { IUser } from '../../common/interfaces/user';
 import { BaseEntity } from '../../database/base.entity';
 import { TokenEntity } from '../auth/token.entity';
 import { KycEntity } from '../kyc/kyc.entity';
 import { SiteKeyEntity } from './site-key.entity';
 import { UserQualificationEntity } from '../qualification/user-qualification.entity';
 
+export enum UserStatus {
+  ACTIVE = 'active',
+  PENDING = 'pending',
+  INACTIVE = 'inactive',
+}
+
+export enum Role {
+  OPERATOR = 'operator',
+  WORKER = 'worker',
+  HUMAN_APP = 'human_app',
+  ADMIN = 'admin',
+}
+
 @Entity({ schema: DATABASE_SCHEMA_NAME, name: 'users' })
-export class UserEntity extends BaseEntity implements IUser {
+export class UserEntity extends BaseEntity {
   @Exclude()
   @Column({ type: 'varchar', nullable: true })
   public password: string;

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.repository.ts
@@ -1,12 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { BaseRepository } from '../../database/base.repository';
-import { UserEntity } from './user.entity';
-import { Role, UserStatus } from '../../common/enums/user';
+import { Role, UserStatus, UserEntity } from './user.entity';
 
 @Injectable()
 export class UserRepository extends BaseRepository<UserEntity> {
-  constructor(private dataSource: DataSource) {
+  constructor(dataSource: DataSource) {
     super(UserEntity, dataSource);
   }
 

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.spec.ts
@@ -1,15 +1,16 @@
-import { Test } from '@nestjs/testing';
 import { createMock } from '@golevelup/ts-jest';
+import { ChainId, KVStoreClient, KVStoreUtils } from '@human-protocol/sdk';
+
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { DeepPartial } from 'typeorm';
+
 import { UserRepository } from './user.repository';
 import { UserService } from './user.service';
 import { RegistrationInExchangeOracleDto } from './user.dto';
-import { UserEntity } from './user.entity';
-import {
-  KycStatus,
-  OperatorStatus,
-  UserStatus,
-  Role,
-} from '../../common/enums/user';
+import { UserStatus, Role, UserEntity } from './user.entity';
+import { KycStatus, OperatorStatus } from '../../common/enums/user';
 import { signMessage, prepareSignatureBody } from '../../utils/web3';
 import {
   MOCK_ADDRESS,
@@ -17,9 +18,6 @@ import {
   MOCK_PRIVATE_KEY,
 } from '../../../test/constants';
 import { Web3Service } from '../web3/web3.service';
-import { DeepPartial } from 'typeorm';
-import { ChainId, KVStoreClient, KVStoreUtils } from '@human-protocol/sdk';
-import { ConfigService } from '@nestjs/config';
 import { SignatureBodyDto } from '../user/user.dto';
 import { SignatureType } from '../../common/enums/web3';
 import { Web3ConfigService } from '../../config/web3-config.service';
@@ -27,7 +25,6 @@ import { SiteKeyRepository } from './site-key.repository';
 import { SiteKeyEntity } from './site-key.entity';
 import { HCaptchaService } from '../../integrations/hcaptcha/hcaptcha.service';
 import { HCaptchaConfigService } from '../../config/hcaptcha-config.service';
-import { HttpService } from '@nestjs/axios';
 import {
   UserError,
   UserErrorMessage,

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.service.ts
@@ -3,12 +3,7 @@ import { Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { HCaptchaConfigService } from '../../config/hcaptcha-config.service';
 import { Web3ConfigService } from '../../config/web3-config.service';
-import {
-  KycStatus,
-  OperatorStatus,
-  UserStatus,
-  Role,
-} from '../../common/enums/user';
+import { KycStatus, OperatorStatus } from '../../common/enums/user';
 import { SignatureType } from '../../common/enums/web3';
 import { SiteKeyType } from '../../common/enums';
 import { HCaptchaService } from '../../integrations/hcaptcha/hcaptcha.service';
@@ -21,7 +16,7 @@ import { Web3Service } from '../web3/web3.service';
 import { SiteKeyEntity } from './site-key.entity';
 import { SiteKeyRepository } from './site-key.repository';
 import { RegisterAddressRequestDto } from './user.dto';
-import { UserEntity } from './user.entity';
+import { Role, UserStatus, UserEntity } from './user.entity';
 import {
   UserError,
   UserErrorMessage,


### PR DESCRIPTION
## Issue tracking
Part of #3084

## Context behind the change
Started to refactor `users` module by moving corresponding enums and found out that `auth` guard & strategy are not properly used. Right now by default every route is public, there is no need in `Public` decorator, because jwt-auth is applied per route/controller. This PR aims to change that so we have jwt strategy as global for app and set some routes as `public`.

Also this PR introduces `index.ts` to `user` module. The goal of this file is to encapsulate module internals and export to outer world only expected things. `user.entity` is still imported directly in `database` module, but it's intentional.

## How has this been tested?
- [x] use swagger to trigger every endpoint w/o jwt token, make sure that all non-public routes return `401` with proper message
- [x] use swagger to trigger every endpoint w jwt token, make sure that all private routes are authorized successfully
- [x] use swagger to trigger some private endpoint with expired token, make sure it's `401`
- [x] use swagger authed as worker user, trigger `POST /qualifications`, make sure `403` is returned 

## Release plan
Just merge.

## Potential risks; What to monitor; Rollback plan
Should be none