### PR TITLE
[Reputation Oracle] fix: refresh token expiration

### DIFF
--- a/packages/apps/reputation-oracle/server/src/config/auth-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/auth-config.service.ts
@@ -30,11 +30,11 @@ export class AuthConfigService {
   }
 
   /**
-   * The expiration time (in seconds) for refresh tokens.
-   * Default: 3600
+   * The expiration time (in ms) for refresh tokens.
+   * Default: 3600000
    */
   get refreshTokenExpiresIn(): number {
-    return +this.configService.get('JWT_REFRESH_TOKEN_EXPIRES_IN', 3600);
+    return +this.configService.get('JWT_REFRESH_TOKEN_EXPIRES_IN', 3600) * 1000;
   }
 
   /**

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -40,7 +40,7 @@ const mockAuthConfigService = {
   jwtPrivateKey: privateKey,
   jwtPublicKey: publicKey,
   accessTokenExpiresIn: 600,
-  refreshTokenExpiresIn: 3600,
+  refreshTokenExpiresIn: 3600000,
   verifyEmailTokenExpiresIn: 86400000,
   forgotPasswordExpiresIn: 86400000,
   humanAppEmail: faker.internet.email(),


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/humanprotocol/human-protocol/pull/3281

## Context behind the change
In previous PR, while fixing access token TTL, introduced a bug to refresh token TTL by mistake: it's value is used in ms in code when generated. Fixing it here

## How has this been tested?
- [x] unit tests
- [x] sign in and verify `expires_at` is correct in DB

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
Buggy version was released, so we might want to extend refresh token TTL env var till we release the fix or release it quickly