### PR TITLE
chore: bump vite to address dep review

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20090,9 +20090,9 @@ vite-plugin-svgr@^4.2.0:
     "@svgr/plugin-jsx" "^8.1.0"
 
 "vite@^5.0.0 || ^6.0.0", vite@^6.2.4:
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.4.tgz#05809de3f918fded87f73a838761995a4d66a680"
-  integrity sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.5.tgz#d093b5fe8eb96e594761584a966ab13f24457820"
+  integrity sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==
   dependencies:
     esbuild "^0.25.0"
     postcss "^8.5.3"


### PR DESCRIPTION
## Issue tracking
https://github.com/humanprotocol/human-protocol/actions/runs/14310193487?pr=3213

## Context behind the change
Bumping resolved `vite` package version to avoid dep review

## How has this been tested?
- CI

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
N/A