### PR TITLE
Add GraphQL ESLint rules in subgraph package

### DIFF
--- a/packages/sdk/typescript/subgraph/.eslintrc
+++ b/packages/sdk/typescript/subgraph/.eslintrc
@@ -7,8 +7,30 @@
       "parserOptions": {
         "schema": "./schema.graphql"
       },
-      // TODO: Add GraphQL ESLint rules here
-      "rules": {}
+      // GraphQL ESLint rules
+      "rules": {
+        "@graphql-eslint/no-anonymous-operations": "error",
+        "@graphql-eslint/naming-convention": [
+          "error",
+          {
+            "OperationDefinition": {
+              "style": "camelCase"
+            },
+            "FragmentDefinition": {
+              "style": "camelCase"
+            }
+          }
+        ],
+        "@graphql-eslint/require-description": [
+          "warn",
+          {
+            "types": true,
+            "fields": true
+          }
+        ],
+        "@graphql-eslint/no-duplicate-fields": "error",
+        "@graphql-eslint/fields-on-correct-type": "error"
+      }
     },
     {
       "files": ["*.ts"],


### PR DESCRIPTION
## Issue tracking
<!--
Where is the progress of this issue being tracked?
Where can one find the requirements for this issue?
Where did this issue originated from?
E.g. GitHub issue, Slack message, etc.
-->
This issue originated from a TODO comment in the subgraph package's .eslintrc file that needed to be addressed to improve code quality. No specific tracking issue was attached.

## Context behind the change

This PR adds specific ESLint rules for GraphQL files in the TypeScript subgraph package:
- Added no-anonymous-operations rule to enforce named operations
- Added naming-convention rule to enforce camelCase styling for operations and fragments
- Added require-description rule to encourage documentation for types and fields
- Added no-duplicate-fields rule to prevent duplicate field definitions
- Added fields-on-correct-type rule to validate field types
These rules will improve code quality and consistency in GraphQL schemas and queries, helping to maintain a standardized codebase and reducing potential errors during development.

## How has this been tested?

Testing was performed by:
1. Running the linter on existing GraphQL files to ensure no critical errors were introduced
2. Verifying that the new rules align with the project's existing code style
3. Making sure the rules match industry best practices for GraphQL development
This change doesn't affect runtime behavior and has no performance implications.

## Release plan

This change is contained within the linting configuration and requires no special deployment steps.
Developers should be informed about the new GraphQL linting rules to ensure compliance in future code changes. A brief message in the team chat would be sufficient.

## Potential risks; What to monitor; Rollback plan

- Low risk change as it only affects development tooling, not runtime code
- Some existing GraphQL files might initially fail linting with the new rules
# What to monitor:
- CI pipeline results for any linting failures on existing GraphQL files
- Developer feedback on whether the rules are too strict or causing friction
# Rollback plan:
 If issues arise, we can:
- Temporarily disable specific rules that cause problems
- Revert to the previous configuration if necessary
- Adjust rule severity from "error" to "warn" to allow for gradual adoption