### PR TITLE
refactor: change ci actions to run on push

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -2,15 +2,6 @@ name: Lint check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-    paths-ignore:
-      - 'packages/examples/cvat/**'
-  pull_request:
-    branches:
-      - develop
-      - main
     paths-ignore:
       - 'packages/examples/cvat/**'
 

--- a/.github/workflows/ci-test-core.yaml
+++ b/.github/workflows/ci-test-core.yaml
@@ -2,13 +2,6 @@ name: Protocol check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
 

--- a/.github/workflows/ci-test-dashboard.yaml
+++ b/.github/workflows/ci-test-dashboard.yaml
@@ -2,13 +2,6 @@ name: Dashboard Check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-faucet-server.yaml
+++ b/.github/workflows/ci-test-faucet-server.yaml
@@ -2,13 +2,6 @@ name: Faucet server check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-fortune.yaml
+++ b/.github/workflows/ci-test-fortune.yaml
@@ -2,11 +2,6 @@ name: Fortune check
 
 on:
   push:
-    branches:
-      - develop
-  pull_request:
-    branches:
-      - develop
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-human-app.yaml
+++ b/.github/workflows/ci-test-human-app.yaml
@@ -2,13 +2,6 @@ name: Human App Check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-job-launcher.yaml
+++ b/.github/workflows/ci-test-job-launcher.yaml
@@ -2,13 +2,6 @@ name: Job Launcher Check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-node-sdk.yaml
+++ b/.github/workflows/ci-test-node-sdk.yaml
@@ -2,17 +2,9 @@ name: Node.js SDK check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'
-  workflow_dispatch:
 
 jobs:
   node-sdk-test:

--- a/.github/workflows/ci-test-python-sdk.yaml
+++ b/.github/workflows/ci-test-python-sdk.yaml
@@ -2,13 +2,6 @@ name: Python SDK check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/python/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-reputation-oracle.yaml
+++ b/.github/workflows/ci-test-reputation-oracle.yaml
@@ -2,13 +2,6 @@ name: Reputation Oracle Check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-subgraph.yaml
+++ b/.github/workflows/ci-test-subgraph.yaml
@@ -2,13 +2,6 @@ name: Subgraph check
 
 on:
   push:
-    branches:
-      - develop
-      - main
-  pull_request:
-    branches:
-      - develop
-      - main
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/subgraph/**'


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
[Recently changed triggers for actions](https://github.com/humanprotocol/human-protocol/pull/3316), it led to actions run twice when there is a PR opened to `main` branch and you merge a PR to `develop`.

The main difference between `pull_request` and `push` triggers is that `push` runs on the actual commits history from branch/ref, but `pull_request` runs on "merge commit". In case we change it to always be `push` - in PRs it will run on exact commit history only, removing duplicates. It should be fine because after we do actual merge we will run on `develop`/`main` as on `push` trigger to see if it's all good.

## How has this been tested?
- [x] PR checks

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No