### PR TITLE
[Reputation Oracle] chore: cleanup after refactoring

### DIFF
--- a/packages/apps/reputation-oracle/server/src/config/auth-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/auth-config.service.ts
@@ -10,7 +10,7 @@ export class AuthConfigService {
    * Required
    */
   get jwtPrivateKey(): string {
-    return this.configService.getOrThrow<string>('JWT_PRIVATE_KEY');
+    return this.configService.getOrThrow('JWT_PRIVATE_KEY');
   }
 
   /**
@@ -18,7 +18,7 @@ export class AuthConfigService {
    * Required
    */
   get jwtPublicKey(): string {
-    return this.configService.getOrThrow<string>('JWT_PUBLIC_KEY');
+    return this.configService.getOrThrow('JWT_PUBLIC_KEY');
   }
 
   /**
@@ -26,7 +26,7 @@ export class AuthConfigService {
    * Default: 600
    */
   get accessTokenExpiresIn(): number {
-    return +this.configService.get('JWT_ACCESS_TOKEN_EXPIRES_IN', 600);
+    return Number(this.configService.get('JWT_ACCESS_TOKEN_EXPIRES_IN')) || 600;
   }
 
   /**
@@ -34,7 +34,9 @@ export class AuthConfigService {
    * Default: 3600000
    */
   get refreshTokenExpiresIn(): number {
-    return +this.configService.get('JWT_REFRESH_TOKEN_EXPIRES_IN', 3600) * 1000;
+    const configValueSeconds =
+      Number(this.configService.get('JWT_REFRESH_TOKEN_EXPIRES_IN')) || 3600;
+    return configValueSeconds * 1000;
   }
 
   /**
@@ -42,9 +44,9 @@ export class AuthConfigService {
    * Default: 86400000
    */
   get verifyEmailTokenExpiresIn(): number {
-    return (
-      +this.configService.get('VERIFY_EMAIL_TOKEN_EXPIRES_IN', 86400) * 1000
-    );
+    const configValueSeconds =
+      Number(this.configService.get('VERIFY_EMAIL_TOKEN_EXPIRES_IN')) || 86400;
+    return configValueSeconds * 1000;
   }
 
   /**
@@ -52,15 +54,16 @@ export class AuthConfigService {
    * Default: 86400000
    */
   get forgotPasswordExpiresIn(): number {
-    return (
-      +this.configService.get('FORGOT_PASSWORD_TOKEN_EXPIRES_IN', 86400) * 1000
-    );
+    const configValueSeconds =
+      Number(this.configService.get('FORGOT_PASSWORD_TOKEN_EXPIRES_IN')) ||
+      86400;
+    return configValueSeconds * 1000;
   }
 
   /**
    * Human APP email.
    */
   get humanAppEmail(): string {
-    return this.configService.getOrThrow<string>('HUMAN_APP_EMAIL');
+    return this.configService.getOrThrow('HUMAN_APP_EMAIL');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/database-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/database-config.service.ts
@@ -9,7 +9,7 @@ export class DatabaseConfigService {
    * The URL for connecting to the PostgreSQL database.
    */
   get url(): string | undefined {
-    return this.configService.get<string>('POSTGRES_URL');
+    return this.configService.get('POSTGRES_URL');
   }
 
   /**
@@ -17,7 +17,7 @@ export class DatabaseConfigService {
    * Default: '127.0.0.1'
    */
   get host(): string {
-    return this.configService.get<string>('POSTGRES_HOST', '127.0.0.1');
+    return this.configService.get('POSTGRES_HOST', '127.0.0.1');
   }
 
   /**
@@ -25,7 +25,7 @@ export class DatabaseConfigService {
    * Default: 5432
    */
   get port(): number {
-    return +this.configService.get<number>('POSTGRES_PORT', 5432);
+    return Number(this.configService.get('POSTGRES_PORT')) || 5432;
   }
 
   /**
@@ -33,7 +33,7 @@ export class DatabaseConfigService {
    * Default: 'operator'
    */
   get user(): string {
-    return this.configService.get<string>('POSTGRES_USER', 'operator');
+    return this.configService.get('POSTGRES_USER', 'operator');
   }
 
   /**
@@ -41,7 +41,7 @@ export class DatabaseConfigService {
    * Default: 'qwerty'
    */
   get password(): string {
-    return this.configService.get<string>('POSTGRES_PASSWORD', 'qwerty');
+    return this.configService.get('POSTGRES_PASSWORD', 'qwerty');
   }
 
   /**
@@ -49,10 +49,7 @@ export class DatabaseConfigService {
    * Default: 'reputation-oracle'
    */
   get database(): string {
-    return this.configService.get<string>(
-      'POSTGRES_DATABASE',
-      'reputation-oracle',
-    );
+    return this.configService.get('POSTGRES_DATABASE', 'reputation-oracle');
   }
 
   /**
@@ -60,7 +57,7 @@ export class DatabaseConfigService {
    * Default: false
    */
   get ssl(): boolean {
-    return this.configService.get<string>('POSTGRES_SSL', 'false') === 'true';
+    return this.configService.get('POSTGRES_SSL', 'false') === 'true';
   }
 
   /**
@@ -68,9 +65,6 @@ export class DatabaseConfigService {
    * Default: 'log,info,warn,error'
    */
   get logging(): string {
-    return this.configService.get<string>(
-      'POSTGRES_LOGGING',
-      'log,info,warn,error',
-    );
+    return this.configService.get('POSTGRES_LOGGING', 'log,info,warn,error');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/email-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/email-config.service.ts
@@ -11,7 +11,7 @@ export class EmailConfigService {
    * Default: 'disabled'
    */
   get apiKey(): string {
-    return this.configService.get<string>('SENDGRID_API_KEY', 'disabled');
+    return this.configService.get('SENDGRID_API_KEY', 'disabled');
   }
 
   /**
@@ -19,10 +19,7 @@ export class EmailConfigService {
    * Default: 'app@humanprotocol.org'
    */
   get from(): string {
-    return this.configService.get<string>(
-      'EMAIL_FROM',
-      'app@humanprotocol.org',
-    );
+    return this.configService.get('EMAIL_FROM', 'app@humanprotocol.org');
   }
 
   /**
@@ -30,6 +27,6 @@ export class EmailConfigService {
    * Default: 'Human Protocol'
    */
   get fromName(): string {
-    return this.configService.get<string>('EMAIL_FROM_NAME', 'Human Protocol');
+    return this.configService.get('EMAIL_FROM_NAME', 'Human Protocol');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/hcaptcha-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/hcaptcha-config.service.ts
@@ -10,7 +10,7 @@ export class HCaptchaConfigService {
    * Required
    */
   get siteKey(): string {
-    return this.configService.getOrThrow<string>('HCAPTCHA_SITE_KEY');
+    return this.configService.getOrThrow('HCAPTCHA_SITE_KEY');
   }
 
   /**
@@ -18,7 +18,7 @@ export class HCaptchaConfigService {
    * Required
    */
   get apiKey(): string {
-    return this.configService.getOrThrow<string>('HCAPTCHA_API_KEY');
+    return this.configService.getOrThrow('HCAPTCHA_API_KEY');
   }
 
   /**
@@ -26,7 +26,7 @@ export class HCaptchaConfigService {
    * Required
    */
   get secret(): string {
-    return this.configService.getOrThrow<string>('HCAPTCHA_SECRET');
+    return this.configService.getOrThrow('HCAPTCHA_SECRET');
   }
 
   /**
@@ -34,7 +34,7 @@ export class HCaptchaConfigService {
    * Default: 'https://api.hcaptcha.com'
    */
   get protectionURL(): string {
-    return this.configService.get<string>(
+    return this.configService.get(
       'HCAPTCHA_PROTECTION_URL',
       'https://api.hcaptcha.com',
     );
@@ -45,7 +45,7 @@ export class HCaptchaConfigService {
    * Default: 'https://foundation-accounts.hmt.ai'
    */
   get labelingURL(): string {
-    return this.configService.get<string>(
+    return this.configService.get(
       'HCAPTCHA_LABELING_URL',
       'https://foundation-accounts.hmt.ai',
     );
@@ -56,9 +56,6 @@ export class HCaptchaConfigService {
    * Default: 'en'
    */
   get defaultLabelerLang(): string {
-    return this.configService.get<string>(
-      'HCAPTCHA_DEFAULT_LABELER_LANG',
-      'en',
-    );
+    return this.configService.get('HCAPTCHA_DEFAULT_LABELER_LANG', 'en');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/kyc-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/kyc-config.service.ts
@@ -10,7 +10,7 @@ export class KycConfigService {
    * Required
    */
   get apiKey(): string {
-    return this.configService.getOrThrow<string>('KYC_API_KEY');
+    return this.configService.getOrThrow('KYC_API_KEY');
   }
 
   /**
@@ -18,7 +18,7 @@ export class KycConfigService {
    * Required
    */
   get apiPrivateKey(): string {
-    return this.configService.getOrThrow<string>('KYC_API_PRIVATE_KEY');
+    return this.configService.getOrThrow('KYC_API_PRIVATE_KEY');
   }
 
   /**
@@ -26,7 +26,7 @@ export class KycConfigService {
    * Default: 'https://stationapi.veriff.com/v1'
    */
   get baseUrl(): string {
-    return this.configService.get<string>(
+    return this.configService.get(
       'KYC_BASE_URL',
       'https://stationapi.veriff.com/v1',
     );

--- a/packages/apps/reputation-oracle/server/src/config/nda-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/nda-config.service.ts
@@ -9,6 +9,6 @@ export class NDAConfigService {
    * Latest NDA Url.
    */
   get latestNdaUrl(): string {
-    return this.configService.getOrThrow<string>('NDA_URL');
+    return this.configService.getOrThrow('NDA_URL');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/pgp-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/pgp-config.service.ts
@@ -10,20 +10,20 @@ export class PGPConfigService {
    * Default: false
    */
   get encrypt(): boolean {
-    return this.configService.get<string>('PGP_ENCRYPT', 'false') === 'true';
+    return this.configService.get('PGP_ENCRYPT', 'false') === 'true';
   }
 
   /**
    * The private key used for PGP encryption or decryption.
    */
   get privateKey(): string {
-    return this.configService.getOrThrow<string>('PGP_PRIVATE_KEY');
+    return this.configService.getOrThrow('PGP_PRIVATE_KEY');
   }
 
   /**
    * The passphrase associated with the PGP private key.
    */
   get passphrase(): string {
-    return this.configService.getOrThrow<string>('PGP_PASSPHRASE');
+    return this.configService.getOrThrow('PGP_PASSPHRASE');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/reputation-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/reputation-config.service.ts
@@ -11,7 +11,7 @@ export class ReputationConfigService {
    * Default: 300
    */
   get lowLevel(): number {
-    return +this.configService.get<number>('REPUTATION_LEVEL_LOW', 300);
+    return Number(this.configService.get('REPUTATION_LEVEL_LOW')) || 300;
   }
 
   /**
@@ -20,6 +20,6 @@ export class ReputationConfigService {
    * Default: 700
    */
   get highLevel(): number {
-    return +this.configService.get<number>('REPUTATION_LEVEL_HIGH', 700);
+    return Number(this.configService.get('REPUTATION_LEVEL_HIGH')) || 700;
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/s3-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/s3-config.service.ts
@@ -10,7 +10,7 @@ export class S3ConfigService {
    * Default: '127.0.0.1'
    */
   get endpoint(): string {
-    return this.configService.get<string>('S3_ENDPOINT', '127.0.0.1');
+    return this.configService.get('S3_ENDPOINT', '127.0.0.1');
   }
 
   /**
@@ -18,7 +18,7 @@ export class S3ConfigService {
    * Default: 9000
    */
   get port(): number {
-    return +this.configService.get<number>('S3_PORT', 9000);
+    return Number(this.configService.get('S3_PORT')) || 9000;
   }
 
   /**
@@ -26,7 +26,7 @@ export class S3ConfigService {
    * Required
    */
   get accessKey(): string {
-    return this.configService.getOrThrow<string>('S3_ACCESS_KEY');
+    return this.configService.getOrThrow('S3_ACCESS_KEY');
   }
 
   /**
@@ -34,7 +34,7 @@ export class S3ConfigService {
    * Required
    */
   get secretKey(): string {
-    return this.configService.getOrThrow<string>('S3_SECRET_KEY');
+    return this.configService.getOrThrow('S3_SECRET_KEY');
   }
 
   /**
@@ -42,7 +42,7 @@ export class S3ConfigService {
    * Default: 'reputation'
    */
   get bucket(): string {
-    return this.configService.get<string>('S3_BUCKET', 'reputation');
+    return this.configService.get('S3_BUCKET', 'reputation');
   }
 
   /**
@@ -50,6 +50,6 @@ export class S3ConfigService {
    * Default: false
    */
   get useSSL(): boolean {
-    return this.configService.get<string>('S3_USE_SSL', 'false') === 'true';
+    return this.configService.get('S3_USE_SSL', 'false') === 'true';
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/server-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/server-config.service.ts
@@ -6,7 +6,7 @@ export class ServerConfigService {
   constructor(private configService: ConfigService) {}
 
   get gitHash(): string {
-    return this.configService.get<string>('GIT_HASH', '');
+    return this.configService.get('GIT_HASH', '');
   }
 
   /**
@@ -14,7 +14,7 @@ export class ServerConfigService {
    * Default: 'localhost'
    */
   get host(): string {
-    return this.configService.get<string>('HOST', 'localhost');
+    return this.configService.get('HOST', 'localhost');
   }
 
   /**
@@ -22,7 +22,7 @@ export class ServerConfigService {
    * Default: 5003
    */
   get port(): number {
-    return +this.configService.get<number>('PORT', 5003);
+    return Number(this.configService.get('PORT')) || 5003;
   }
 
   /**
@@ -30,7 +30,7 @@ export class ServerConfigService {
    * Default: 'http://localhost:3001'
    */
   get feURL(): string {
-    return this.configService.get<string>('FE_URL', 'http://localhost:3001');
+    return this.configService.get('FE_URL', 'http://localhost:3001');
   }
 
   /**
@@ -38,7 +38,7 @@ export class ServerConfigService {
    * Default: 'session_key'
    */
   get sessionSecret(): string {
-    return this.configService.get<string>('SESSION_SECRET', 'session_key');
+    return this.configService.get('SESSION_SECRET', 'session_key');
   }
 
   /**
@@ -46,7 +46,7 @@ export class ServerConfigService {
    * Default: 5
    */
   get maxRetryCount(): number {
-    return +this.configService.get<number>('MAX_RETRY_COUNT', 5);
+    return Number(this.configService.get('MAX_RETRY_COUNT')) || 5;
   }
 
   /**
@@ -54,12 +54,9 @@ export class ServerConfigService {
    * Default: 1 day (24 * 60 * 60 * 1000 ms)
    */
   get qualificationMinValidity(): number {
-    return (
-      +this.configService.get('QUALIFICATION_MIN_VALIDITY', 1) *
-      24 *
-      60 *
-      60 *
-      1000
-    );
+    const configValueDays =
+      Number(this.configService.get('QUALIFICATION_MIN_VALIDITY')) || 1;
+
+    return configValueDays * 24 * 60 * 60 * 1000;
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/slack-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/slack-config.service.ts
@@ -5,12 +5,12 @@ import { ConfigService } from '@nestjs/config';
 export class SlackConfigService {
   constructor(private configService: ConfigService) {}
   get abuseWebhookUrl(): string {
-    return this.configService.getOrThrow<string>('ABUSE_SLACK_WEBHOOK_URL');
+    return this.configService.getOrThrow('ABUSE_SLACK_WEBHOOK_URL');
   }
   get abuseOauthToken(): string {
-    return this.configService.getOrThrow<string>('ABUSE_SLACK_OAUTH_TOKEN');
+    return this.configService.getOrThrow('ABUSE_SLACK_OAUTH_TOKEN');
   }
   get abuseSigningSecret(): string {
-    return this.configService.getOrThrow<string>('ABUSE_SLACK_SIGNING_SECRET');
+    return this.configService.getOrThrow('ABUSE_SLACK_SIGNING_SECRET');
   }
 }

--- a/packages/apps/reputation-oracle/server/src/config/web3-config.service.ts
+++ b/packages/apps/reputation-oracle/server/src/config/web3-config.service.ts
@@ -23,7 +23,7 @@ export class Web3ConfigService {
    * Default: 'testnet'
    */
   get network(): Web3Network {
-    return this.configService.get<Web3Network>('WEB3_ENV', Web3Network.TESTNET);
+    return this.configService.get('WEB3_ENV', Web3Network.TESTNET);
   }
 
   /**
@@ -31,7 +31,7 @@ export class Web3ConfigService {
    * Required
    */
   get privateKey(): string {
-    return this.configService.getOrThrow<string>('WEB3_PRIVATE_KEY');
+    return this.configService.getOrThrow('WEB3_PRIVATE_KEY');
   }
 
   /**
@@ -53,23 +53,17 @@ export class Web3ConfigService {
    * Default: 1
    */
   get gasPriceMultiplier(): number {
-    return +this.configService.get<number>('GAS_PRICE_MULTIPLIER', 1);
+    return Number(this.configService.get('GAS_PRICE_MULTIPLIER')) || 1;
   }
 
   getRpcUrlByChainId(chainId: number): string | undefined {
     const rpcUrlsByChainId: Record<string, string | undefined> = {
-      [ChainId.POLYGON]: this.configService.get<string>('RPC_URL_POLYGON'),
-      [ChainId.POLYGON_AMOY]: this.configService.get<string>(
-        'RPC_URL_POLYGON_AMOY',
-      ),
-      [ChainId.BSC_MAINNET]: this.configService.get<string>(
-        'RPC_URL_BSC_MAINNET',
-      ),
-      [ChainId.BSC_TESTNET]: this.configService.get<string>(
-        'RPC_URL_BSC_TESTNET',
-      ),
-      [ChainId.SEPOLIA]: this.configService.get<string>('RPC_URL_SEPOLIA'),
-      [ChainId.LOCALHOST]: this.configService.get<string>('RPC_URL_LOCALHOST'),
+      [ChainId.POLYGON]: this.configService.get('RPC_URL_POLYGON'),
+      [ChainId.POLYGON_AMOY]: this.configService.get('RPC_URL_POLYGON_AMOY'),
+      [ChainId.BSC_MAINNET]: this.configService.get('RPC_URL_BSC_MAINNET'),
+      [ChainId.BSC_TESTNET]: this.configService.get('RPC_URL_BSC_TESTNET'),
+      [ChainId.SEPOLIA]: this.configService.get('RPC_URL_SEPOLIA'),
+      [ChainId.LOCALHOST]: this.configService.get('RPC_URL_LOCALHOST'),
     };
 
     return rpcUrlsByChainId[chainId];

--- a/packages/apps/reputation-oracle/server/src/modules/abuse/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/abuse/fixtures/index.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { generateTestnetChainId } from '../web3/fixtures';
-import { AbuseStatus } from './constants';
-import { generateWorkerUser } from '../user/fixtures';
-import { AbuseEntity } from './abuse.entity';
+import { generateTestnetChainId } from '../../web3/fixtures';
+import { AbuseStatus } from '../constants';
+import { generateWorkerUser } from '../../user/fixtures';
+import { AbuseEntity } from '../abuse.entity';
 
 export function generateAbuseEntity(
   overrides?: Partial<AbuseEntity>,

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -1007,7 +1007,7 @@ describe('AuthService', () => {
   });
 
   describe('emailVerification', () => {
-    it('should verify an email', async () => {
+    it('should verify an email and remove token', async () => {
       const mockToken = {
         userId: faker.number.int(),
         uuid: faker.string.uuid(),
@@ -1028,6 +1028,8 @@ describe('AuthService', () => {
           status: UserStatus.ACTIVE,
         },
       );
+      expect(mockTokenRepository.deleteOne).toHaveBeenCalledTimes(1);
+      expect(mockTokenRepository.deleteOne).toHaveBeenCalledWith(mockToken);
     });
 
     it('should throw AuthError(AuthErrorMessage.INVALID_EMAIL_TOKEN) if token not found', async () => {
@@ -1042,20 +1044,22 @@ describe('AuthService', () => {
       );
     });
 
-    it('should throw AuthError(AuthErrorMessage.EMAIL_TOKEN_EXPIRED)', async () => {
+    it('should throw AuthError(AuthErrorMessage.EMAIL_TOKEN_EXPIRED) and remove token', async () => {
       const uuid = faker.string.uuid();
-
-      mockTokenRepository.findOneByUuidAndType.mockResolvedValueOnce({
+      const mockToken = {
         uuid,
         expiresAt: faker.date.past(),
-      } as TokenEntity);
-      mockTokenRepository.findOneByUuidAndType.mockResolvedValueOnce(null);
+      } as TokenEntity;
+
+      mockTokenRepository.findOneByUuidAndType.mockResolvedValueOnce(mockToken);
 
       await expect(service.emailVerification(uuid)).rejects.toThrow(
         new AuthErrors.AuthError(
           AuthErrors.AuthErrorMessage.EMAIL_TOKEN_EXPIRED,
         ),
       );
+      expect(mockTokenRepository.deleteOne).toHaveBeenCalledTimes(1);
+      expect(mockTokenRepository.deleteOne).toHaveBeenCalledWith(mockToken);
     });
   });
 

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -414,12 +414,14 @@ export class AuthService {
     }
 
     if (new Date() > tokenEntity.expiresAt) {
+      await this.tokenRepository.deleteOne(tokenEntity);
       throw new AuthError(AuthErrorMessage.EMAIL_TOKEN_EXPIRED);
     }
 
     await this.userRepository.updateOneById(tokenEntity.userId, {
       status: UserStatus.ACTIVE,
     });
+    await this.tokenRepository.deleteOne(tokenEntity);
   }
 
   async resendEmailVerification(user: Web2UserEntity): Promise<void> {

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/fixtures/index.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
-import { CronJobEntity } from './cron-job.entity';
-import { CronJobType } from './constants';
+
+import { CronJobEntity } from '../cron-job.entity';
+import { CronJobType } from '../constants';
 
 const cronJobTypes = Object.values(CronJobType);
 

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/fixtures/index.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
 
-import { KycConfigService } from '../../config/kyc-config.service';
-import { KycEntity } from './kyc.entity';
-import { KycStatus } from './constants';
+import { KycConfigService } from '../../../config/kyc-config.service';
+import { KycEntity } from '../kyc.entity';
+import { KycStatus } from '../constants';
 
 export const mockKycConfigService: Omit<KycConfigService, 'configService'> = {
   apiPrivateKey: faker.string.alphanumeric(),

--- a/packages/apps/reputation-oracle/server/src/modules/nda/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/fixtures/index.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 
-import { NDAConfigService } from '../../config/nda-config.service';
+import { NDAConfigService } from '../../../config/nda-config.service';
 
 export const mockNdaConfigService: Omit<NDAConfigService, 'configService'> = {
   latestNdaUrl: faker.internet.url(),

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/fixtures/index.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker';
 
-import { generateTestnetChainId } from '../web3/fixtures';
+import { generateTestnetChainId } from '../../web3/fixtures';
 
-import { ReputationEntityType } from './constants';
-import { ReputationEntity } from './reputation.entity';
+import { ReputationEntityType } from '../constants';
+import { ReputationEntity } from '../reputation.entity';
 
 const REPUTATION_ENTITY_TYPES = Object.values(ReputationEntityType);
 export function generateReputationEntityType(): ReputationEntityType {

--- a/packages/apps/reputation-oracle/server/src/modules/web3/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/web3/fixtures/index.ts
@@ -2,9 +2,10 @@ import { faker } from '@faker-js/faker';
 import {
   Web3ConfigService,
   Web3Network,
-} from '../../config/web3-config.service';
-import { generateEthWallet } from '../../../test/fixtures/web3';
-import { supportedChainIdsByNetwork } from './web3.service';
+} from '../../../config/web3-config.service';
+import { generateEthWallet } from '../../../../test/fixtures/web3';
+
+import { supportedChainIdsByNetwork } from '../web3.service';
 
 const testWallet = generateEthWallet();
 

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/fixtures/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/fixtures/index.ts
@@ -2,14 +2,14 @@ import { faker } from '@faker-js/faker';
 import * as crypto from 'crypto';
 import stringify from 'json-stable-stringify';
 
-import { generateTestnetChainId } from '../web3/fixtures';
+import { generateTestnetChainId } from '../../web3/fixtures';
 import {
   IncomingWebhookStatus,
   OutgoingWebhookEventType,
   OutgoingWebhookStatus,
-} from './types';
-import { IncomingWebhookEntity } from './webhook-incoming.entity';
-import { OutgoingWebhookEntity } from './webhook-outgoing.entity';
+} from '../types';
+import { IncomingWebhookEntity } from '../webhook-incoming.entity';
+import { OutgoingWebhookEntity } from '../webhook-outgoing.entity';
 
 type GenerateIncomingWebhookOptions = {
   retriesCount?: number;


### PR DESCRIPTION
## Issue tracking
Part of #3084

## Context behind the change
1) `configService` always returns either `string` or `undefined` in our setup, so in order to avoid confusion - remove usage of specific types where not applicable. Also use `Number` instead of `+` conversion to increase readability and provide a default as `||` condition instead of config default, so even if value from config is not valid by some reason (in spite of validation schema) - we can rely on default
2) Moved `fixtures` to separate folder for cleaner folder structure view
3) Remove email verification token if we are able to identify it's expired and also after successful verification: there is no need to store them in DB. We could use some kind of `pg_cron` extension, but probably no need this atm. 

## How has this been tested?
- [x] unit tests
- [x] app builds and runs

## Release plan
Simply merge

## Potential risks; What to monitor; Rollback plan
No