### PR TITLE
[CVAT] Fix invalid status check

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/cvat/api_calls.py
+++ b/packages/examples/cvat/exchange-oracle/src/cvat/api_calls.py
@@ -541,7 +541,7 @@ def fetch_projects(assignee: str = "") -> list[models.ProjectRead]:
             raise
 
 
-def get_task_upload_status(cvat_id: int) -> tuple[RequestStatus | None, str]:
+def get_task_upload_status(cvat_id: int) -> tuple[RequestStatus, str]:
     logger = logging.getLogger("app")
 
     with get_api_client() as api_client:
@@ -563,12 +563,12 @@ def get_task_upload_status(cvat_id: int) -> tuple[RequestStatus | None, str]:
                 if task.size > 0:
                     status = RequestStatus.FINISHED
                     reason = ""
+                else:
+                    status = RequestStatus.QUEUED
+                    reason = ""
 
             return status, reason
         except exceptions.ApiException as e:
-            if e.status == 404:
-                return None, e.body
-
             logger.exception(f"Exception when calling ProjectsApi.list(): {e}\n")
             raise
 


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->

If task creation status returned `None` (e.g. if no request was found and the task is not processed yet), the [gt uploading function](https://github.com/humanprotocol/human-protocol/blob/6953efedea7fa6de7981a2ad351442167ed143d6/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py#L212-L227) simply exited with no error. This could possibly lead to successful escrow creation with the GT job uninitialized.

Removed the possibility of `None` as a return value in status checks.

- Fixed invalid task creation status checks, leading to uninitialized GT jobs

## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->