### PR TITLE
[Job Launcher Client] Allow adding biliing details without tax ID

### DIFF
--- a/packages/apps/job-launcher/client/src/components/BillingDetails/BillingDetailsModal.tsx
+++ b/packages/apps/job-launcher/client/src/components/BillingDetails/BillingDetailsModal.tsx
@@ -84,11 +84,11 @@ const BillingDetailsModal = ({
       }
     });
 
-    if (!formData?.vat) {
-      newErrors.vat = 'Tax ID required';
+    if (formData?.vat && !formData?.vatType) {
+      newErrors.vatType = 'Tax ID Type is required';
     }
-    if (!formData?.vatType) {
-      newErrors.vatType = 'Tax ID type required';
+    if (formData?.vatType && !formData?.vat) {
+      newErrors.vat = 'Tax ID is required';
     }
 
     setErrors(newErrors);

--- a/packages/apps/job-launcher/client/src/components/BillingDetails/BillingDetailsModal.tsx
+++ b/packages/apps/job-launcher/client/src/components/BillingDetails/BillingDetailsModal.tsx
@@ -100,8 +100,16 @@ const BillingDetailsModal = ({
     if (validateForm()) {
       setIsLoading(true);
       try {
+        if (formData.vat === '') {
+          delete formData.vat;
+        }
+        if (formData.vatType === '') {
+          delete formData.vatType;
+        }
+
         const email = formData?.email;
         delete formData?.email;
+
         await editUserBillingInfo(formData);
         setBillingInfo({ ...formData, email });
       } catch (err: any) {
@@ -217,6 +225,7 @@ const BillingDetailsModal = ({
                 error={!!errors.vatType}
                 helperText={errors.vatType || ''}
               >
+                <MenuItem value="">None</MenuItem>
                 {Object.entries(vatTypeOptions).map(([key, label]) => (
                   <MenuItem key={key} value={key}>
                     {label}

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -317,8 +317,8 @@ export type BillingInfo = {
   name: string;
   email?: string;
   address: Address;
-  vat: string;
-  vatType: string;
+  vat?: string;
+  vatType?: string;
 };
 
 type Address = {

--- a/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/payment/payment.service.ts
@@ -669,20 +669,17 @@ export class PaymentService {
       );
     }
     // If the VAT or VAT type has changed, update it in Stripe
+    const existingTaxIds = await this.stripe.customers.listTaxIds(
+      user.stripeCustomerId,
+    );
+
+    // Delete any existing tax IDs before adding the new one
+    for (const taxId of existingTaxIds.data) {
+      await this.stripe.customers.deleteTaxId(user.stripeCustomerId, taxId.id);
+    }
+
+    // Create the new VAT tax ID
     if (updateBillingInfoDto.vat && updateBillingInfoDto.vatType) {
-      const existingTaxIds = await this.stripe.customers.listTaxIds(
-        user.stripeCustomerId,
-      );
-
-      // Delete any existing tax IDs before adding the new one
-      for (const taxId of existingTaxIds.data) {
-        await this.stripe.customers.deleteTaxId(
-          user.stripeCustomerId,
-          taxId.id,
-        );
-      }
-
-      // Create the new VAT tax ID
       await this.stripe.customers.createTaxId(user.stripeCustomerId, {
         type: updateBillingInfoDto.vatType,
         value: updateBillingInfoDto.vat,


### PR DESCRIPTION
## Issue tracking
#3206

## Context behind the change
Update validation logic for optional VAT and VAT Type in BillingDetailsModal

## How has this been tested?
Deployed and tested locally

## Release plan
None

## Potential risks; What to monitor; Rollback plan
Check if Vat and Vat type can be added appropriately 