### PR TITLE
[HUMAN App] fix: operator signup endpoint

### DIFF
--- a/packages/apps/human-app/server/src/integrations/reputation-oracle/reputation-oracle.gateway.ts
+++ b/packages/apps/human-app/server/src/integrations/reputation-oracle/reputation-oracle.gateway.ts
@@ -80,6 +80,7 @@ import {
   SigninOperatorCommand,
   SigninOperatorData,
   SigninOperatorResponse,
+  SignupOperatorResponse,
 } from '../../modules/user-operator/model/operator-signin.model';
 import {
   GetNDACommand,
@@ -149,7 +150,9 @@ export class ReputationOracleGateway {
     return this.handleRequestToReputationOracle<void>(options);
   }
 
-  async sendOperatorSignup(command: SignupOperatorCommand): Promise<void> {
+  async sendOperatorSignup(
+    command: SignupOperatorCommand,
+  ): Promise<SignupOperatorResponse> {
     const data = this.mapper.map(
       command,
       SignupOperatorCommand,
@@ -159,8 +162,11 @@ export class ReputationOracleGateway {
       ReputationOracleEndpoints.OPERATOR_SIGNUP,
       data,
     );
-    return this.handleRequestToReputationOracle<void>(options);
+    return this.handleRequestToReputationOracle<SignupOperatorResponse>(
+      options,
+    );
   }
+
   async sendOperatorSignin(
     command: SigninOperatorCommand,
   ): Promise<SigninOperatorResponse> {

--- a/packages/apps/human-app/server/src/modules/user-operator/model/operator-signin.model.ts
+++ b/packages/apps/human-app/server/src/modules/user-operator/model/operator-signin.model.ts
@@ -27,3 +27,8 @@ export class SigninOperatorResponse {
   refresh_token: string;
   access_token: string;
 }
+
+export class SignupOperatorResponse {
+  refresh_token: string;
+  access_token: string;
+}

--- a/packages/apps/human-app/server/src/modules/user-operator/operator.controller.ts
+++ b/packages/apps/human-app/server/src/modules/user-operator/operator.controller.ts
@@ -21,6 +21,7 @@ import {
   SigninOperatorCommand,
   SigninOperatorDto,
   SigninOperatorResponse,
+  SignupOperatorResponse,
 } from './model/operator-signin.model';
 import {
   DisableOperatorCommand,
@@ -44,13 +45,13 @@ export class OperatorController {
   @UsePipes(new ValidationPipe())
   async signupOperator(
     @Body() signupOperatorDto: SignupOperatorDto,
-  ): Promise<void> {
+  ): Promise<SignupOperatorResponse> {
     const signupOperatorCommand = this.mapper.map(
       signupOperatorDto,
       SignupOperatorDto,
       SignupOperatorCommand,
     );
-    await this.service.signupOperator(signupOperatorCommand);
+    return this.service.signupOperator(signupOperatorCommand);
   }
 
   @ApiTags('User-Operator')


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Some time ago `/auth/web3/signup` was changed to correspond to `void` return type, but actually it returned auth tokens for operators. This broke sign up flow for operator on UI, so changing it back here and fixing types to correspond to reality.

## How has this been tested?
- [x] e2e: sign up new operator; make sure it gets tokens in response and profile page is opened with data

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No