### PR TITLE
[Job Launcher] Send ESCROW_CANCELED webhooks

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -343,7 +343,7 @@ export class CronJobService {
     try {
       const webhookEntities = await this.webhookRepository.findByStatusAndType(
         WebhookStatus.PENDING,
-        EventType.ESCROW_CREATED,
+        [EventType.ESCROW_CREATED, EventType.ESCROW_CANCELED],
       );
 
       for (const webhookEntity of webhookEntities) {

--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.repository.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { BaseRepository } from '../../database/base.repository';
-import { DataSource, LessThanOrEqual } from 'typeorm';
+import { DataSource, In, LessThanOrEqual } from 'typeorm';
 import { ServerConfigService } from '../../common/config/server-config.service';
 import { EventType, WebhookStatus } from '../../common/enums/webhook';
 import { WebhookEntity } from './webhook.entity';
@@ -17,12 +17,13 @@ export class WebhookRepository extends BaseRepository<WebhookEntity> {
   }
   public findByStatusAndType(
     status: WebhookStatus,
-    type: EventType,
+    type: EventType | EventType[],
   ): Promise<WebhookEntity[]> {
+    const typeClause = !Array.isArray(type) ? [type] : type;
     return this.find({
       where: {
         status: status,
-        eventType: type,
+        eventType: In(typeClause),
         retriesCount: LessThanOrEqual(this.serverConfigService.maxRetryCount),
         waitUntil: LessThanOrEqual(new Date()),
       },


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Support multiple event types in webhook status query.

## How has this been tested?
Deployed locally. Created a new escrow, canceled it and checked that the webhook has been created and sent to Exchange Oracle

## Release plan
None

## Potential risks; What to monitor; Rollback plan
Check if ESCROW_CANCELED webhooks are being processed