### PR TITLE
[HUMAN App] fix: invalid sorting by `reward_amount`

### DIFF
--- a/packages/apps/human-app/server/src/common/constants/hmt.ts
+++ b/packages/apps/human-app/server/src/common/constants/hmt.ts
@@ -1,0 +1,1 @@
+export const HMT_TOKEN_SYMBOL = 'HMT';

--- a/packages/apps/human-app/server/src/common/enums/global-common.ts
+++ b/packages/apps/human-app/server/src/common/enums/global-common.ts
@@ -3,7 +3,7 @@ export enum JobDiscoveryFieldName {
   RewardAmount = 'reward_amount',
   RewardToken = 'reward_token',
   CreatedAt = 'created_at',
-  Qualifications = 'qualifications',
+  UpdatedAt = 'updated_at',
 }
 
 export enum JobStatus {

--- a/packages/apps/human-app/server/src/common/utils/pagination.utils.ts
+++ b/packages/apps/human-app/server/src/common/utils/pagination.utils.ts
@@ -4,7 +4,7 @@ export function paginateAndSortResults<T>(
   data: T[],
   page = 0,
   pageSize = 10,
-  sortField: keyof T | undefined = 'created_at' as keyof T,
+  sortField: keyof T,
   sortOrder = SortOrder.DESC,
 ): {
   results: T[];
@@ -15,10 +15,6 @@ export function paginateAndSortResults<T>(
 } {
   let results = data;
 
-  // Sorting
-  if (!sortField) {
-    sortField = 'created_at' as keyof T;
-  }
   results = results.sort((a, b) => {
     if (sortOrder === SortOrder.DESC) {
       return a[sortField] < b[sortField] ? 1 : -1;

--- a/packages/apps/human-app/server/src/common/utils/pagination.utils.ts
+++ b/packages/apps/human-app/server/src/common/utils/pagination.utils.ts
@@ -1,10 +1,14 @@
+import _ from 'lodash';
+
 import { SortOrder } from '../../common/enums/global-common';
+
+export type Iteratee<T> = keyof T | ((value: T) => any);
 
 export function paginateAndSortResults<T>(
   data: T[],
   page = 0,
   pageSize = 10,
-  sortField: keyof T,
+  iteratee: Iteratee<T>,
   sortOrder = SortOrder.DESC,
 ): {
   results: T[];
@@ -13,15 +17,7 @@ export function paginateAndSortResults<T>(
   total_pages: number;
   total_results: number;
 } {
-  let results = data;
-
-  results = results.sort((a, b) => {
-    if (sortOrder === SortOrder.DESC) {
-      return a[sortField] < b[sortField] ? 1 : -1;
-    } else {
-      return a[sortField] > b[sortField] ? 1 : -1;
-    }
-  });
+  const orderedData = _.orderBy(data, iteratee, sortOrder);
 
   // Pagination
   const start = page * pageSize;
@@ -32,6 +28,6 @@ export function paginateAndSortResults<T>(
     page_size: pageSize,
     total_pages: Math.ceil(data.length / pageSize),
     total_results: data.length,
-    results: results.slice(start, end),
+    results: orderedData.slice(start, end),
   };
 }

--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -2,9 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CronJob } from 'cron';
 import { ExchangeOracleGateway } from '../../integrations/exchange-oracle/exchange-oracle.gateway';
 import {
+  DiscoveredJob,
   JobsDiscoveryParams,
   JobsDiscoveryParamsCommand,
-  JobsDiscoveryResponseItem,
+  JobsDiscoveryResponse,
 } from '../jobs-discovery/model/jobs-discovery.model';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 import { OracleDiscoveryService } from '../oracle-discovery/oracle-discovery.service';
@@ -13,6 +14,27 @@ import { WorkerService } from '../user-worker/worker.service';
 import { JobDiscoveryFieldName } from '../../common/enums/global-common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { JobsDiscoveryService } from '../jobs-discovery/jobs-discovery.service';
+
+function assertJobsDiscoveryResponseItemsFormat(
+  items: JobsDiscoveryResponse['results'],
+): asserts items is DiscoveredJob[] {
+  if (items.length === 0) {
+    return;
+  }
+
+  const item = items[0];
+  if (
+    [
+      item.job_description,
+      item.reward_amount,
+      item.reward_token,
+      item.created_at,
+      item.updated_at,
+    ].includes(undefined)
+  ) {
+    throw new Error('Job discovery response items missing expected fields');
+  }
+}
 
 @Injectable()
 export class CronJobService {
@@ -81,7 +103,7 @@ export class CronJobService {
 
   async updateJobsListCache(oracle: DiscoveredOracle, token: string) {
     try {
-      let allResults: JobsDiscoveryResponseItem[] = [];
+      let allResults: DiscoveredJob[] = [];
 
       // Initial fetch to determine the total number of pages
       const command = new JobsDiscoveryParamsCommand();
@@ -91,14 +113,17 @@ export class CronJobService {
       command.data.page = 0;
       command.data.pageSize = command.data.pageSize || 10; // Max value for Exchange Oracle
       command.data.fields = [
-        JobDiscoveryFieldName.CreatedAt,
         JobDiscoveryFieldName.JobDescription,
         JobDiscoveryFieldName.RewardAmount,
         JobDiscoveryFieldName.RewardToken,
-        JobDiscoveryFieldName.Qualifications,
+        JobDiscoveryFieldName.CreatedAt,
+        JobDiscoveryFieldName.UpdatedAt,
       ];
       const initialResponse =
         await this.exchangeOracleGateway.fetchJobs(command);
+
+      assertJobsDiscoveryResponseItemsFormat(initialResponse.results);
+
       allResults = this.mergeJobs(allResults, initialResponse.results);
 
       const totalPages = initialResponse.total_pages;
@@ -112,6 +137,7 @@ export class CronJobService {
 
       const remainingResponses = await Promise.all(pageFetches);
       for (const response of remainingResponses) {
+        assertJobsDiscoveryResponseItemsFormat(response.results);
         allResults = this.mergeJobs(allResults, response.results);
       }
 
@@ -143,10 +169,10 @@ export class CronJobService {
   }
 
   private mergeJobs(
-    cachedJobs: JobsDiscoveryResponseItem[],
-    newJobs: JobsDiscoveryResponseItem[],
-  ): JobsDiscoveryResponseItem[] {
-    const jobsMap = new Map<string, JobsDiscoveryResponseItem>();
+    cachedJobs: DiscoveredJob[],
+    newJobs: DiscoveredJob[],
+  ): DiscoveredJob[] {
+    const jobsMap = new Map<string, DiscoveredJob>();
 
     for (const job of cachedJobs) {
       jobsMap.set(job.escrow_address + '-' + job.chain_id, job);

--- a/packages/apps/human-app/server/src/modules/job-assignment/job-assignment.service.ts
+++ b/packages/apps/human-app/server/src/modules/job-assignment/job-assignment.service.ts
@@ -14,6 +14,7 @@ import {
   ResignJobCommand,
 } from './model/job-assignment.model';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
+import { AssignmentSortField } from '../../common/enums/global-common';
 import { paginateAndSortResults } from '../../common/utils/pagination.utils';
 import { JOB_ASSIGNMENT_CACHE_KEY } from '../../common/constants/cache';
 
@@ -105,7 +106,7 @@ export class JobAssignmentService {
         this.applyFilters(cachedData, command.data),
         command.data.page,
         command.data.pageSize,
-        command.data.sortField as keyof JobsFetchResponseItem,
+        command.data.sortField || AssignmentSortField.CREATED_AT,
         command.data.sort,
       );
     }

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { paginateAndSortResults } from '../../common/utils/pagination.utils';
 import {
+  DiscoveredJob,
   JobsDiscoveryParamsCommand,
   JobsDiscoveryResponse,
-  JobsDiscoveryResponseItem,
 } from './model/jobs-discovery.model';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -31,15 +31,15 @@ export class JobsDiscoveryService {
       filteredJobs,
       command.data.page,
       command.data.pageSize,
-      command.data.sortField as keyof JobsDiscoveryResponseItem,
+      command.data.sortField as keyof DiscoveredJob,
       command.data.sort,
     );
   }
 
   private applyFilters(
-    jobs: JobsDiscoveryResponseItem[],
+    jobs: DiscoveredJob[],
     filters: JobsDiscoveryParamsCommand['data'],
-  ): JobsDiscoveryResponseItem[] {
+  ): DiscoveredJob[] {
     const difference = Object.values(JobDiscoveryFieldName).filter(
       (value) => !filters.fields?.includes(value),
     );
@@ -92,21 +92,19 @@ export class JobsDiscoveryService {
     return `${JOB_DISCOVERY_CACHE_KEY}:${oracleAddress}`;
   }
 
-  async getCachedJobs(
-    oracleAddress: string,
-  ): Promise<JobsDiscoveryResponseItem[]> {
+  async getCachedJobs(oracleAddress: string): Promise<DiscoveredJob[]> {
     const cacheKey = JobsDiscoveryService.makeCacheKeyForOracle(oracleAddress);
 
-    const cachedJobs = await this.cacheManager.get<
-      JobsDiscoveryResponseItem[] | undefined
-    >(cacheKey);
+    const cachedJobs = await this.cacheManager.get<DiscoveredJob[] | undefined>(
+      cacheKey,
+    );
 
     return cachedJobs || [];
   }
 
   async setCachedJobs(
     oracleAddress: string,
-    jobs: JobsDiscoveryResponseItem[],
+    jobs: DiscoveredJob[],
   ): Promise<void> {
     const cacheKey = JobsDiscoveryService.makeCacheKeyForOracle(oracleAddress);
     await this.cacheManager.set(cacheKey, jobs);

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/jobs-discovery.service.ts
@@ -9,7 +9,10 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { EnvironmentConfigService } from '../../common/config/environment-config.service';
 import { JOB_DISCOVERY_CACHE_KEY } from '../../common/constants/cache';
-import { JobDiscoveryFieldName } from '../../common/enums/global-common';
+import {
+  JobDiscoveryFieldName,
+  JobDiscoverySortField,
+} from '../../common/enums/global-common';
 
 @Injectable()
 export class JobsDiscoveryService {
@@ -31,7 +34,7 @@ export class JobsDiscoveryService {
       filteredJobs,
       command.data.page,
       command.data.pageSize,
-      command.data.sortField as keyof DiscoveredJob,
+      command.data.sortField || JobDiscoverySortField.CREATED_AT,
       command.data.sort,
     );
   }

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/model/jobs-discovery.model.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/model/jobs-discovery.model.ts
@@ -95,18 +95,21 @@ export class JobsDiscoveryParamsCommand {
   data: JobsDiscoveryParams;
 }
 
-export class JobsDiscoveryResponseItem {
+export type JobsDiscoveryResponseItem = {
   escrow_address: string;
   chain_id: number;
   job_type: string;
   status: JobStatus;
-  created_at?: string;
   job_description?: string;
-  reward_amount?: number;
+  reward_amount?: string;
   reward_token?: string;
-  qualifications?: string[];
-}
+  created_at?: string;
+  updated_at?: string;
+  qualifications: string[];
+};
 
 export class JobsDiscoveryResponse extends PageableResponse {
   results: JobsDiscoveryResponseItem[];
 }
+
+export type DiscoveredJob = Required<JobsDiscoveryResponseItem>;

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.fixtures.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.fixtures.ts
@@ -77,18 +77,21 @@ export const responseItemFixture1: JobsDiscoveryResponseItem = {
   chain_id: CHAIN_ID,
   job_type: JOB_TYPE,
   status: JobStatus.ACTIVE,
+  qualifications: [],
 };
 export const responseItemFixture2: JobsDiscoveryResponseItem = {
   escrow_address: ESCROW_ADDRESS2,
   chain_id: CHAIN_ID,
   job_type: JOB_TYPE,
   status: JobStatus.COMPLETED,
+  qualifications: [],
 };
 export const responseItemFixture3: JobsDiscoveryResponseItem = {
   escrow_address: ESCROW_ADDRESS3,
   chain_id: CHAIN_ID,
   job_type: JOB_TYPE,
   status: JobStatus.ACTIVE,
+  qualifications: [],
 };
 export const responseItemsFixture: JobsDiscoveryResponseItem[] = [
   responseItemFixture1,

--- a/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.fixtures.ts
+++ b/packages/apps/human-app/server/src/modules/jobs-discovery/spec/jobs-discovery.fixtures.ts
@@ -77,6 +77,7 @@ export const responseItemFixture1: JobsDiscoveryResponseItem = {
   chain_id: CHAIN_ID,
   job_type: JOB_TYPE,
   status: JobStatus.ACTIVE,
+  created_at: '2025-03-18T03:00:00.000Z',
   qualifications: [],
 };
 export const responseItemFixture2: JobsDiscoveryResponseItem = {
@@ -84,6 +85,7 @@ export const responseItemFixture2: JobsDiscoveryResponseItem = {
   chain_id: CHAIN_ID,
   job_type: JOB_TYPE,
   status: JobStatus.COMPLETED,
+  created_at: '2025-03-18T02:00:00.000Z',
   qualifications: [],
 };
 export const responseItemFixture3: JobsDiscoveryResponseItem = {
@@ -91,6 +93,7 @@ export const responseItemFixture3: JobsDiscoveryResponseItem = {
   chain_id: CHAIN_ID,
   job_type: JOB_TYPE,
   status: JobStatus.ACTIVE,
+  created_at: '2025-03-18T01:00:00.000Z',
   qualifications: [],
 };
 export const responseItemsFixture: JobsDiscoveryResponseItem[] = [


### PR DESCRIPTION
## Issue tracking
Fixes #2679 

## Context behind the change
`reward_amount` is returned from exchange oracles as `string` that represents decimal. Even if we convert it to some big int - we will have to store it as string in Redis and then convert it back when responding to client, so taking into account there are no more use cases other than sort we simply pass a comparator function to pagination+sort util when `reward_amount` property is desired as sort field.

Also changed job discovery process to ensure that it always has all necessary fields before caching jobs in Redis.

## How has this been tested?
- [x] locally: open available jobs page for some oracle and sort "from highest"/"from lowest"
- [x] locally: open assigned jobs page for some oracle and sort "from highest"/"from lowest"

## Release plan
Just merge.

## Potential risks; What to monitor; Rollback plan
No.