### PR TITLE
[Reputation Oracle] fix: jwt expiration time

### DIFF
--- a/packages/apps/reputation-oracle/server/src/config/auth-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/auth-config.service.ts
@@ -22,24 +22,19 @@ export class AuthConfigService {
   }
 
   /**
-   * The expiration time (in ms) for access tokens.
-   * Default: 600000
+   * The expiration time (in seconds) for access tokens.
+   * Default: 600
    */
   get accessTokenExpiresIn(): number {
-    return (
-      +this.configService.get<number>('JWT_ACCESS_TOKEN_EXPIRES_IN', 600) * 1000
-    );
+    return +this.configService.get('JWT_ACCESS_TOKEN_EXPIRES_IN', 600);
   }
 
   /**
-   * The expiration time (in ms) for refresh tokens.
-   * Default: 3600000
+   * The expiration time (in seconds) for refresh tokens.
+   * Default: 3600
    */
   get refreshTokenExpiresIn(): number {
-    return (
-      +this.configService.get<number>('JWT_REFRESH_TOKEN_EXPIRES_IN', 3600) *
-      1000
-    );
+    return +this.configService.get('JWT_REFRESH_TOKEN_EXPIRES_IN', 3600);
   }
 
   /**
@@ -48,8 +43,7 @@ export class AuthConfigService {
    */
   get verifyEmailTokenExpiresIn(): number {
     return (
-      +this.configService.get<number>('VERIFY_EMAIL_TOKEN_EXPIRES_IN', 86400) *
-      1000
+      +this.configService.get('VERIFY_EMAIL_TOKEN_EXPIRES_IN', 86400) * 1000
     );
   }
 
@@ -59,10 +53,7 @@ export class AuthConfigService {
    */
   get forgotPasswordExpiresIn(): number {
     return (
-      +this.configService.get<number>(
-        'FORGOT_PASSWORD_TOKEN_EXPIRES_IN',
-        86400,
-      ) * 1000
+      +this.configService.get('FORGOT_PASSWORD_TOKEN_EXPIRES_IN', 86400) * 1000
     );
   }
 

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -39,8 +39,8 @@ const { publicKey, privateKey } = generateES256Keys();
 const mockAuthConfigService = {
   jwtPrivateKey: privateKey,
   jwtPublicKey: publicKey,
-  accessTokenExpiresIn: 600000,
-  refreshTokenExpiresIn: 3600000,
+  accessTokenExpiresIn: 600,
+  refreshTokenExpiresIn: 3600,
   verifyEmailTokenExpiresIn: 86400000,
   forgotPasswordExpiresIn: 86400000,
   humanAppEmail: faker.internet.email(),


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Introduced in https://github.com/humanprotocol/human-protocol/pull/3205: expiration time for JWT is multiplied by 1000, but JWT modules accepts value in seconds, hence JWT expiration time is longer than expected now. Fixing it back to be seconds.

## How has this been tested?
- [x] sign in locally, check that JWT expiration time is 10 minutes

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No