### PR TITLE
[CVAT] Move annotation downloading after successful validation

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/core/annotation_meta.py
+++ b/packages/examples/cvat/exchange-oracle/src/core/annotation_meta.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from pydantic import BaseModel
 
 ANNOTATION_RESULTS_METAFILE_NAME = "annotation_meta.json"
@@ -9,7 +7,6 @@ RESULTING_ANNOTATIONS_FILE = "resulting_annotations.zip"
 class JobMeta(BaseModel):
     job_id: int
     task_id: int
-    annotation_filename: Path
     annotator_wallet_address: str
     assignment_id: str
     start_frame: int

--- a/packages/examples/cvat/exchange-oracle/src/core/oracle_events.py
+++ b/packages/examples/cvat/exchange-oracle/src/core/oracle_events.py
@@ -47,6 +47,10 @@ class ExchangeOracleEvent_JobFinished(OracleEvent):
     pass  # escrow is enough for now
 
 
+class ExchangeOracleEvent_EscrowRecorded(OracleEvent):
+    pass  # escrow is enough for now
+
+
 class ExchangeOracleEvent_EscrowCleaned(OracleEvent):
     pass
 
@@ -56,10 +60,12 @@ class ReputationOracleEvent_EscrowCompleted(OracleEvent):
 
 
 _event_type_map = {
+    # TODO: make sender-dependent
     JobLauncherEventTypes.escrow_created: JobLauncherEvent_EscrowCreated,
     JobLauncherEventTypes.escrow_canceled: JobLauncherEvent_EscrowCanceled,
     RecordingOracleEventTypes.job_completed: RecordingOracleEvent_JobCompleted,
     RecordingOracleEventTypes.submission_rejected: RecordingOracleEvent_SubmissionRejected,
+    ExchangeOracleEventTypes.escrow_recorded: ExchangeOracleEvent_EscrowRecorded,
     ExchangeOracleEventTypes.escrow_failed: ExchangeOracleEvent_EscrowFailed,
     ExchangeOracleEventTypes.job_finished: ExchangeOracleEvent_JobFinished,
     ExchangeOracleEventTypes.escrow_cleaned: ExchangeOracleEvent_EscrowCleaned,
@@ -68,6 +74,7 @@ _event_type_map = {
 
 
 def get_class_for_event_type(event_type: str) -> type[OracleEvent]:
+    # TODO: make sender-dependent
     event_class = next((v for k, v in _event_type_map.items() if k == event_type), None)
 
     if not event_class:

--- a/packages/examples/cvat/exchange-oracle/src/core/types.py
+++ b/packages/examples/cvat/exchange-oracle/src/core/types.py
@@ -65,6 +65,7 @@ class ExchangeOracleEventTypes(str, Enum, metaclass=BetterEnumMeta):
     escrow_failed = "escrow_failed"
     job_finished = "job_finished"
     escrow_cleaned = "escrow_cleaned"
+    escrow_recorded = "escrow_recorded"
 
 
 class JobLauncherEventTypes(str, Enum, metaclass=BetterEnumMeta):
@@ -78,7 +79,6 @@ class RecordingOracleEventTypes(str, Enum, metaclass=BetterEnumMeta):
 
 
 class ReputationOracleEventTypes(str, Enum, metaclass=BetterEnumMeta):
-    # TODO: rename to ReputationOracleEventType
     escrow_completed = "escrow_completed"
 
 

--- a/packages/examples/cvat/exchange-oracle/src/crons/__init__.py
+++ b/packages/examples/cvat/exchange-oracle/src/crons/__init__.py
@@ -16,6 +16,7 @@ from src.crons.webhooks.job_launcher import (
     process_outgoing_job_launcher_webhooks,
 )
 from src.crons.webhooks.recording_oracle import (
+    process_incoming_recording_oracle_webhook_job_completed,
     process_incoming_recording_oracle_webhooks,
     process_outgoing_recording_oracle_webhooks,
 )
@@ -38,6 +39,11 @@ def setup_cron_jobs(app: FastAPI) -> None:
         )
         scheduler.add_job(
             process_incoming_recording_oracle_webhooks,
+            "interval",
+            seconds=Config.cron_config.process_recording_oracle_webhooks_int,
+        )
+        scheduler.add_job(
+            process_incoming_recording_oracle_webhook_job_completed,
             "interval",
             seconds=Config.cron_config.process_recording_oracle_webhooks_int,
         )

--- a/packages/examples/cvat/exchange-oracle/src/handlers/completed_escrows.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/completed_escrows.py
@@ -135,8 +135,8 @@ def _export_escrow_annotations(
     )
     logger.debug(f"Uploading annotations for the escrow ({escrow_address=})")
 
-    _upload_annotations(
-        annotation_files=(
+    _upload_escrow_results(
+        files=(
             resulting_annotations_file_desc,
             *job_annotations.values(),
             prepare_annotation_metafile(jobs=jobs),
@@ -174,8 +174,8 @@ def _request_escrow_validation(
 
     logger.debug(f"Uploading assignment info for the escrow ({escrow_address=})")
 
-    _upload_annotations(
-        annotation_files=(prepare_annotation_metafile(jobs=jobs),),
+    _upload_escrow_results(
+        files=[prepare_annotation_metafile(jobs=jobs)],
         chain_id=chain_id,
         escrow_address=escrow_address,
     )
@@ -191,8 +191,8 @@ def _request_escrow_validation(
     logger.info(f"The escrow ({escrow_address=}) annotation is finished, " f"requesting validation")
 
 
-def _upload_annotations(
-    annotation_files: Sequence[FileDescriptor], chain_id: int, escrow_address: str
+def _upload_escrow_results(
+    files: Sequence[FileDescriptor], chain_id: int, escrow_address: str
 ) -> None:
     storage_info = BucketAccessInfo.parse_obj(StorageConfig)
     storage_client = cloud_service.make_client(storage_info)
@@ -205,7 +205,8 @@ def _upload_annotations(
             trim_prefix=True,
         )
     ) - {ANNOTATION_RESULTS_METAFILE_NAME, RESULTING_ANNOTATIONS_FILE}
-    for file_descriptor in annotation_files:
+
+    for file_descriptor in files:
         if file_descriptor.filename in existing_storage_files:
             continue
 

--- a/packages/examples/cvat/exchange-oracle/src/handlers/cvat_events.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/cvat_events.py
@@ -142,6 +142,7 @@ def handle_create_job_event(payload: dict) -> None:
                 session,
                 escrow_address=project.escrow_address,
                 chain_id=project.chain_id,
+                active=True,
                 for_update=True,
             )
 

--- a/packages/examples/cvat/exchange-oracle/src/handlers/job_export.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/job_export.py
@@ -43,9 +43,7 @@ class FileDescriptor:
     file: io.RawIOBase | None
 
 
-def prepare_annotation_metafile(
-    jobs: list[Job], job_annotations: dict[int, FileDescriptor]
-) -> FileDescriptor:
+def prepare_annotation_metafile(jobs: list[Job]) -> FileDescriptor:
     """
     Prepares a task/project annotation descriptor file with annotator mapping.
     """
@@ -54,7 +52,6 @@ def prepare_annotation_metafile(
         jobs=[
             JobMeta(
                 job_id=job.cvat_id,
-                annotation_filename=job_annotations[job.cvat_id].filename,
                 annotator_wallet_address=job.latest_assignment.user_wallet_address,
                 assignment_id=job.latest_assignment.id,
                 task_id=job.cvat_task_id,

--- a/packages/examples/cvat/exchange-oracle/src/services/cvat.py
+++ b/packages/examples/cvat/exchange-oracle/src/services/cvat.py
@@ -439,32 +439,26 @@ def create_escrow_creation(
     return escrow_creation_id
 
 
-def get_escrow_creation_by_id(
-    session: Session,
-    escrow_creation_id: str,
-    *,
-    for_update: bool | ForUpdateParams = False,
-) -> EscrowCreation | None:
-    return (
-        _maybe_for_update(session.query(EscrowCreation), enable=for_update)
-        .where(EscrowCreation.id == escrow_creation_id, EscrowCreation.finished_at.is_(None))
-        .first()
-    )
-
-
 def get_escrow_creation_by_escrow_address(
     session: Session,
     escrow_address: str,
     chain_id: int,
     *,
+    active: bool | None,
     for_update: bool | ForUpdateParams = False,
 ) -> EscrowCreation | None:
+    is_active_filter = []
+    if active is True:
+        is_active_filter = [EscrowCreation.finished_at.is_(None)]
+    elif active is False:
+        is_active_filter = [EscrowCreation.finished_at.is_not(None)]
+
     return (
         _maybe_for_update(session.query(EscrowCreation), enable=for_update)
         .where(
             EscrowCreation.escrow_address == escrow_address,
             EscrowCreation.chain_id == chain_id,
-            EscrowCreation.finished_at.is_(None),
+            *is_active_filter,
         )
         .first()
     )

--- a/packages/examples/cvat/recording-oracle/src/core/annotation_meta.py
+++ b/packages/examples/cvat/recording-oracle/src/core/annotation_meta.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TCH003
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
@@ -15,7 +14,6 @@ RESULTING_ANNOTATIONS_FILE = "resulting_annotations.zip"
 class JobMeta(BaseModel):
     job_id: int
     task_id: int
-    annotation_filename: Path
     annotator_wallet_address: str
     assignment_id: str
     start_frame: int

--- a/packages/examples/cvat/recording-oracle/src/core/oracle_events.py
+++ b/packages/examples/cvat/recording-oracle/src/core/oracle_events.py
@@ -33,20 +33,27 @@ class ExchangeOracleEvent_JobFinished(OracleEvent):
     pass  # escrow is enough for now
 
 
+class ExchangeOracleEvent_EscrowExported(OracleEvent):
+    pass  # escrow is enough for now
+
+
 class ExchangeOracleEvent_EscrowCleaned(OracleEvent):
     pass
 
 
 _event_type_map = {
+    # TODO: make sender-dependent
     RecordingOracleEventTypes.job_completed: RecordingOracleEvent_JobCompleted,
     RecordingOracleEventTypes.submission_rejected: RecordingOracleEvent_SubmissionRejected,
     ExchangeOracleEventTypes.escrow_failed: ExchangeOracleEvent_EscrowFailed,
     ExchangeOracleEventTypes.job_finished: ExchangeOracleEvent_JobFinished,
     ExchangeOracleEventTypes.escrow_cleaned: ExchangeOracleEvent_EscrowCleaned,
+    ExchangeOracleEventTypes.escrow_recorded: ExchangeOracleEvent_EscrowExported,
 }
 
 
 def get_class_for_event_type(event_type: str) -> type[OracleEvent]:
+    # TODO: make sender-dependent
     event_class = next((v for k, v in _event_type_map.items() if k == event_type), None)
 
     if not event_class:

--- a/packages/examples/cvat/recording-oracle/src/core/types.py
+++ b/packages/examples/cvat/recording-oracle/src/core/types.py
@@ -35,6 +35,7 @@ class ExchangeOracleEventTypes(str, Enum, metaclass=BetterEnumMeta):
     escrow_failed = "escrow_failed"
     job_finished = "job_finished"
     escrow_cleaned = "escrow_cleaned"
+    escrow_recorded = "escrow_recorded"
 
 
 class RecordingOracleEventTypes(str, Enum, metaclass=BetterEnumMeta):

--- a/packages/examples/cvat/recording-oracle/src/core/validation_results.py
+++ b/packages/examples/cvat/recording-oracle/src/core/validation_results.py
@@ -12,10 +12,16 @@ class ValidationResult:
 @dataclass
 class ValidationSuccess(ValidationResult):
     validation_meta: ValidationMeta
-    resulting_annotations: bytes
     average_quality: float
 
 
 @dataclass
 class ValidationFailure(ValidationResult):
     rejected_jobs: dict[int, DatasetValidationError]
+
+
+@dataclass
+class FinalResult(ValidationResult):
+    validation_meta: ValidationMeta
+    resulting_annotations: bytes
+    average_quality: float

--- a/packages/examples/cvat/recording-oracle/src/crons/__init__.py
+++ b/packages/examples/cvat/recording-oracle/src/crons/__init__.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 
 from src.core.config import Config
 from src.crons.process_exchange_oracle_webhooks import (
+    process_incoming_exchange_oracle_webhook_escrow_recorded,
     process_incoming_exchange_oracle_webhooks,
     process_outgoing_exchange_oracle_webhooks,
 )
@@ -15,6 +16,11 @@ def setup_cron_jobs(app: FastAPI):
         scheduler = BackgroundScheduler()
         scheduler.add_job(
             process_incoming_exchange_oracle_webhooks,
+            "interval",
+            seconds=Config.cron_config.process_exchange_oracle_webhooks_int,
+        )
+        scheduler.add_job(
+            process_incoming_exchange_oracle_webhook_escrow_recorded,
             "interval",
             seconds=Config.cron_config.process_exchange_oracle_webhooks_int,
         )

--- a/packages/examples/cvat/recording-oracle/src/handlers/completion.py
+++ b/packages/examples/cvat/recording-oracle/src/handlers/completion.py
@@ -1,0 +1,173 @@
+import io
+import os
+from logging import Logger
+
+from sqlalchemy.orm import Session
+
+import src.core.annotation_meta as annotation
+import src.core.validation_meta as validation
+import src.services.webhook as oracle_db_service
+from src.chain import escrow
+from src.core.config import Config
+from src.core.manifest import TaskManifest, parse_manifest
+from src.core.oracle_events import (
+    RecordingOracleEvent_JobCompleted,
+)
+from src.core.storage import (
+    compose_results_bucket_filename as compose_annotation_results_bucket_filename,
+)
+from src.core.types import OracleWebhookTypes
+from src.core.validation_results import FinalResult
+from src.handlers.process_intermediate_results import (
+    parse_annotation_metafile,
+    process_final_results,
+    serialize_validation_meta,
+)
+from src.log import ROOT_LOGGER_NAME
+from src.services.cloud import make_client as make_cloud_client
+from src.services.cloud.utils import BucketAccessInfo
+from src.utils.assignments import compute_resulting_annotations_hash
+from src.utils.logging import NullLogger, get_function_logger
+
+module_logger_name = f"{ROOT_LOGGER_NAME}.cron.webhook"
+
+
+class _TaskUploader:
+    def __init__(
+        self, escrow_address: str, chain_id: int, manifest: TaskManifest, db_session: Session
+    ) -> None:
+        self.escrow_address = escrow_address
+        self.chain_id = chain_id
+        self.manifest = manifest
+        self.db_session = db_session
+        self.logger: Logger = NullLogger()
+
+        self.data_bucket = BucketAccessInfo.parse_obj(Config.exchange_oracle_storage_config)
+
+        self.annotation_meta: annotation.AnnotationMeta | None = None
+        self.merged_annotations: bytes | None = None
+
+    def set_logger(self, logger: Logger):
+        self.logger = logger
+
+    def _download_results_meta(self):
+        data_bucket_client = make_cloud_client(self.data_bucket)
+
+        annotation_meta_path = compose_annotation_results_bucket_filename(
+            self.escrow_address,
+            self.chain_id,
+            annotation.ANNOTATION_RESULTS_METAFILE_NAME,
+        )
+        annotation_metafile_data = data_bucket_client.download_file(annotation_meta_path)
+        self.annotation_meta = parse_annotation_metafile(io.BytesIO(annotation_metafile_data))
+
+    def _download_annotations(self):
+        assert self.annotation_meta is not None
+
+        data_bucket_client = make_cloud_client(self.data_bucket)
+
+        exchange_oracle_merged_annotation_path = compose_annotation_results_bucket_filename(
+            self.escrow_address,
+            self.chain_id,
+            annotation.RESULTING_ANNOTATIONS_FILE,
+        )
+        merged_annotations = data_bucket_client.download_file(
+            exchange_oracle_merged_annotation_path
+        )
+
+        self.merged_annotations = merged_annotations
+
+    def _download_results(self):
+        self._download_results_meta()
+        self._download_annotations()
+
+    def _process_annotation_results(self) -> FinalResult:
+        assert self.annotation_meta is not None
+        assert self.merged_annotations is not None
+
+        return process_final_results(
+            session=self.db_session,
+            escrow_address=self.escrow_address,
+            chain_id=self.chain_id,
+            meta=self.annotation_meta,
+            merged_annotations=io.BytesIO(self.merged_annotations),
+            manifest=self.manifest,
+            logger=self.logger,
+        )
+
+    def upload(self):
+        self._download_results()
+
+        validation_result = self._process_annotation_results()
+
+        self._handle_validation_result(validation_result)
+
+    def _compose_validation_results_bucket_filename(self, filename: str) -> str:
+        return f"{self.escrow_address}@{self.chain_id}/{filename}"
+
+    _LOW_QUALITY_REASON_MESSAGE_TEMPLATE = (
+        "Annotation quality ({}) is below the required threshold ({})"
+    )
+
+    def _handle_validation_result(self, export_result: FinalResult):
+        logger = self.logger
+        escrow_address = self.escrow_address
+        chain_id = self.chain_id
+        db_session = self.db_session
+
+        logger.info(
+            f"Result uploading for escrow_address={escrow_address}: successful, "
+            f"average annotation quality is {export_result.average_quality * 100:.2f}%"
+        )
+
+        recor_merged_annotations_path = self._compose_validation_results_bucket_filename(
+            validation.RESULTING_ANNOTATIONS_FILE,
+        )
+
+        recor_validation_meta_path = self._compose_validation_results_bucket_filename(
+            validation.VALIDATION_METAFILE_NAME,
+        )
+        validation_metafile = serialize_validation_meta(export_result.validation_meta)
+
+        storage_client = make_cloud_client(BucketAccessInfo.parse_obj(Config.storage_config))
+
+        # TODO: add encryption
+        storage_client.create_file(
+            recor_merged_annotations_path,
+            export_result.resulting_annotations,
+        )
+        storage_client.create_file(
+            recor_validation_meta_path,
+            validation_metafile,
+        )
+
+        escrow.store_results(
+            chain_id,
+            escrow_address,
+            Config.storage_config.bucket_url() + os.path.dirname(recor_merged_annotations_path),  # noqa: PTH120
+            compute_resulting_annotations_hash(export_result.resulting_annotations),
+        )
+
+        oracle_db_service.outbox.create_webhook(
+            db_session,
+            escrow_address,
+            chain_id,
+            OracleWebhookTypes.reputation_oracle,
+            event=RecordingOracleEvent_JobCompleted(),
+        )
+
+
+def export_results(
+    escrow_address: str,
+    chain_id: int,
+    db_session: Session,
+):
+    logger = get_function_logger(module_logger_name)
+
+    manifest = parse_manifest(escrow.get_escrow_manifest(chain_id, escrow_address))
+
+    uploader = _TaskUploader(
+        escrow_address=escrow_address, chain_id=chain_id, manifest=manifest, db_session=db_session
+    )
+    uploader.set_logger(logger)
+    uploader.upload()

--- a/packages/examples/cvat/recording-oracle/src/handlers/process_intermediate_results.py
+++ b/packages/examples/cvat/recording-oracle/src/handlers/process_intermediate_results.py
@@ -27,7 +27,7 @@ from src.core.validation_errors import (
     TooSlowAnnotationError,
 )
 from src.core.validation_meta import JobMeta, ResultMeta, ValidationMeta
-from src.core.validation_results import ValidationFailure, ValidationSuccess
+from src.core.validation_results import FinalResult, ValidationFailure, ValidationSuccess
 from src.db.utils import ForUpdateParams
 from src.services.cloud import make_client as make_cloud_client
 from src.services.cloud.utils import BucketAccessInfo
@@ -79,7 +79,6 @@ _TaskIdToLabels = dict[int, list[str]]
 class _ValidationResult:
     job_results: _JobResults
     rejected_jobs: _RejectedJobs
-    updated_merged_dataset: io.BytesIO
     gt_stats: GtStats
     task_id_to_val_layout: _TaskIdToValidationLayout
     task_id_to_honeypots_mapping: _TaskIdToHoneypotsMapping
@@ -90,7 +89,25 @@ class _ValidationResult:
 T = TypeVar("T")
 
 
-class _TaskValidator:
+class _TaskHandler:
+    def __init__(
+        self,
+        escrow_address: str,
+        chain_id: int,
+        manifest: TaskManifest,
+    ) -> None:
+        self.escrow_address = escrow_address
+        self.chain_id = chain_id
+        self.manifest = manifest
+
+        self._temp_dir: Path | None = None
+
+    def _require_field(self, field: T | None) -> T:
+        assert field is not None
+        return field
+
+
+class _TaskValidator(_TaskHandler):
     UNKNOWN_QUALITY = -1
     "The value to be used when job quality cannot be computed (e.g. no GT images available)"
 
@@ -100,52 +117,18 @@ class _TaskValidator:
         chain_id: int,
         manifest: TaskManifest,
         *,
-        merged_annotations: io.IOBase,
         meta: AnnotationMeta,
         gt_stats: GtStats | None = None,
     ) -> None:
-        self.escrow_address = escrow_address
-        self.chain_id = chain_id
-        self.manifest = manifest
+        super().__init__(escrow_address=escrow_address, chain_id=chain_id, manifest=manifest)
 
         self._gt_stats: GtStats = gt_stats or {}
-        self._merged_annotations: io.IOBase = merged_annotations
 
-        self._updated_merged_dataset_archive: io.IOBase | None = None
         self._job_results: _JobResults | None = None
         self._rejected_jobs: _RejectedJobs | None = None
 
         self._temp_dir: Path | None = None
-        self._input_gt_dataset: dm.Dataset | None = None
         self._meta: AnnotationMeta = meta
-
-    def _require_field(self, field: T | None) -> T:
-        assert field is not None
-        return field
-
-    def _gt_key_to_sample_id(self, gt_key: str) -> str:
-        return gt_key
-
-    def _parse_gt_dataset(self, gt_file_data: bytes) -> dm.Dataset:
-        with TemporaryDirectory() as gt_temp_dir:
-            gt_filename = os.path.join(gt_temp_dir, "gt_annotations.json")
-            with open(gt_filename, "wb") as f:
-                f.write(gt_file_data)
-
-            gt_dataset = dm.Dataset.import_from(
-                gt_filename,
-                format=DM_GT_DATASET_FORMAT_MAPPING[self.manifest.annotation.type],
-            )
-
-            gt_dataset.init_cache()
-
-            return gt_dataset
-
-    def _load_gt_dataset(self):
-        input_gt_bucket = BucketAccessInfo.parse_obj(self.manifest.validation.gt_url)
-        gt_bucket_client = make_cloud_client(input_gt_bucket)
-        gt_data = gt_bucket_client.download_file(input_gt_bucket.path)
-        self._input_gt_dataset = self._parse_gt_dataset(gt_data)
 
     def _validate_jobs(self):
         manifest = self._require_field(self.manifest)
@@ -255,6 +238,62 @@ class _TaskValidator:
         self._task_id_to_sequence_of_frame_names = task_id_to_sequence_of_frame_names
         self._task_id_to_labels = task_id_to_labels
 
+    def validate(self) -> _ValidationResult:
+        with TemporaryDirectory() as tempdir:
+            self._temp_dir = Path(tempdir)
+
+            self._validate_jobs()
+
+        return _ValidationResult(
+            job_results=self._require_field(self._job_results),
+            rejected_jobs=self._require_field(self._rejected_jobs),
+            gt_stats=self._require_field(self._gt_stats),
+            task_id_to_val_layout=self._require_field(self._task_id_to_val_layout),
+            task_id_to_honeypots_mapping=self._require_field(self._task_id_to_honeypots_mapping),
+            task_id_to_frame_names=self._require_field(self._task_id_to_sequence_of_frame_names),
+            task_id_to_labels=self._require_field(self._task_id_to_labels),
+        )
+
+
+class _TaskAnnotationMerger(_TaskHandler):
+    def __init__(
+        self,
+        escrow_address: str,
+        chain_id: int,
+        manifest: TaskManifest,
+        *,
+        merged_annotations: io.IOBase,
+    ) -> None:
+        super().__init__(escrow_address=escrow_address, chain_id=chain_id, manifest=manifest)
+
+        self._merged_annotations: io.IOBase = merged_annotations
+
+        self._updated_merged_dataset_archive: io.IOBase | None = None
+
+        self._temp_dir: Path | None = None
+        self._input_gt_dataset: dm.Dataset | None = None
+
+    def _parse_gt_dataset(self, gt_file_data: bytes) -> dm.Dataset:
+        with TemporaryDirectory() as gt_temp_dir:
+            gt_filename = os.path.join(gt_temp_dir, "gt_annotations.json")
+            with open(gt_filename, "wb") as f:
+                f.write(gt_file_data)
+
+            gt_dataset = dm.Dataset.import_from(
+                gt_filename,
+                format=DM_GT_DATASET_FORMAT_MAPPING[self.manifest.annotation.type],
+            )
+
+            gt_dataset.init_cache()
+
+            return gt_dataset
+
+    def _load_gt_dataset(self):
+        input_gt_bucket = BucketAccessInfo.parse_obj(self.manifest.validation.gt_url)
+        gt_bucket_client = make_cloud_client(input_gt_bucket)
+        gt_data = gt_bucket_client.download_file(input_gt_bucket.path)
+        self._input_gt_dataset = self._parse_gt_dataset(gt_data)
+
     def _restore_original_image_paths(self, merged_dataset: dm.Dataset) -> dm.Dataset:
         class RemoveCommonPrefix(dm.ItemTransform):
             def __init__(self, extractor: dm.IExtractor, *, prefix: str) -> None:
@@ -361,24 +400,14 @@ class _TaskValidator:
             case _:
                 raise AssertionError(f"Unknown task type {manifest.annotation.type}")
 
-    def validate(self) -> _ValidationResult:
+    def merge_results(self) -> io.IOBase:
         with TemporaryDirectory() as tempdir:
             self._temp_dir = Path(tempdir)
 
             self._load_gt_dataset()
-            self._validate_jobs()
             self._prepare_merged_dataset()
 
-        return _ValidationResult(
-            job_results=self._require_field(self._job_results),
-            rejected_jobs=self._require_field(self._rejected_jobs),
-            updated_merged_dataset=self._require_field(self._updated_merged_dataset_archive),
-            gt_stats=self._require_field(self._gt_stats),
-            task_id_to_val_layout=self._require_field(self._task_id_to_val_layout),
-            task_id_to_honeypots_mapping=self._require_field(self._task_id_to_honeypots_mapping),
-            task_id_to_frame_names=self._require_field(self._task_id_to_sequence_of_frame_names),
-            task_id_to_labels=self._require_field(self._task_id_to_labels),
-        )
+        return self._require_field(self._updated_merged_dataset_archive)
 
 
 @dataclass
@@ -714,7 +743,6 @@ def process_intermediate_results(  # noqa: PLR0912
     escrow_address: str,
     chain_id: int,
     meta: AnnotationMeta,
-    merged_annotations: io.RawIOBase,
     manifest: TaskManifest,
     logger: logging.Logger,
 ) -> ValidationSuccess | ValidationFailure:
@@ -759,7 +787,6 @@ def process_intermediate_results(  # noqa: PLR0912
         escrow_address=escrow_address,
         chain_id=chain_id,
         manifest=manifest,
-        merged_annotations=merged_annotations,
         meta=unchecked_jobs_meta,
         gt_stats=gt_stats,
     )
@@ -911,7 +938,103 @@ def process_intermediate_results(  # noqa: PLR0912
     return ValidationSuccess(
         job_results=job_results,
         validation_meta=validation_meta,
-        resulting_annotations=validation_result.updated_merged_dataset.getvalue(),
+        average_quality=np.mean(
+            [v for v in job_results.values() if v != _TaskValidator.UNKNOWN_QUALITY and v >= 0]
+            or [0]
+        ),
+    )
+
+
+def process_final_results(
+    session: Session,
+    *,
+    escrow_address: str,
+    chain_id: int,
+    meta: AnnotationMeta,
+    merged_annotations: io.RawIOBase,
+    manifest: TaskManifest,
+    logger: logging.Logger,
+) -> FinalResult:
+    assert logger  # unused
+
+    task = db_service.get_task_by_escrow_address(
+        session,
+        escrow_address,
+        for_update=ForUpdateParams(
+            nowait=True
+        ),  # should not happen, but waiting should not block processing
+    )
+    if not task:
+        raise AssertionError(f"Validation results for escrow {escrow_address} not found")
+
+    merger = _TaskAnnotationMerger(
+        escrow_address=escrow_address,
+        chain_id=chain_id,
+        manifest=manifest,
+        merged_annotations=merged_annotations,
+    )
+
+    merged_annotations = merger.merge_results()
+
+    job_final_result_ids: dict[str, str] = {}
+
+    for job_meta in meta.jobs:
+        job = db_service.get_job_by_cvat_id(session, job_meta.job_id)
+        if not job:
+            raise AssertionError(
+                f"Can't find validation results for job " f"{job_meta.job_id} ({escrow_address=})"
+            )
+
+        assignment_validation_result = db_service.get_validation_result_by_assignment_id(
+            session, job_meta.assignment_id
+        )
+        if not assignment_validation_result:
+            raise AssertionError(
+                f"Can't find validation results for assignments "
+                f"{job_meta.assignment_id} ({escrow_address=})"
+            )
+
+        job_final_result_ids[job.id] = assignment_validation_result.id
+
+    task_jobs = task.jobs
+
+    task_validation_results = db_service.get_task_validation_results(session, task.id)
+
+    job_id_to_meta_id = {job.id: i for i, job in enumerate(task_jobs)}
+
+    validation_result_id_to_meta_id = {r.id: i for i, r in enumerate(task_validation_results)}
+
+    validation_meta = ValidationMeta(
+        jobs=[
+            JobMeta(
+                job_id=job_id_to_meta_id[job.id],
+                final_result_id=validation_result_id_to_meta_id[job_final_result_ids[job.id]],
+            )
+            for job in task_jobs
+        ],
+        results=[
+            ResultMeta(
+                id=validation_result_id_to_meta_id[r.id],
+                job_id=job_id_to_meta_id[r.job.id],
+                annotator_wallet_address=r.annotator_wallet_address,
+                annotation_quality=r.annotation_quality,
+            )
+            for r in task_validation_results
+        ],
+    )
+
+    # Include final results for all jobs
+    job_results: _JobResults = {
+        job.cvat_id: task_validation_results[
+            validation_result_id_to_meta_id[job_final_result_ids[job.id]]
+        ].annotation_quality
+        for job in task_jobs
+    }
+
+    return FinalResult(
+        job_results=job_results,
+        validation_meta=validation_meta,
+        resulting_annotations=merged_annotations.read(),
         average_quality=np.mean(
             [v for v in job_results.values() if v != _TaskValidator.UNKNOWN_QUALITY and v >= 0]
             or [0]

--- a/packages/examples/cvat/recording-oracle/tests/integration/services/test_validation_service.py
+++ b/packages/examples/cvat/recording-oracle/tests/integration/services/test_validation_service.py
@@ -24,7 +24,10 @@ from src.core.validation_errors import TooSlowAnnotationError
 from src.core.validation_results import ValidationFailure, ValidationSuccess
 from src.cvat import api_calls as cvat_api
 from src.db import SessionLocal
-from src.handlers.process_intermediate_results import process_intermediate_results
+from src.handlers.process_intermediate_results import (
+    process_final_results,
+    process_intermediate_results,
+)
 from src.services.validation import (
     create_job,
     create_task,
@@ -128,15 +131,6 @@ class TestManifestChange:
             common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj")
             )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.extract_zip_archive")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive")
-            )
 
             common_lock_es.enter_context(
                 mock.patch("src.core.config.ValidationConfig.min_warmup_progress", 0),
@@ -174,22 +168,11 @@ class TestManifestChange:
             )
             mock_get_task_labels.return_value = [label.name for label in manifest.annotation.labels]
 
-            def patched_prepare_merged_dataset(self):
-                self._updated_merged_dataset_archive = io.BytesIO()
-
-            common_lock_es.enter_context(
-                mock.patch(
-                    "src.handlers.process_intermediate_results._TaskValidator._prepare_merged_dataset",
-                    patched_prepare_merged_dataset,
-                )
-            )
-
             annotation_meta = AnnotationMeta(
                 jobs=[
                     JobMeta(
                         job_id=cvat_job_id,
                         task_id=cvat_task_id,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment1_id,
                         start_frame=0,
@@ -237,7 +220,6 @@ class TestManifestChange:
                     escrow_address=escrow_address,
                     chain_id=chain_id,
                     meta=annotation_meta,
-                    merged_annotations=io.BytesIO(),
                     manifest=manifest,
                     logger=logger,
                 )
@@ -283,7 +265,6 @@ class TestManifestChange:
                     escrow_address=escrow_address,
                     chain_id=chain_id,
                     meta=annotation_meta,
-                    merged_annotations=io.BytesIO(),
                     manifest=manifest,
                     logger=logger,
                 )
@@ -354,15 +335,6 @@ class TestValidationLogic:
             common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj")
             )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.extract_zip_archive")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive")
-            )
 
             mock_make_cloud_client = common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.make_cloud_client")
@@ -397,22 +369,11 @@ class TestValidationLogic:
             )
             mock_get_task_labels.return_value = [label.name for label in manifest.annotation.labels]
 
-            def patched_prepare_merged_dataset(self):
-                self._updated_merged_dataset_archive = io.BytesIO()
-
-            common_lock_es.enter_context(
-                mock.patch(
-                    "src.handlers.process_intermediate_results._TaskValidator._prepare_merged_dataset",
-                    patched_prepare_merged_dataset,
-                )
-            )
-
             annotation_meta = AnnotationMeta(
                 jobs=[
                     JobMeta(
                         job_id=1 + i,
                         task_id=cvat_task_id,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment1_id,
                         start_frame=job_start,
@@ -468,7 +429,6 @@ class TestValidationLogic:
                     escrow_address=escrow_address,
                     chain_id=chain_id,
                     meta=annotation_meta,
-                    merged_annotations=io.BytesIO(),
                     manifest=manifest,
                     logger=logger,
                 )
@@ -610,15 +570,6 @@ class TestValidationLogic:
             common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj")
             )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.extract_zip_archive")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive")
-            )
 
             mock_make_cloud_client = common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.make_cloud_client")
@@ -652,22 +603,11 @@ class TestValidationLogic:
             )
             mock_get_task_labels.return_value = [label.name for label in manifest.annotation.labels]
 
-            def patched_prepare_merged_dataset(self):
-                self._updated_merged_dataset_archive = io.BytesIO()
-
-            common_lock_es.enter_context(
-                mock.patch(
-                    "src.handlers.process_intermediate_results._TaskValidator._prepare_merged_dataset",
-                    patched_prepare_merged_dataset,
-                )
-            )
-
             annotation_meta = AnnotationMeta(
                 jobs=[
                     JobMeta(
                         job_id=cvat_job_id,
                         task_id=cvat_task_id,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment1_id,
                         start_frame=0,
@@ -718,7 +658,6 @@ class TestValidationLogic:
                         escrow_address=escrow_address,
                         chain_id=chain_id,
                         meta=annotation_meta,
-                        merged_annotations=io.BytesIO(),
                         manifest=manifest,
                         logger=logger,
                     )
@@ -747,15 +686,6 @@ class TestValidationLogic:
 
             common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.extract_zip_archive")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive")
             )
 
             mock_make_cloud_client = common_lock_es.enter_context(
@@ -797,22 +727,11 @@ class TestValidationLogic:
                 )
             )
 
-            def patched_prepare_merged_dataset(self):
-                self._updated_merged_dataset_archive = io.BytesIO()
-
-            common_lock_es.enter_context(
-                mock.patch(
-                    "src.handlers.process_intermediate_results._TaskValidator._prepare_merged_dataset",
-                    patched_prepare_merged_dataset,
-                )
-            )
-
             annotation_meta = AnnotationMeta(
                 jobs=[
                     JobMeta(
                         job_id=cvat_task_id1,
                         task_id=cvat_task_id1,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment1_id,
                         start_frame=0,
@@ -821,7 +740,6 @@ class TestValidationLogic:
                     JobMeta(
                         job_id=cvat_task_id2,
                         task_id=cvat_task_id2,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment2_id,
                         start_frame=0,
@@ -887,7 +805,6 @@ class TestValidationLogic:
                     escrow_address=escrow_address,
                     chain_id=chain_id,
                     meta=annotation_meta,
-                    merged_annotations=io.BytesIO(),
                     manifest=manifest,
                     logger=logger,
                 )
@@ -951,15 +868,6 @@ class TestValidationLogic:
             common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj")
             )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.extract_zip_archive")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive")
-            )
 
             mock_make_cloud_client = common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.make_cloud_client")
@@ -1000,22 +908,11 @@ class TestValidationLogic:
                 )
             )
 
-            def patched_prepare_merged_dataset(self):
-                self._updated_merged_dataset_archive = io.BytesIO()
-
-            common_lock_es.enter_context(
-                mock.patch(
-                    "src.handlers.process_intermediate_results._TaskValidator._prepare_merged_dataset",
-                    patched_prepare_merged_dataset,
-                )
-            )
-
             annotation_meta = AnnotationMeta(
                 jobs=[
                     JobMeta(
                         job_id=cvat_task_id1,
                         task_id=cvat_task_id1,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment1_id,
                         start_frame=0,
@@ -1024,7 +921,6 @@ class TestValidationLogic:
                     JobMeta(
                         job_id=cvat_task_id2,
                         task_id=cvat_task_id2,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment2_id,
                         start_frame=0,
@@ -1090,7 +986,6 @@ class TestValidationLogic:
                     escrow_address=escrow_address,
                     chain_id=chain_id,
                     meta=annotation_meta,
-                    merged_annotations=io.BytesIO(),
                     manifest=manifest,
                     logger=logger,
                 )
@@ -1126,15 +1021,6 @@ class TestValidationLogic:
 
             common_lock_es.enter_context(
                 mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.extract_zip_archive")
-            )
-            common_lock_es.enter_context(
-                mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive")
             )
 
             mock_make_cloud_client = common_lock_es.enter_context(
@@ -1176,22 +1062,11 @@ class TestValidationLogic:
                 )
             )
 
-            def patched_prepare_merged_dataset(self):
-                self._updated_merged_dataset_archive = io.BytesIO()
-
-            common_lock_es.enter_context(
-                mock.patch(
-                    "src.handlers.process_intermediate_results._TaskValidator._prepare_merged_dataset",
-                    patched_prepare_merged_dataset,
-                )
-            )
-
             annotation_meta = AnnotationMeta(
                 jobs=[
                     JobMeta(
                         job_id=cvat_task_id,
                         task_id=cvat_task_id,
-                        annotation_filename="",
                         annotator_wallet_address=annotator1,
                         assignment_id=assignment1_id,
                         start_frame=0,
@@ -1249,7 +1124,6 @@ class TestValidationLogic:
                     escrow_address=escrow_address,
                     chain_id=chain_id,
                     meta=annotation_meta,
-                    merged_annotations=io.BytesIO(),
                     manifest=manifest,
                     logger=logger,
                 )
@@ -1258,3 +1132,100 @@ class TestValidationLogic:
             assert any("Too few validation frames left in the task" in m for m in caplog.messages)
 
             mock_update_task_validation_layout.assert_not_called()
+
+
+class TestAnnotationMerging:
+    def test_can_prepare_final_results_in_validated_escrow(self, session: Session):
+        escrow_address = ESCROW_ADDRESS
+        chain_id = Networks.localhost.value
+
+        task1_id = create_task(session, escrow_address=escrow_address, chain_id=chain_id)
+
+        job1_id = create_job(session, job_cvat_id=1, task_id=task1_id)
+
+        job2_id = create_job(session, job_cvat_id=2, task_id=task1_id)
+
+        assignment_id1 = str(uuid.uuid4())
+        annotator1 = WALLET_ADDRESS1
+        vr1 = models.ValidationResult(
+            id=str(uuid.uuid4()),
+            job_id=job1_id,
+            assignment_id=assignment_id1,
+            annotator_wallet_address=annotator1,
+            annotation_quality=0.8,
+        )
+        session.add(vr1)
+
+        assignment_id2 = str(uuid.uuid4())
+        vr2 = models.ValidationResult(
+            id=str(uuid.uuid4()),
+            job_id=job2_id,
+            assignment_id=assignment_id2,
+            annotator_wallet_address=annotator1,
+            annotation_quality=0.6,
+        )
+        session.add(vr2)
+
+        session.commit()
+
+        manifest = generate_manifest(min_quality=0.4)
+
+        def patched_prepare_merged_dataset(self):
+            self._updated_merged_dataset_archive = io.BytesIO(b"test")
+
+        with (
+            mock.patch("src.handlers.process_intermediate_results.BucketAccessInfo.parse_obj"),
+            mock.patch(
+                "src.handlers.process_intermediate_results.make_cloud_client"
+            ) as mock_make_cloud_client,
+            mock.patch("src.handlers.process_intermediate_results.dm.Dataset.import_from"),
+            mock.patch("src.handlers.process_intermediate_results.extract_zip_archive"),
+            mock.patch("src.handlers.process_intermediate_results.write_dir_to_zip_archive"),
+            mock.patch(
+                "src.handlers.process_intermediate_results._TaskAnnotationMerger._prepare_merged_dataset",
+                patched_prepare_merged_dataset,
+            ),
+        ):
+            mock_make_cloud_client.return_value.download_file = mock.Mock(return_value=b"")
+
+            annotation_meta = AnnotationMeta(
+                jobs=[
+                    JobMeta(
+                        job_id=1,
+                        task_id=1,
+                        annotator_wallet_address=annotator1,
+                        assignment_id=assignment_id1,
+                        start_frame=0,
+                        stop_frame=manifest.annotation.job_size + manifest.validation.val_size,
+                    ),
+                    JobMeta(
+                        job_id=2,
+                        task_id=1,
+                        annotator_wallet_address=annotator1,
+                        assignment_id=assignment_id2,
+                        start_frame=0,
+                        stop_frame=manifest.annotation.job_size + manifest.validation.val_size,
+                    ),
+                ]
+            )
+
+            final_result = process_final_results(
+                session=session,
+                escrow_address=escrow_address,
+                chain_id=chain_id,
+                meta=annotation_meta,
+                manifest=manifest,
+                merged_annotations=io.BytesIO(),
+                logger=mock.Mock(Logger),
+            )
+
+        assert mock_make_cloud_client.return_value.download_file.call_count == 1  # gt
+
+        assert final_result.average_quality == 0.7
+        assert final_result.resulting_annotations == b"test"
+        assert final_result.job_results == {
+            1: 0.8,
+            2: 0.6,
+        }
+        assert len(final_result.validation_meta.jobs) == 2
+        assert len(final_result.validation_meta.results) == 2


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->

## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->

Annotation export for an escrow can take huge amount of time, but it's not really necessary as we do validation in CVAT. This PR moves exporting to happen only after successful escrow acceptance.

Messaging:
old:
1. EO -> job_finished -> RO
2. RO -> job_completed -> EO, RepO

new:
1. EO -> job_finished -> RO
2. RO -> job_completed -> EO
3. EO -> escrow_recorded -> RO
4. RO -> job_completed -> RepO

- Added a new EO -> RO event `escrow_recorded`, it is sent after successful annotation export
- EO: 
  - Removed annotation export from validation attempt preparations (right before `job_finished` event)
  - Added annotation export to RO `job_completed` event handling
  - Added sending of new event `escrow_recorded` after successful export in RO `job_completed` event handling
- RO: 
  - Removed annotation merging and uploading from EO `job_finished` event handling
  - Removed RepO notification from EO `job_finished` event handling
  - Added new EO `escrow_recorded` event handling: 
    - GT is merged with assignment annotations, uploaded to RO storage
    - RepO is notified with RO `job_completed` event

As annotation export is a long operation, it's handled in a separate event handling thread.

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->