### PR TITLE
fix: vite package resolutions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19835,18 +19835,7 @@ vite-plugin-svgr@^4.2.0:
     "@svgr/core" "^8.1.0"
     "@svgr/plugin-jsx" "^8.1.0"
 
-"vite@^5.0.0 || ^6.0.0":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.2.tgz#8098b12a6bfd95abe39399aa7d5faa56545d7a1a"
-  integrity sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==
-  dependencies:
-    esbuild "^0.25.0"
-    postcss "^8.5.3"
-    rollup "^4.30.1"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@^6.2.3:
+"vite@^5.0.0 || ^6.0.0", vite@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.3.tgz#249e92d32886981ab46bc1f049ac72abc6fa81e2"
   integrity sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/humanprotocol/human-protocol/pull/3235

## Context behind the change
`vite` got bumped, but not all resolutions were respected. Fixing in this PR.

## How has this been tested?
Searched in `yarn.lock` for `vite` entries to ensure they are correct.

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
No