### PR TITLE
[Job Launcher] Remove external link from HCaptchaJobRequestForm

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
@@ -252,13 +252,7 @@ export const HCaptchaJobRequestForm = () => {
                     >
                       Unsure what job type to choose?
                     </Typography>
-                    <Button
-                      href="https://escrow-dashboard-git-feat-escrow-dashboard-ba2730-humanprotocol.vercel.app/launchpad/explore-jobs"
-                      target="_blank"
-                      sx={{ ml: 2 }}
-                    >
-                      Explore jobs
-                    </Button>
+                    <Button sx={{ ml: 2 }}>Explore jobs</Button>
                   </Box>
                 </Box>
               </Grid>


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
Remove external link from HCaptchaJobRequestForm.
Hcaptcha job creation from the frontend is disabled anyway. In case we enable it, a proper link should be set.

## How has this been tested?
Run locally

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA