### PR TITLE
[Reputation Oracle] refactor: move some types to separate files

### DIFF
--- a/.github/workflows/ci-dependency-review.yaml
+++ b/.github/workflows/ci-dependency-review.yaml
@@ -1,9 +1,5 @@
 name: Dependency Review
 on:
-  push:
-    branches:
-      - develop
-      - main
   pull_request:
     branches:
       - develop

--- a/packages/apps/reputation-oracle/server/src/common/errors/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/common/errors/manifest.ts
@@ -1,9 +1,0 @@
-import { BaseError } from './base';
-
-class ManifestError extends BaseError {}
-
-export class MissingManifestUrlError extends ManifestError {
-  constructor(readonly escrowAddress: string) {
-    super('Manifest url is missing for escrow');
-  }
-}

--- a/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
@@ -6,7 +6,7 @@ import {
   HttpException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import { DatabaseError, isDuplicatedError } from '../errors/database';
+import { DatabaseError, isDuplicatedError } from '../../database';
 import logger from '../../logger';
 import { transformKeysFromCamelToSnake } from '../../utils/case-converters';
 

--- a/packages/apps/reputation-oracle/server/src/database/base.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/database/base.repository.ts
@@ -1,5 +1,5 @@
 import { DataSource, EntityTarget, ObjectLiteral, Repository } from 'typeorm';
-import { DatabaseError, handleDbError } from '../common/errors/database';
+import { DatabaseError, handleDbError } from './errors';
 import { BaseEntity } from './base.entity';
 
 export class BaseRepository<

--- a/packages/apps/reputation-oracle/server/src/database/errors.ts
+++ b/packages/apps/reputation-oracle/server/src/database/errors.ts
@@ -1,6 +1,6 @@
-import { BaseError } from './base';
+import { BaseError } from '../common/errors/base';
 
-export enum PostgresErrorCodes {
+enum PostgresErrorCodes {
   Duplicated = '23505',
 }
 

--- a/packages/apps/reputation-oracle/server/src/database/index.ts
+++ b/packages/apps/reputation-oracle/server/src/database/index.ts
@@ -1,3 +1,8 @@
 export { BaseEntity } from './base.entity';
 export { BaseRepository } from './base.repository';
 export { DatabaseModule } from './database.module';
+export {
+  DatabaseErrorMessages,
+  DatabaseError,
+  isDuplicatedError,
+} from './errors';

--- a/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.service.spec.ts
@@ -10,10 +10,7 @@ import {
 } from '@human-protocol/sdk';
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
-import {
-  DatabaseError,
-  DatabaseErrorMessages,
-} from '../../common/errors/database';
+import { DatabaseError, DatabaseErrorMessages } from '../../database';
 import { ServerConfigService } from '../../config';
 import { generateTestnetChainId } from '../web3/fixtures';
 import { Web3Service } from '../web3';

--- a/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@human-protocol/sdk';
 import { Injectable } from '@nestjs/common';
 import { ethers } from 'ethers';
-import { isDuplicatedError } from '../../common/errors/database';
+import { isDuplicatedError } from '../../database';
 import { ServerConfigService } from '../../config';
 import logger from '../../logger';
 import { Web3Service } from '../web3';

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -40,11 +40,7 @@ import {
 } from './auth.error';
 import { TokenEntity, TokenType } from './token.entity';
 import { TokenRepository } from './token.repository';
-
-type AuthTokens = {
-  accessToken: string;
-  refreshToken: string;
-};
+import type { AuthTokens } from './types';
 
 @Injectable()
 export class AuthService {

--- a/packages/apps/reputation-oracle/server/src/modules/auth/types.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/types.ts
@@ -1,0 +1,4 @@
+export type AuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -14,7 +14,7 @@ import stringify from 'json-stable-stringify';
 import _ from 'lodash';
 
 import { BACKOFF_INTERVAL_SECONDS } from '../../common/constants';
-import { isDuplicatedError } from '../../common/errors/database';
+import { isDuplicatedError } from '../../database';
 import { JobManifest, JobRequestType } from '../../common/types';
 import { ServerConfigService } from '../../config';
 import logger from '../../logger';

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.service.ts
@@ -14,14 +14,7 @@ import { KycSignedAddressDto, UpdateKycStatusDto } from './kyc.dto';
 import { KycEntity } from './kyc.entity';
 import { KycErrorMessage, KycError } from './kyc.error';
 import { KycRepository } from './kyc.repository';
-
-type VeriffCreateSessionResponse = {
-  status: string;
-  verification: {
-    id: string;
-    url: string;
-  };
-};
+import type { VeriffCreateSessionResponse } from './types';
 
 @Injectable()
 export class KycService {

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/types.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/types.ts
@@ -1,0 +1,7 @@
+export type VeriffCreateSessionResponse = {
+  status: string;
+  verification: {
+    id: string;
+    url: string;
+  };
+};

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.ts
@@ -11,15 +11,9 @@ import {
   QualificationErrorMessage,
 } from './qualification.error';
 import { QualificationRepository } from './qualification.repository';
+import type { Qualification } from './types';
 import { UserQualificationEntity } from './user-qualification.entity';
 import { UserQualificationRepository } from './user-qualification.repository';
-
-type Qualification = {
-  reference: string;
-  title: string;
-  description: string;
-  expiresAt?: string;
-};
 
 @Injectable()
 export class QualificationService {

--- a/packages/apps/reputation-oracle/server/src/modules/qualification/types.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/types.ts
@@ -1,0 +1,6 @@
+export type Qualification = {
+  reference: string;
+  title: string;
+  description: string;
+  expiresAt?: string;
+};

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.repository.ts
@@ -7,12 +7,7 @@ import { BaseRepository } from '../../database';
 
 import { ReputationEntityType, ReputationOrderBy } from './constants';
 import { ReputationEntity } from './reputation.entity';
-
-export type ExclusiveReputationCriteria = {
-  chainId: number;
-  address: string;
-  type: ReputationEntityType;
-};
+import type { ExclusiveReputationCriteria } from './types';
 
 @Injectable()
 export class ReputationRepository extends BaseRepository<ReputationEntity> {

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ChainId, EscrowClient } from '@human-protocol/sdk';
 
 import { SortDirection } from '../../common/enums';
-import { isDuplicatedError } from '../../common/errors/database';
+import { isDuplicatedError } from '../../database';
 import { ReputationConfigService, Web3ConfigService } from '../../config';
 
 import { Web3Service } from '../web3';

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/reputation.service.ts
@@ -14,17 +14,8 @@ import {
   ReputationOrderBy,
 } from './constants';
 import { ReputationEntity } from './reputation.entity';
-import {
-  ReputationRepository,
-  type ExclusiveReputationCriteria,
-} from './reputation.repository';
-
-type ReputationData = {
-  chainId: ChainId;
-  address: string;
-  level: ReputationLevel;
-  role: ReputationEntityType;
-};
+import { ReputationRepository } from './reputation.repository';
+import type { ExclusiveReputationCriteria, ReputationData } from './types';
 
 function assertAdjustableReputationPoints(points: number) {
   if (points > 0 && Number.isInteger(points)) {

--- a/packages/apps/reputation-oracle/server/src/modules/reputation/types.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/reputation/types.ts
@@ -1,0 +1,16 @@
+import { ChainId } from '@human-protocol/sdk';
+
+import { ReputationEntityType, ReputationLevel } from './constants';
+
+export type ReputationData = {
+  chainId: ChainId;
+  address: string;
+  level: ReputationLevel;
+  role: ReputationEntityType;
+};
+
+export type ExclusiveReputationCriteria = {
+  chainId: number;
+  address: string;
+  type: ReputationEntityType;
+};

--- a/packages/apps/reputation-oracle/server/src/modules/web3/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/web3/index.ts
@@ -1,2 +1,3 @@
 export { Web3Module } from './web3.module';
-export { WalletWithProvider, Web3Service } from './web3.service';
+export { Web3Service } from './web3.service';
+export type { WalletWithProvider } from './types';

--- a/packages/apps/reputation-oracle/server/src/modules/web3/types.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/web3/types.ts
@@ -1,0 +1,10 @@
+import { ChainId } from '@human-protocol/sdk';
+
+import type { Provider, Wallet } from 'ethers';
+
+export type Chain = {
+  id: ChainId;
+  rpcUrl: string;
+};
+
+export type WalletWithProvider = Wallet & { provider: Provider };

--- a/packages/apps/reputation-oracle/server/src/modules/web3/web3.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/web3/web3.service.spec.ts
@@ -1,9 +1,12 @@
 import { createMock } from '@golevelup/ts-jest';
+import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
 import { FeeData, JsonRpcProvider, Provider } from 'ethers';
-import { faker } from '@faker-js/faker';
-import { WalletWithProvider, Web3Service } from './web3.service';
+
 import { Web3ConfigService } from '../../config';
+
+import { Web3Service } from './web3.service';
+import type { WalletWithProvider } from './types';
 
 import { generateTestnetChainId, mockWeb3ConfigService } from './fixtures';
 

--- a/packages/apps/reputation-oracle/server/src/modules/web3/web3.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/web3/web3.service.ts
@@ -1,7 +1,8 @@
 import { ChainId } from '@human-protocol/sdk';
 import { Injectable } from '@nestjs/common';
-import { Provider, Wallet, ethers } from 'ethers';
+import { Wallet, ethers } from 'ethers';
 import { Web3ConfigService, Web3Network } from '../../config';
+import type { Chain, WalletWithProvider } from './types';
 
 export const supportedChainIdsByNetwork = {
   [Web3Network.MAINNET]: [ChainId.POLYGON, ChainId.BSC_MAINNET],
@@ -12,13 +13,6 @@ export const supportedChainIdsByNetwork = {
   ],
   [Web3Network.LOCAL]: [ChainId.LOCALHOST],
 } as const;
-
-type Chain = {
-  id: ChainId;
-  rpcUrl: string;
-};
-
-export type WalletWithProvider = Wallet & { provider: Provider };
 
 @Injectable()
 export class Web3Service {

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.spec.ts
@@ -2,10 +2,7 @@ import { faker } from '@faker-js/faker';
 import { createMock } from '@golevelup/ts-jest';
 import { Test } from '@nestjs/testing';
 
-import {
-  DatabaseError,
-  DatabaseErrorMessages,
-} from '../../common/errors/database';
+import { DatabaseError, DatabaseErrorMessages } from '../../database';
 import { ServerConfigService } from '../../config';
 import { EscrowCompletionService } from '../escrow-completion';
 import { generateTestnetChainId } from '../web3/fixtures';

--- a/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/webhook/webhook-incoming.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { BACKOFF_INTERVAL_SECONDS } from '../../common/constants';
-import { isDuplicatedError } from '../../common/errors/database';
+import { isDuplicatedError } from '../../database';
 import { ServerConfigService } from '../../config';
 import { EscrowCompletionService } from '../escrow-completion';
 import { calculateExponentialBackoffMs } from '../../utils/backoff';


### PR DESCRIPTION
## Issue tracking
Part of #3084

## Context behind the change
Moving some types to separate `types.ts` in order to have smaller `service` (and similar) files and improve their readability. This should be general approach for `service` file and types that are shared within or outside the module. However, if it's a type that declared just to improve readability but can be inline (e.g. `EscrowFinalResultsDetails`), no need to move it.

## How has this been tested?
- [x] unit tests & lint
- [x] run app

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No