### PR TITLE
[Job Launcher] [Client] Infinite spinner when create job fails

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Headers/AuthHeader.tsx
+++ b/packages/apps/job-launcher/client/src/components/Headers/AuthHeader.tsx
@@ -106,7 +106,7 @@ export const AuthHeader = () => {
             variant="contained"
             sx={{ mr: 1 }}
             onClick={() => {
-              reset?.();
+              reset();
               navigate('/jobs/create');
             }}
           >

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CreateJob.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CreateJob.tsx
@@ -55,7 +55,7 @@ export const CreateJob = () => {
             }}
             value={jobRequest.jobType}
             onChange={(e) =>
-              updateJobRequest?.({
+              updateJobRequest({
                 ...jobRequest,
                 jobType: e.target.value as JobType,
               })
@@ -74,7 +74,7 @@ export const CreateJob = () => {
           label="Choose Network"
           value={jobRequest.chainId}
           onChange={(e) =>
-            updateJobRequest?.({
+            updateJobRequest({
               ...jobRequest,
               chainId: e.target.value as ChainId,
             })

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
@@ -256,7 +256,7 @@ export const CryptoPayForm = ({
           You are on wrong network, please switch to{' '}
           {NETWORKS[jobRequest.chainId!]?.title}.
         </Typography>
-        <Button variant="outlined" onClick={() => goToPrevStep?.()}>
+        <Button variant="outlined" onClick={goToPrevStep}>
           Back
         </Button>
       </Box>
@@ -492,7 +492,7 @@ export const CryptoPayForm = ({
             variant="outlined"
             sx={{ width: '240px', ml: 4 }}
             size="large"
-            onClick={() => goToPrevStep?.()}
+            onClick={goToPrevStep}
           >
             Cancel
           </Button>

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -129,7 +129,7 @@ export const CvatJobRequestForm = () => {
       return { name: name };
     });
 
-    updateJobRequest?.({
+    updateJobRequest({
       ...jobRequest,
       cvatRequest: {
         labels: labelArray,
@@ -157,7 +157,7 @@ export const CvatJobRequestForm = () => {
         accuracyTarget,
       },
     });
-    goToNextStep?.();
+    goToNextStep();
   };
 
   const {
@@ -844,8 +844,8 @@ export const CvatJobRequestForm = () => {
           <Button
             variant="outlined"
             onClick={() => {
-              goToPrevStep?.();
-              updateJobRequest?.({
+              goToPrevStep();
+              updateJobRequest({
                 ...jobRequest,
                 chainId: undefined,
               });

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -34,6 +34,7 @@ import {
   Qualification,
   StorageProviders,
 } from '../../../types';
+import { mapCvatFormValues } from './helpers';
 import { CvatJobRequestValidationSchema, dataValidationSchema } from './schema';
 
 export const CvatJobRequestForm = () => {
@@ -44,28 +45,16 @@ export const CvatJobRequestForm = () => {
   const [qualificationsOptions, setQualificationsOptions] = useState<
     Qualification[]
   >([]);
+  const [updatedValidationSchema, setUpdatedValidationSchema] = useState(
+    CvatJobRequestValidationSchema,
+  );
 
-  const initialValues = {
-    labels: [],
-    nodes: [],
-    type: CvatJobType.IMAGE_BOXES,
-    description: '',
-    qualifications: [],
-    userGuide: '',
-    accuracyTarget: 80,
-    dataProvider: StorageProviders.AWS,
-    dataRegion: '',
-    dataBucketName: '',
-    dataPath: '',
-    bpProvider: StorageProviders.AWS,
-    bpRegion: '',
-    bpBucketName: '',
-    bpPath: '',
-    gtProvider: StorageProviders.AWS,
-    gtRegion: '',
-    gtBucketName: '',
-    gtPath: '',
-  };
+  const persistedFormValues = mapCvatFormValues(
+    jobRequest,
+    qualificationsOptions,
+  );
+
+  const initialValues = { ...persistedFormValues };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -73,7 +62,6 @@ export const CvatJobRequestForm = () => {
         try {
           setQualificationsOptions(await getQualifications(jobRequest.chainId));
         } catch (error) {
-          // eslint-disable-next-line no-console
           console.error('Error fetching data:', error);
         }
       }
@@ -111,9 +99,9 @@ export const CvatJobRequestForm = () => {
     gtPath,
     userGuide,
     accuracyTarget,
-  }: any) => {
+  }: ReturnType<typeof mapCvatFormValues>) => {
     let bp = undefined;
-    if (type === CvatJobType.IMAGE_BOXES_FROM_POINTS)
+    if (type === CvatJobType.IMAGE_BOXES_FROM_POINTS) {
       bp = {
         points: {
           provider: bpProvider,
@@ -122,7 +110,7 @@ export const CvatJobRequestForm = () => {
           path: bpPath,
         },
       };
-    else if (type === CvatJobType.IMAGE_SKELETONS_FROM_BOXES)
+    } else if (type === CvatJobType.IMAGE_SKELETONS_FROM_BOXES) {
       bp = {
         boxes: {
           provider: bpProvider,
@@ -131,11 +119,16 @@ export const CvatJobRequestForm = () => {
           path: bpPath,
         },
       };
+    }
+
     const labelArray: Label[] = labels.map((name: string) => {
-      if (type === CvatJobType.IMAGE_SKELETONS_FROM_BOXES)
+      if (type === CvatJobType.IMAGE_SKELETONS_FROM_BOXES) {
         return { name: name, nodes: nodes };
-      else return { name: name };
+      }
+
+      return { name: name };
     });
+
     updateJobRequest?.({
       ...jobRequest,
       cvatRequest: {
@@ -166,10 +159,6 @@ export const CvatJobRequestForm = () => {
     });
     goToNextStep?.();
   };
-
-  const [updatedValidationSchema, setUpdatedValidationSchema] = useState(
-    CvatJobRequestValidationSchema,
-  );
 
   const {
     errors,

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CvatJobRequestForm.tsx
@@ -123,10 +123,10 @@ export const CvatJobRequestForm = () => {
 
     const labelArray: Label[] = labels.map((name: string) => {
       if (type === CvatJobType.IMAGE_SKELETONS_FROM_BOXES) {
-        return { name: name, nodes: nodes };
+        return { name, nodes };
       }
 
-      return { name: name };
+      return { name };
     });
 
     updateJobRequest({

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FiatPayForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FiatPayForm.tsx
@@ -540,7 +540,7 @@ export const FiatPayForm = ({
                 variant="outlined"
                 sx={{ width: '240px', ml: 4 }}
                 size="large"
-                onClick={() => goToPrevStep?.()}
+                onClick={goToPrevStep}
               >
                 Cancel
               </Button>

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
@@ -32,7 +32,10 @@ export const FortuneJobRequestForm = () => {
     Qualification[]
   >([]);
 
-  const initialValues = mapFortuneFormValues(jobRequest, qualificationsOptions);
+  const persistedFormValues = mapFortuneFormValues(
+    jobRequest,
+    qualificationsOptions,
+  );
 
   useEffect(() => {
     const fetchData = async () => {
@@ -71,7 +74,7 @@ export const FortuneJobRequestForm = () => {
   return (
     <Box sx={{ mt: '42px' }}>
       <Formik
-        initialValues={initialValues}
+        initialValues={persistedFormValues}
         validationSchema={FortuneJobRequestValidationSchema}
         onSubmit={handleNext}
       >

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
@@ -54,7 +54,7 @@ export const FortuneJobRequestForm = () => {
     description,
     qualifications,
   }: ReturnType<typeof mapFortuneFormValues>) => {
-    updateJobRequest?.({
+    updateJobRequest({
       ...jobRequest,
       fortuneRequest: {
         title,
@@ -65,7 +65,7 @@ export const FortuneJobRequestForm = () => {
         ),
       },
     });
-    goToNextStep?.();
+    goToNextStep();
   };
 
   return (
@@ -222,8 +222,8 @@ export const FortuneJobRequestForm = () => {
               <Button
                 variant="outlined"
                 onClick={() => {
-                  goToPrevStep?.();
-                  updateJobRequest?.({
+                  goToPrevStep();
+                  updateJobRequest({
                     ...jobRequest,
                     chainId: undefined,
                   });

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FortuneJobRequestForm.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Formik } from 'formik';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Accordion,
   AccordionDetails,
@@ -21,22 +21,18 @@ import { CollectionsFilledIcon } from '../../../components/Icons/CollectionsFill
 import { useCreateJobPageUI } from '../../../providers/CreateJobPageUIProvider';
 import { getQualifications } from '../../../services/qualification';
 import { Qualification } from '../../../types';
+import { mapFortuneFormValues } from './helpers';
 import { FortuneJobRequestValidationSchema } from './schema';
 
 export const FortuneJobRequestForm = () => {
   const { jobRequest, updateJobRequest, goToPrevStep, goToNextStep } =
     useCreateJobPageUI();
-  const [expanded, setExpanded] = useState<string | false>('panel1');
+  const [isExpanded, setIsExpanded] = useState(true);
   const [qualificationsOptions, setQualificationsOptions] = useState<
     Qualification[]
   >([]);
 
-  const initialValues = {
-    title: '',
-    fortunesRequested: undefined,
-    description: '',
-    qualifications: [],
-  };
+  const initialValues = mapFortuneFormValues(jobRequest, qualificationsOptions);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -44,7 +40,6 @@ export const FortuneJobRequestForm = () => {
         try {
           setQualificationsOptions(await getQualifications(jobRequest.chainId));
         } catch (error) {
-          // eslint-disable-next-line no-console
           console.error('Error fetching data:', error);
         }
       }
@@ -53,17 +48,12 @@ export const FortuneJobRequestForm = () => {
     fetchData();
   }, [jobRequest.chainId]);
 
-  const handleChange =
-    (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {
-      setExpanded(newExpanded ? panel : false);
-    };
-
   const handleNext = ({
     title,
     fortunesRequested,
     description,
     qualifications,
-  }: any) => {
+  }: ReturnType<typeof mapFortuneFormValues>) => {
     updateJobRequest?.({
       ...jobRequest,
       fortuneRequest: {
@@ -97,8 +87,8 @@ export const FortuneJobRequestForm = () => {
         }) => (
           <form onSubmit={handleSubmit}>
             <Accordion
-              expanded={expanded === 'panel1'}
-              onChange={handleChange('panel1')}
+              expanded={isExpanded}
+              onChange={() => setIsExpanded((prevState) => !prevState)}
             >
               <AccordionSummary
                 aria-controls="panel1d-content"

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FundingMethod.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FundingMethod.tsx
@@ -18,8 +18,8 @@ export const FundingMethod = () => {
 
   const handleClickCrypto = () => {
     if (isConnected) {
-      changePayMethod?.(PayMethod.Crypto);
-      goToNextStep?.();
+      changePayMethod(PayMethod.Crypto);
+      goToNextStep();
     } else {
       setWalletModalOpen(true);
     }
@@ -28,7 +28,7 @@ export const FundingMethod = () => {
   useEffect(() => {
     if (isConnected && walletModalOpen) {
       setWalletModalOpen(false);
-      goToNextStep?.();
+      goToNextStep();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected]);
@@ -116,8 +116,8 @@ export const FundingMethod = () => {
                   variant="outlined"
                   sx={{ minWidth: '200px' }}
                   onClick={() => {
-                    changePayMethod?.(PayMethod.Fiat);
-                    goToNextStep?.();
+                    changePayMethod(PayMethod.Fiat);
+                    goToNextStep();
                   }}
                 >
                   Pay with Credit Card

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/HCaptchaJobRequestForm.tsx
@@ -103,11 +103,11 @@ export const HCaptchaJobRequestForm = () => {
     if (data.completionDate) {
       hCaptchaRequest['completionDate'] = data.completionDate;
     }
-    updateJobRequest?.({
+    updateJobRequest({
       ...jobRequest,
       hCaptchaRequest,
     });
-    goToNextStep?.();
+    goToNextStep();
   };
 
   const {
@@ -723,8 +723,8 @@ export const HCaptchaJobRequestForm = () => {
           <Button
             variant="outlined"
             onClick={() => {
-              goToPrevStep?.();
-              updateJobRequest?.({
+              goToPrevStep();
+              updateJobRequest({
                 ...jobRequest,
                 chainId: undefined,
               });

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchJobProgress.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchJobProgress.tsx
@@ -30,7 +30,7 @@ export const LaunchJobProgress = ({
   goToPrevStep,
 }: {
   isPayingFailed: boolean;
-  goToPrevStep?: () => void;
+  goToPrevStep: () => void;
 }) => {
   return (
     <Box

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchJobProgress.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchJobProgress.tsx
@@ -64,7 +64,7 @@ export const LaunchJobProgress = ({
         variant="outlined"
         sx={{ width: '240px', position: 'absolute', bottom: 16, right: 16 }}
         size="large"
-        onClick={() => goToPrevStep?.()}
+        onClick={goToPrevStep}
       >
         Cancel
       </Button>

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchJobProgress.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchJobProgress.tsx
@@ -1,27 +1,37 @@
-import { Box, Typography, CircularProgress } from '@mui/material';
+import ClearIcon from '@mui/icons-material/Clear';
+import { Box, Button, Typography, CircularProgress } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React from 'react';
+
 import { CheckFilledIcon } from '../../../components/Icons/CheckFilledIcon';
 
 const ProgressText = styled(Typography)({
   display: 'flex',
   alignItems: 'center',
   position: 'relative',
-  paddingLeft: '30px',
-  paddingTop: 10,
 });
 
 const CheckedIcon = styled(CheckFilledIcon)({
   position: 'absolute',
-  left: '0px',
+  left: '-30px',
 });
 
 const ProgressIcon = styled(CircularProgress)({
   position: 'absolute',
-  left: '0px',
+  left: '-30px',
 });
 
-export const LaunchJobProgress = () => {
+const ErrorIcon = styled(ClearIcon)({
+  position: 'absolute',
+  left: '-30px',
+});
+
+export const LaunchJobProgress = ({
+  isPayingFailed,
+  goToPrevStep,
+}: {
+  isPayingFailed: boolean;
+  goToPrevStep?: () => void;
+}) => {
   return (
     <Box
       sx={{
@@ -33,17 +43,31 @@ export const LaunchJobProgress = () => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
+        position: 'relative',
       }}
     >
-      <ProgressText>
-        <CheckedIcon /> Creating Job
-      </ProgressText>
-      <ProgressText>
-        <CheckedIcon /> Setting Up Job
-      </ProgressText>
-      <ProgressText>
-        <ProgressIcon size={20} /> Paying Job
-      </ProgressText>
+      <Box display="flex" flexDirection="column" gap={1}>
+        <ProgressText>
+          <CheckedIcon /> Creating Job
+        </ProgressText>
+        <ProgressText>
+          <CheckedIcon /> Setting Up Job
+        </ProgressText>
+        <ProgressText>
+          {isPayingFailed ? <ErrorIcon /> : <ProgressIcon size={20} />}
+          Paying Job
+        </ProgressText>
+      </Box>
+      <Button
+        disabled={!isPayingFailed}
+        color="primary"
+        variant="outlined"
+        sx={{ width: '240px', position: 'absolute', bottom: 16, right: 16 }}
+        size="large"
+        onClick={() => goToPrevStep?.()}
+      >
+        Cancel
+      </Button>
     </Box>
   );
 };

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchSuccess.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/LaunchSuccess.tsx
@@ -34,7 +34,7 @@ export const LaunchSuccess = () => {
           variant="contained"
           color="primary"
           sx={{ width: 240 }}
-          onClick={() => reset?.()}
+          onClick={reset}
         >
           Add New Job
         </Button>

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/PayJob.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/PayJob.tsx
@@ -9,22 +9,28 @@ import { CryptoPayForm } from './CryptoPayForm';
 import { FiatPayForm } from './FiatPayForm';
 import { LaunchJobProgress } from './LaunchJobProgress';
 
+type PayingStatus = 'idle' | 'pending' | 'success' | 'error';
+
 export const PayJob = () => {
-  const { payMethod, changePayMethod, goToNextStep } = useCreateJobPageUI();
-  const [isPaying, setIsPaying] = useState(false);
+  const { payMethod, changePayMethod, goToNextStep, goToPrevStep } =
+    useCreateJobPageUI();
+  const [payingStatus, setPayingStatus] = useState<PayingStatus>('idle');
   const { showError } = useSnackbar();
   const { user } = useAppSelector((state) => state.auth);
 
+  const isIdle = payingStatus === 'idle';
+
   const handleStart = () => {
-    setIsPaying(true);
+    setPayingStatus('pending');
   };
 
   const handleFinish = () => {
-    setIsPaying(false);
+    setPayingStatus('success');
     goToNextStep?.();
   };
 
   const handleError = (err: any) => {
+    setPayingStatus('error');
     if (err.code === 'UNPREDICTABLE_GAS_LIMIT') {
       showError('Insufficient token amount or the gas limit is too low');
     } else if (err.code === 'ACTION_REJECTED') {
@@ -34,7 +40,7 @@ export const PayJob = () => {
     }
   };
 
-  return !isPaying ? (
+  return isIdle ? (
     <Box
       sx={{
         mx: 'auto',
@@ -99,6 +105,9 @@ export const PayJob = () => {
       </Box>
     </Box>
   ) : (
-    <LaunchJobProgress />
+    <LaunchJobProgress
+      isPayingFailed={payingStatus === 'error'}
+      goToPrevStep={goToPrevStep}
+    />
   );
 };

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/PayJob.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/PayJob.tsx
@@ -4,33 +4,33 @@ import { StyledTab, StyledTabs } from '../../../components/Tabs';
 import { useCreateJobPageUI } from '../../../providers/CreateJobPageUIProvider';
 import { useSnackbar } from '../../../providers/SnackProvider';
 import { useAppSelector } from '../../../state';
-import { PayMethod } from '../../../types';
+import { PayingStatus, PayMethod } from '../../../types';
 import { CryptoPayForm } from './CryptoPayForm';
 import { FiatPayForm } from './FiatPayForm';
 import { LaunchJobProgress } from './LaunchJobProgress';
 
-type PayingStatus = 'idle' | 'pending' | 'success' | 'error';
-
 export const PayJob = () => {
   const { payMethod, changePayMethod, goToNextStep, goToPrevStep } =
     useCreateJobPageUI();
-  const [payingStatus, setPayingStatus] = useState<PayingStatus>('idle');
+  const [payingStatus, setPayingStatus] = useState<PayingStatus>(
+    PayingStatus.Idle,
+  );
   const { showError } = useSnackbar();
   const { user } = useAppSelector((state) => state.auth);
 
-  const isIdle = payingStatus === 'idle';
+  const isIdle = payingStatus === PayingStatus.Idle;
 
   const handleStart = () => {
-    setPayingStatus('pending');
+    setPayingStatus(PayingStatus.Pending);
   };
 
   const handleFinish = () => {
-    setPayingStatus('success');
-    goToNextStep?.();
+    setPayingStatus(PayingStatus.Success);
+    goToNextStep();
   };
 
   const handleError = (err: any) => {
-    setPayingStatus('error');
+    setPayingStatus(PayingStatus.Error);
     if (err.code === 'UNPREDICTABLE_GAS_LIMIT') {
       showError('Insufficient token amount or the gas limit is too low');
     } else if (err.code === 'ACTION_REJECTED') {
@@ -52,7 +52,7 @@ export const PayJob = () => {
     >
       <StyledTabs
         value={payMethod}
-        onChange={(e, newValue) => changePayMethod?.(newValue)}
+        onChange={(e, newValue) => changePayMethod(newValue)}
         sx={{
           '& .MuiTabs-indicator': {
             display: 'none',
@@ -106,7 +106,7 @@ export const PayJob = () => {
     </Box>
   ) : (
     <LaunchJobProgress
-      isPayingFailed={payingStatus === 'error'}
+      isPayingFailed={payingStatus === PayingStatus.Error}
       goToPrevStep={goToPrevStep}
     />
   );

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/helpers.ts
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/helpers.ts
@@ -1,0 +1,69 @@
+import {
+  JobRequest,
+  Qualification,
+  CvatJobType,
+  StorageProviders,
+  GCSRegions,
+  AWSRegions,
+} from 'src/types';
+
+export const mapCvatFormValues = (
+  jobRequest: JobRequest,
+  qualificationsOptions: Qualification[],
+) => {
+  const { cvatRequest } = jobRequest;
+  return {
+    labels: cvatRequest?.labels?.map((label) => label.name) || [],
+    nodes: cvatRequest?.labels?.[0]?.nodes || [],
+    type: cvatRequest?.type || CvatJobType.IMAGE_BOXES,
+    description: cvatRequest?.description || '',
+    qualifications: cvatRequest?.qualifications
+      ? qualificationsOptions.filter((q: Qualification) =>
+          cvatRequest?.qualifications?.includes(q.reference),
+        )
+      : [],
+    userGuide: cvatRequest?.userGuide || '',
+    accuracyTarget: cvatRequest?.accuracyTarget || 80,
+    dataProvider: cvatRequest?.data?.dataset?.provider || StorageProviders.AWS,
+    dataRegion:
+      (cvatRequest?.data?.dataset?.region as AWSRegions | GCSRegions) || '',
+    dataBucketName: cvatRequest?.data?.dataset?.bucketName || '',
+    dataPath: cvatRequest?.data?.dataset?.path || '',
+    bpProvider:
+      cvatRequest?.data?.points?.provider ||
+      cvatRequest?.data?.boxes?.provider ||
+      StorageProviders.AWS,
+    bpRegion:
+      cvatRequest?.data?.points?.region ||
+      (cvatRequest?.data?.boxes?.region as AWSRegions | GCSRegions) ||
+      '',
+    bpBucketName:
+      cvatRequest?.data?.points?.bucketName ||
+      cvatRequest?.data?.boxes?.bucketName ||
+      '',
+    bpPath:
+      cvatRequest?.data?.points?.path || cvatRequest?.data?.boxes?.path || '',
+    gtProvider: cvatRequest?.groundTruth?.provider || StorageProviders.AWS,
+    gtRegion:
+      (cvatRequest?.groundTruth?.region as AWSRegions | GCSRegions) || '',
+    gtBucketName: cvatRequest?.groundTruth?.bucketName || '',
+    gtPath: cvatRequest?.groundTruth?.path || '',
+  };
+};
+
+export const mapFortuneFormValues = (
+  jobRequest: JobRequest,
+  qualificationsOptions: Qualification[],
+) => {
+  const { fortuneRequest } = jobRequest;
+  return {
+    title: fortuneRequest?.title || '',
+    fortunesRequested: fortuneRequest?.fortunesRequested || undefined,
+    description: fortuneRequest?.description || '',
+    qualifications: fortuneRequest?.qualifications
+      ? qualificationsOptions.filter((q: Qualification) =>
+          fortuneRequest?.qualifications?.includes(q.reference),
+        )
+      : [],
+  };
+};

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/helpers.ts
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/helpers.ts
@@ -5,7 +5,7 @@ import {
   StorageProviders,
   GCSRegions,
   AWSRegions,
-} from 'src/types';
+} from '../../../types';
 
 export const mapCvatFormValues = (
   jobRequest: JobRequest,
@@ -58,7 +58,7 @@ export const mapFortuneFormValues = (
   const { fortuneRequest } = jobRequest;
   return {
     title: fortuneRequest?.title || '',
-    fortunesRequested: fortuneRequest?.fortunesRequested || undefined,
+    fortunesRequested: fortuneRequest?.fortunesRequested || 0,
     description: fortuneRequest?.description || '',
     qualifications: fortuneRequest?.qualifications
       ? qualificationsOptions.filter((q: Qualification) =>

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/index.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/index.tsx
@@ -18,10 +18,10 @@ export const CreateJobView = () => {
     const supportedJobTypes = ['fortune', 'cvat', 'hcaptcha'];
 
     if (jobType && supportedJobTypes.includes(jobType.toLowerCase())) {
-      changePayMethod?.(PayMethod.Fiat);
+      changePayMethod(PayMethod.Fiat);
       setStep(CreateJobStep.CreateJob);
 
-      updateJobRequest?.({
+      updateJobRequest({
         jobType:
           jobType === 'fortune'
             ? JobType.Fortune

--- a/packages/apps/job-launcher/client/src/providers/CreateJobPageUIProvider.tsx
+++ b/packages/apps/job-launcher/client/src/providers/CreateJobPageUIProvider.tsx
@@ -63,7 +63,7 @@ export const CreateJobPageUIProvider = ({
   };
 
   const goToNextStep = () => {
-    if (step < CreateJobStep.PayJob) {
+    if (step < CreateJobStep.Launch) {
       setStep((prev) => prev + 1);
     }
   };

--- a/packages/apps/job-launcher/client/src/providers/CreateJobPageUIProvider.tsx
+++ b/packages/apps/job-launcher/client/src/providers/CreateJobPageUIProvider.tsx
@@ -8,25 +8,27 @@ export type CreateJobPageUIType = {
   step: CreateJobStep;
   payMethod: PayMethod;
   jobRequest: JobRequest;
-  reset?: () => void;
-  changePayMethod?: (method: PayMethod) => void;
-  updateJobRequest?: (jobRequest: JobRequest) => void;
-  goToPrevStep?: () => void;
-  goToNextStep?: () => void;
+  reset: () => void;
+  changePayMethod: (method: PayMethod) => void;
+  updateJobRequest: (jobRequest: JobRequest) => void;
+  goToPrevStep: () => void;
+  goToNextStep: () => void;
   setStep: (step: CreateJobStep) => void;
 };
 
-const initialData: Omit<
-  CreateJobPageUIType,
-  'changePayMethod' | 'goToNextStep'
-> = {
+const initialData: CreateJobPageUIType = {
   step: CreateJobStep.FundingMethod,
   payMethod: PayMethod.Crypto,
   jobRequest: {
     jobType: JobType.Fortune,
     chainId: undefined,
   },
-  setStep: () => {},
+  reset: () => {},
+  changePayMethod: (_) => {},
+  updateJobRequest: (_) => {},
+  goToPrevStep: () => {},
+  goToNextStep: () => {},
+  setStep: (_) => {},
 };
 
 export const CreateJobPageUIContext =
@@ -55,11 +57,15 @@ export const CreateJobPageUIProvider = ({
   });
 
   const goToPrevStep = () => {
-    setStep((prev) => prev - 1);
+    if (step > CreateJobStep.FundingMethod) {
+      setStep((prev) => prev - 1);
+    }
   };
 
   const goToNextStep = () => {
-    setStep((prev) => prev + 1);
+    if (step < CreateJobStep.PayJob) {
+      setStep((prev) => prev + 1);
+    }
   };
 
   const changePayMethod = (method: PayMethod) => setPayMethod(method);

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -72,6 +72,13 @@ export enum PayMethod {
   Fiat,
 }
 
+export enum PayingStatus {
+  Idle,
+  Pending,
+  Success,
+  Error,
+}
+
 export enum JobType {
   Fortune,
   CVAT,

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -96,7 +96,7 @@ export enum HCaptchaJobType {
 
 export type FortuneRequest = {
   title: string;
-  fortunesRequested: number;
+  fortunesRequested?: number;
   description: string;
   qualifications?: string[];
 };

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -96,7 +96,7 @@ export enum HCaptchaJobType {
 
 export type FortuneRequest = {
   title: string;
-  fortunesRequested?: number;
+  fortunesRequested: number;
   description: string;
   qualifications?: string[];
 };


### PR DESCRIPTION
## Issue tracking
Closes #3209

## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->
The spinner being shown regardless of the request's status, no matter whether it's fulfilled or rejected. Instead, let's display an ErrorIcon if the request is failed. Moreover, I've added a button that lets users get back to the form and see what values might be wrong.
Also this pr includes some refactoring

## How has this been tested?
tested it locally: go to the job launching form, fill in all the fields and click on Pay Now. you shall see the error icon and 'cancel' button, that takes you back to the second step

https://github.com/user-attachments/assets/278fc4ab-d27d-4dc9-b49f-33a7afe88245

## Release plan
regular plan

## Potential risks; What to monitor; Rollback plan
not determined yet