### PR TITLE
[HUMAN App] fix: operator role values

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/signup/operator/components/add-keys/edit-existing-keys-form.tsx
+++ b/packages/apps/human-app/frontend/src/modules/signup/operator/components/add-keys/edit-existing-keys-form.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/shared/components/data-entry/input';
 import type { EthKVStoreKeyValues } from '@/modules/smart-contracts/EthKVStore/config';
 import {
   EthKVStoreKeys,
-  Role,
+  OPERATOR_ROLES,
 } from '@/modules/smart-contracts/EthKVStore/config';
 import { Select } from '@/shared/components/data-entry/select';
 import { MultiSelect } from '@/shared/components/data-entry/multi-select';
@@ -16,12 +16,6 @@ import type { GetEthKVStoreValuesSuccessResponse } from '@/modules/operator/hook
 import { useColorMode } from '@/shared/contexts/color-mode';
 import { PercentsInputMask } from '@/shared/components/data-entry/input-masks';
 import { sortFormKeys, STORE_KEYS_ORDER } from '../../utils';
-
-const OPTIONS = [
-  Role.EXCHANGE_ORACLE,
-  Role.JOB_LAUNCHER,
-  Role.RECORDING_ORACLE,
-];
 
 const formInputsConfig: Record<EthKVStoreKeyValues, React.ReactElement> = {
   [EthKVStoreKeys.Fee]: (
@@ -58,7 +52,7 @@ const formInputsConfig: Record<EthKVStoreKeyValues, React.ReactElement> = {
       isChipRenderValue
       label={t('operator.addKeysPage.existingKeys.role')}
       name={EthKVStoreKeys.Role}
-      options={OPTIONS.map((role, i) => ({
+      options={OPERATOR_ROLES.map((role, i) => ({
         name: role,
         value: role,
         id: i,

--- a/packages/apps/human-app/frontend/src/modules/signup/operator/components/add-keys/edit-pending-keys-form.tsx
+++ b/packages/apps/human-app/frontend/src/modules/signup/operator/components/add-keys/edit-pending-keys-form.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/shared/components/data-entry/input';
 import type { EthKVStoreKeyValues } from '@/modules/smart-contracts/EthKVStore/config';
 import {
   EthKVStoreKeys,
-  Role,
+  OPERATOR_ROLES,
 } from '@/modules/smart-contracts/EthKVStore/config';
 import { Select } from '@/shared/components/data-entry/select';
 import { MultiSelect } from '@/shared/components/data-entry/multi-select';
@@ -12,12 +12,6 @@ import { JOB_TYPES } from '@/shared/consts';
 import type { GetEthKVStoreValuesSuccessResponse } from '@/modules/operator/hooks/use-get-keys';
 import { PercentsInputMask } from '@/shared/components/data-entry/input-masks';
 import { sortFormKeys, STORE_KEYS_ORDER } from '../../utils';
-
-const OPTIONS = [
-  Role.EXCHANGE_ORACLE,
-  Role.JOB_LAUNCHER,
-  Role.RECORDING_ORACLE,
-];
 
 const formInputsConfig: Record<EthKVStoreKeyValues, React.ReactElement> = {
   [EthKVStoreKeys.Fee]: (
@@ -54,7 +48,7 @@ const formInputsConfig: Record<EthKVStoreKeyValues, React.ReactElement> = {
       isChipRenderValue
       label={t('operator.addKeysPage.existingKeys.role')}
       name={EthKVStoreKeys.Role}
-      options={OPTIONS.map((role, i) => ({
+      options={OPERATOR_ROLES.map((role, i) => ({
         name: role,
         value: role,
         id: i,

--- a/packages/apps/human-app/frontend/src/modules/signup/operator/schema/eth-kv-store-values-mutation-schema.ts
+++ b/packages/apps/human-app/frontend/src/modules/signup/operator/schema/eth-kv-store-values-mutation-schema.ts
@@ -3,7 +3,7 @@ import { t } from 'i18next';
 import {
   EthKVStoreKeys,
   JobType,
-  Role,
+  OPERATOR_ROLES,
 } from '@/modules/smart-contracts/EthKVStore/config';
 import { type GetEthKVStoreValuesSuccessResponse } from '@/modules/operator/hooks/use-get-keys';
 import { urlDomainSchema } from '@/shared/schemas';
@@ -12,7 +12,7 @@ const fieldsValidations = {
   [EthKVStoreKeys.PublicKey]: urlDomainSchema,
   [EthKVStoreKeys.Url]: urlDomainSchema,
   [EthKVStoreKeys.WebhookUrl]: urlDomainSchema,
-  [EthKVStoreKeys.Role]: z.nativeEnum(Role),
+  [EthKVStoreKeys.Role]: z.enum(OPERATOR_ROLES),
   [EthKVStoreKeys.JobTypes]: z.array(z.nativeEnum(JobType)).min(1),
   [EthKVStoreKeys.Fee]: z.coerce
     // eslint-disable-next-line camelcase

--- a/packages/apps/human-app/frontend/src/modules/smart-contracts/EthKVStore/config.ts
+++ b/packages/apps/human-app/frontend/src/modules/smart-contracts/EthKVStore/config.ts
@@ -1,9 +1,10 @@
-export enum Role {
-  JOB_LAUNCHER = 'Job Launcher',
-  EXCHANGE_ORACLE = 'Exchange Oracle',
-  REPUTATION_ORACLE = 'Reputation Oracle',
-  RECORDING_ORACLE = 'Recording Oracle',
-}
+import { Role } from '@human-protocol/sdk/src/constants';
+
+export const OPERATOR_ROLES = [
+  Role.ExchangeOracle,
+  Role.JobLauncher,
+  Role.RecordingOracle,
+] as const;
 
 export enum JobType {
   FORTUNE = 'fortune',


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Atm on UI we have it's own list of human-readable options, when in KV store we rely on snake-cased value. Fixing the form to take actual values from sdk

## How has this been tested?
- [ ] update operator role while sign-up, read KV store and make sure snake-cased value is written

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No