### PR TITLE
[Reputation Oracle] refactor: replace increment operation for reputation

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/reputation/fixtures.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/fixtures.ts
@@ -10,13 +10,17 @@ export function generateReputationEntityType(): ReputationEntityType {
   return faker.helpers.arrayElement(REPUTATION_ENTITY_TYPES);
 }
 
+export function generateRandomScorePoints(): number {
+  return faker.number.int({ min: 1, max: 42 });
+}
+
 export function generateReputationEntity(score?: number): ReputationEntity {
   return {
     id: faker.number.int(),
     chainId: generateTestnetChainId(),
     address: faker.finance.ethereumAddress(),
     type: generateReputationEntityType(),
-    reputationPoints: score || faker.number.int(),
+    reputationPoints: score || generateRandomScorePoints(),
     createdAt: faker.date.recent(),
     updatedAt: new Date(),
   };


### PR DESCRIPTION
## Issue tracking
Part of #3084 

## Context behind the change
In previous refactoring PR usage of `increment` and `decrement` repository operations was introduced, but these operations do not update `updated_at` column. Taking into account that we want to keep it updated, change the implementation back to the `updateOne`.

This implementation has a gap for concurrent executions: increment/decrement is not atomic and can lead to lost updates. We accept this risk for now.

## How has this been tested?
- [x] unit tests

## Release plan
Together with main PR.

## Potential risks; What to monitor; Rollback plan
No.