### PR TITLE
[Reputation Oracle] Forbid login if user is in `inactive` status

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.error.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.error.filter.ts
@@ -12,19 +12,22 @@ import {
   AuthError,
   DuplicatedUserAddressError,
   DuplicatedUserEmailError,
+  InactiveUserError,
   InvalidOperatorSignupDataError,
 } from './auth.error';
 
 type AuthControllerError =
   | AuthError
+  | DuplicatedUserAddressError
   | DuplicatedUserEmailError
-  | InvalidOperatorSignupDataError
-  | DuplicatedUserAddressError;
+  | InactiveUserError
+  | InvalidOperatorSignupDataError;
 
 @Catch(
   AuthError,
-  DuplicatedUserEmailError,
   DuplicatedUserAddressError,
+  DuplicatedUserEmailError,
+  InactiveUserError,
   InvalidOperatorSignupDataError,
 )
 export class AuthControllerErrorsFilter implements ExceptionFilter {
@@ -46,6 +49,9 @@ export class AuthControllerErrorsFilter implements ExceptionFilter {
       this.logger.error('Auth conflict', exception);
     } else if (exception instanceof InvalidOperatorSignupDataError) {
       status = HttpStatus.BAD_REQUEST;
+    } else if (exception instanceof InactiveUserError) {
+      status = HttpStatus.FORBIDDEN;
+      this.logger.error('Auth error', exception);
     }
 
     return response.status(status).json({

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.error.ts
@@ -10,6 +10,7 @@ export enum AuthErrorMessage {
   INVALID_EMAIL_TOKEN = 'Email token is not valid',
   INVALID_WEB3_SIGNATURE = 'Invalid signature',
   INVALID_ADDRESS = 'Invalid address',
+  INACTIVE_USER = 'User is in inactive status',
 }
 
 export class AuthError extends BaseError {
@@ -55,5 +56,11 @@ export class DuplicatedUserAddressError extends BaseError {
     super(
       'The address you are trying to use already exists. Please, use a different address.',
     );
+  }
+}
+
+export class InactiveUserError extends BaseError {
+  constructor(readonly userId: number) {
+    super('User is in inactive status. Login forbidden.');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.error.ts
@@ -10,7 +10,6 @@ export enum AuthErrorMessage {
   INVALID_EMAIL_TOKEN = 'Email token is not valid',
   INVALID_WEB3_SIGNATURE = 'Invalid signature',
   INVALID_ADDRESS = 'Invalid address',
-  INACTIVE_USER = 'User is in inactive status',
 }
 
 export class AuthError extends BaseError {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -395,6 +395,20 @@ describe('AuthService', () => {
         ),
       );
     });
+
+    it('should throw InactiveUserError if user status is `inactive`', async () => {
+      const password = faker.string.alphanumeric();
+      const user = generateWorkerUser({
+        password,
+        status: UserStatus.INACTIVE,
+      });
+
+      mockUserService.findWeb2UserByEmail.mockResolvedValueOnce(user);
+
+      await expect(service.signin(user.email, password)).rejects.toThrow(
+        new AuthErrors.InactiveUserError(user.id),
+      );
+    });
   });
 
   describe('web3Signin', () => {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -32,6 +32,7 @@ import {
   AuthErrorMessage,
   DuplicatedUserAddressError,
   DuplicatedUserEmailError,
+  InactiveUserError,
   InvalidOperatorFeeError,
   InvalidOperatorRoleError,
   InvalidOperatorUrlError,
@@ -151,6 +152,10 @@ export class AuthService {
     const userEntity = await this.userService.findWeb2UserByEmail(email);
     if (!userEntity) {
       throw new AuthError(AuthErrorMessage.INVALID_CREDENTIALS);
+    }
+
+    if (userEntity.status === UserStatus.INACTIVE) {
+      throw new InactiveUserError(userEntity.id);
     }
 
     if (!securityUtils.comparePasswordWithHash(password, userEntity.password)) {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -172,6 +172,10 @@ export class AuthService {
       throw new AuthError(AuthErrorMessage.INVALID_ADDRESS);
     }
 
+    if (userEntity.status === UserStatus.INACTIVE) {
+      throw new InactiveUserError(userEntity.id);
+    }
+
     const preSigninData = web3Utils.prepareSignatureBody({
       from: address,
       to: this.web3ConfigService.operatorAddress,


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->
Closes #3236 
## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->
- Forbid workers with `inactive` status to signin
- Forbid operators with `inactive` status (in DB!) to signin
## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

- [x] Unit tests
- [x] Deployed locally and tested affected endpoint

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->
N/A
## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->
N/A