### PR TITLE
[Job Launcher] fix: add missing OracleType for audino

### DIFF
--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -11,7 +11,10 @@ import { EnvironmentConfigService } from '../../common/config/environment-config
 import { OracleDiscoveryService } from '../oracle-discovery/oracle-discovery.service';
 import { DiscoveredOracle } from '../oracle-discovery/model/oracle-discovery.model';
 import { WorkerService } from '../user-worker/worker.service';
-import { JobDiscoveryFieldName } from '../../common/enums/global-common';
+import {
+  JobDiscoveryFieldName,
+  JobStatus,
+} from '../../common/enums/global-common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { JobsDiscoveryService } from '../jobs-discovery/jobs-discovery.service';
 
@@ -119,6 +122,7 @@ export class CronJobService {
         JobDiscoveryFieldName.CreatedAt,
         JobDiscoveryFieldName.UpdatedAt,
       ];
+      command.data.status = JobStatus.ACTIVE;
       const initialResponse =
         await this.exchangeOracleGateway.fetchJobs(command);
 

--- a/packages/apps/job-launcher/server/src/common/enums/webhook.ts
+++ b/packages/apps/job-launcher/server/src/common/enums/webhook.ts
@@ -9,6 +9,7 @@ export enum EventType {
 export enum OracleType {
   FORTUNE = 'fortune',
   CVAT = 'cvat',
+  AUDINO = 'audino',
   HCAPTCHA = 'hcaptcha',
 }
 

--- a/packages/apps/job-launcher/server/src/database/migrations/1743611706650-AudinoOracleType.ts
+++ b/packages/apps/job-launcher/server/src/database/migrations/1743611706650-AudinoOracleType.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AudinoOracleType1743611706650 implements MigrationInterface {
+  name = 'AudinoOracleType1743611706650';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."webhook_oracle_type_enum"
+            RENAME TO "webhook_oracle_type_enum_old"
+        `);
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."webhook_oracle_type_enum" AS ENUM('fortune', 'cvat', 'audino', 'hcaptcha')
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."webhook"
+            ALTER COLUMN "oracle_type" TYPE "hmt"."webhook_oracle_type_enum" USING "oracle_type"::"text"::"hmt"."webhook_oracle_type_enum"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."webhook_oracle_type_enum_old"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."webhook_oracle_type_enum_old" AS ENUM('fortune', 'cvat', 'hcaptcha')
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."webhook"
+            ALTER COLUMN "oracle_type" TYPE "hmt"."webhook_oracle_type_enum_old" USING "oracle_type"::"text"::"hmt"."webhook_oracle_type_enum_old"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."webhook_oracle_type_enum"
+        `);
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."webhook_oracle_type_enum_old"
+            RENAME TO "webhook_oracle_type_enum"
+        `);
+  }
+}

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -1533,6 +1533,8 @@ export class JobService {
       return OracleType.FORTUNE;
     } else if (requestType === JobRequestType.HCAPTCHA) {
       return OracleType.HCAPTCHA;
+    } else if (requestType === JobRequestType.AUDIO_TRANSCRIPTION) {
+      return OracleType.AUDINO;
     } else {
       return OracleType.CVAT;
     }


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/humanprotocol/human-protocol/pull/3258

## Context behind the change
When creating webhooks, we also specify oracle type, and this part was missed while adding Audino. Adding it here.

Also changed HUMAN App to fetch & cache only `active` jobs from ExcO.

## How has this been tested?
- locally

## Release plan
W/ main PR

## Potential risks; What to monitor; Rollback plan
No