### PR TITLE
[HUMAN App] fix: signup error handling

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/signup/operator/views/add-stake.page.tsx
+++ b/packages/apps/human-app/frontend/src/modules/signup/operator/views/add-stake.page.tsx
@@ -71,11 +71,7 @@ export function AddStakeOperatorPage() {
     );
   }
 
-  if (
-    isGetStakedAmountPending ||
-    isDecimalsDataPending ||
-    decimalsData === undefined
-  ) {
+  if (isGetStakedAmountPending || isDecimalsDataPending) {
     return <PageCardLoader />;
   }
 

--- a/packages/apps/human-app/frontend/src/modules/signup/worker/views/sign-up-worker.page.tsx
+++ b/packages/apps/human-app/frontend/src/modules/signup/worker/views/sign-up-worker.page.tsx
@@ -48,7 +48,7 @@ export function SignUpWorkerPage() {
       alert={
         isError ? (
           <Alert color="error" severity="error" sx={{ width: '100%' }}>
-            {getErrorMessageForError(isError, handleSignupError)}
+            {getErrorMessageForError(error, handleSignupError)}
           </Alert>
         ) : undefined
       }

--- a/packages/apps/human-app/frontend/src/modules/worker/jobs-discovery/components/oracles-table.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/jobs-discovery/components/oracles-table.tsx
@@ -41,10 +41,7 @@ export function OraclesTable() {
   if (isOraclesDataError) {
     return (
       <PageCardError
-        errorMessage={
-          oraclesDataError?.message ??
-          t('worker.oraclesTable.error.gettingOracles')
-        }
+        errorMessage={t('worker.oraclesTable.error.gettingOracles')}
       />
     );
   }

--- a/packages/apps/human-app/frontend/src/modules/worker/jobs/available-jobs/hooks/use-assign-job.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/jobs/available-jobs/hooks/use-assign-job.ts
@@ -25,7 +25,7 @@ function assignJob(data: AssignJobBody) {
 export function useAssignJobMutation(
   callbacks?: {
     onSuccess: () => void;
-    onError: (error: unknown) => void;
+    onError: (error: Error) => void;
   },
   mutationKey?: MutationKey
 ) {

--- a/packages/apps/human-app/frontend/src/modules/worker/jobs/hooks/use-jobs-notifications.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/jobs/hooks/use-jobs-notifications.tsx
@@ -16,7 +16,7 @@ export const useJobsNotifications = () => {
     });
   };
 
-  const onJobAssignmentError = (error: unknown) => {
+  const onJobAssignmentError = (error: Error) => {
     showNotification({
       message: getErrorMessageForError(error),
       type: TopNotificationType.WARNING,

--- a/packages/apps/human-app/frontend/src/shared/errors/get-error-message-for-error.ts
+++ b/packages/apps/human-app/frontend/src/shared/errors/get-error-message-for-error.ts
@@ -5,7 +5,7 @@ import { JsonRpcError } from '@/modules/smart-contracts/json-rpc-error';
 type CustomErrorHandler = (unknownError: unknown) => string | undefined;
 
 export function getErrorMessageForError(
-  unknownError: unknown,
+  unknownError: Error | null,
   customErrorHandler?: CustomErrorHandler
 ): string {
   let customError: string | undefined;

--- a/packages/apps/human-app/frontend/src/shared/types/global.type.ts
+++ b/packages/apps/human-app/frontend/src/shared/types/global.type.ts
@@ -6,7 +6,7 @@ export interface Children {
   children?: React.ReactNode;
 }
 
-export type ResponseError = FetchError | Error | ZodError | JsonRpcError | null;
+export type ResponseError = FetchError | Error | ZodError | JsonRpcError;
 
 declare module '@tanstack/react-query' {
   interface Register {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Currently we display common error message for signup
<img width="495" alt="Screenshot 2025-04-10 at 15 01 27" src="https://github.com/user-attachments/assets/2bbb6bd3-2699-47e6-b8c5-574e6e2f11d8" />
so fixing handler here: now it takes bool, but should take error object

## How has this been tested?
- [x] e2e on Vercel

<img width="1319" alt="Screenshot 2025-04-10 at 15 14 03" src="https://github.com/user-attachments/assets/33608b83-43fa-476f-ad37-1a604735eddf" />


## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
N/A