### PR TITLE
[Reputation Oracle] Remove fetching user from a db in a guard

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/enums/hcaptcha.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/hcaptcha.ts
@@ -1,4 +1,0 @@
-export enum TokenType {
-  AUTH = 'auth',
-  EXCHANGE = 'exchange',
-}

--- a/packages/apps/reputation-oracle/server/src/common/enums/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/index.ts
@@ -1,5 +1,4 @@
 export * from './collection';
-export * from './hcaptcha';
 export * from './http';
 export * from './manifest';
 export * from './web3';

--- a/packages/apps/reputation-oracle/server/src/common/types/request.ts
+++ b/packages/apps/reputation-oracle/server/src/common/types/request.ts
@@ -1,3 +1,3 @@
 export interface RequestWithUser extends Request {
-  user: any;
+  user: number;
 }

--- a/packages/apps/reputation-oracle/server/src/common/types/request.ts
+++ b/packages/apps/reputation-oracle/server/src/common/types/request.ts
@@ -1,3 +1,3 @@
 export interface RequestWithUser extends Request {
-  user: number;
+  user: { id: number };
 }

--- a/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.controller.ts
@@ -54,7 +54,7 @@ export class AbuseController {
     await this.abuseService.reportAbuse({
       escrowAddress: data.escrowAddress,
       chainId: data.chainId,
-      userId: request.user,
+      userId: request.user.id,
     });
   }
 
@@ -73,7 +73,9 @@ export class AbuseController {
   async getUserAbuseReports(
     @Req() request: RequestWithUser,
   ): Promise<AbuseResponseDto[]> {
-    const abuseEntities = await this.abuseRepository.findByUserId(request.user);
+    const abuseEntities = await this.abuseRepository.findByUserId(
+      request.user.id,
+    );
     return abuseEntities.map((abuseEntity) => {
       return {
         id: abuseEntity.id,

--- a/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/abuse/abuse.controller.ts
@@ -54,7 +54,7 @@ export class AbuseController {
     await this.abuseService.reportAbuse({
       escrowAddress: data.escrowAddress,
       chainId: data.chainId,
-      userId: request.user.id,
+      userId: request.user,
     });
   }
 
@@ -73,9 +73,7 @@ export class AbuseController {
   async getUserAbuseReports(
     @Req() request: RequestWithUser,
   ): Promise<AbuseResponseDto[]> {
-    const abuseEntities = await this.abuseRepository.findByUserId(
-      request.user.id,
-    );
+    const abuseEntities = await this.abuseRepository.findByUserId(request.user);
     return abuseEntities.map((abuseEntity) => {
       return {
         id: abuseEntity.id,

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -218,7 +218,7 @@ export class AuthController {
   async resendEmailVerification(
     @Req() request: RequestWithUser,
   ): Promise<void> {
-    await this.authService.resendEmailVerification(request.user);
+    await this.authService.resendEmailVerification(request.user.id);
   }
 
   @ApiOperation({
@@ -235,7 +235,7 @@ export class AuthController {
   async logout(@Req() request: RequestWithUser): Promise<void> {
     await this.tokenRepository.deleteOneByTypeAndUserId(
       TokenType.REFRESH,
-      request.user,
+      request.user.id,
     );
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.controller.ts
@@ -235,7 +235,7 @@ export class AuthController {
   async logout(@Req() request: RequestWithUser): Promise<void> {
     await this.tokenRepository.deleteOneByTypeAndUserId(
       TokenType.REFRESH,
-      request.user.id,
+      request.user,
     );
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.spec.ts
@@ -1071,7 +1071,7 @@ describe('AuthService', () => {
         const user = generateWorkerUser({ status: UserStatus.PENDING });
         const tokenUuid = faker.string.uuid();
 
-        mockUserRepository.findOneByEmail.mockResolvedValueOnce(user);
+        mockUserRepository.findOneById.mockResolvedValueOnce(user);
         mockTokenRepository.findOneByUserIdAndType.mockResolvedValueOnce(
           existingEmailToken as TokenEntity,
         );
@@ -1079,7 +1079,7 @@ describe('AuthService', () => {
           uuid: tokenUuid,
         } as TokenEntity);
 
-        await service.resendEmailVerification(user);
+        await service.resendEmailVerification(user.id);
 
         if (existingEmailToken) {
           expect(mockTokenRepository.deleteOne).toHaveBeenCalledTimes(1);
@@ -1110,9 +1110,9 @@ describe('AuthService', () => {
       async (userStatus) => {
         const user = generateWorkerUser({ status: userStatus });
 
-        mockUserRepository.findOneByEmail.mockResolvedValueOnce(null);
+        mockUserRepository.findOneById.mockResolvedValueOnce(null);
 
-        await service.resendEmailVerification(user);
+        await service.resendEmailVerification(user.id);
 
         expect(
           mockTokenRepository.findOneByUserIdAndType,

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -422,7 +422,9 @@ export class AuthService {
   }
 
   async resendEmailVerification(userId: number): Promise<void> {
-    const user = await this.userRepository.findOneById(userId);
+    const user = (await this.userRepository.findOneById(
+      userId,
+    )) as Web2UserEntity;
 
     if (!user || user.status !== UserStatus.PENDING) {
       return;
@@ -446,12 +448,8 @@ export class AuthService {
     );
 
     const token = await this.tokenRepository.createUnique(tokenEntity);
-    await this.emailService.sendEmail(
-      user.email as string,
-      EmailAction.SIGNUP,
-      {
-        url: `${this.serverConfigService.feURL}/verify?token=${token.uuid}`,
-      },
-    );
+    await this.emailService.sendEmail(user.email, EmailAction.SIGNUP, {
+      url: `${this.serverConfigService.feURL}/verify?token=${token.uuid}`,
+    });
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.service.ts
@@ -421,8 +421,10 @@ export class AuthService {
     await this.tokenRepository.deleteOne(tokenEntity);
   }
 
-  async resendEmailVerification(user: Web2UserEntity): Promise<void> {
-    if (user.status !== UserStatus.PENDING) {
+  async resendEmailVerification(userId: number): Promise<void> {
+    const user = await this.userRepository.findOneById(userId);
+
+    if (!user || user.status !== UserStatus.PENDING) {
       return;
     }
 
@@ -444,8 +446,12 @@ export class AuthService {
     );
 
     const token = await this.tokenRepository.createUnique(tokenEntity);
-    await this.emailService.sendEmail(user.email, EmailAction.SIGNUP, {
-      url: `${this.serverConfigService.feURL}/verify?token=${token.uuid}`,
-    });
+    await this.emailService.sendEmail(
+      user.email as string,
+      EmailAction.SIGNUP,
+      {
+        url: `${this.serverConfigService.feURL}/verify?token=${token.uuid}`,
+      },
+    );
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/jwt-http-strategy.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/jwt-http-strategy.ts
@@ -27,7 +27,7 @@ export class JwtHttpStrategy extends PassportStrategy(
   async validate(
     @Req() request: any,
     payload: { user_id: number; status: UserStatus },
-  ): Promise<number> {
+  ): Promise<{ id: number }> {
     if (
       payload.status !== UserStatus.ACTIVE &&
       request.url !== RESEND_EMAIL_VERIFICATION_PATH &&
@@ -36,6 +36,6 @@ export class JwtHttpStrategy extends PassportStrategy(
       throw new UnauthorizedException('User not active');
     }
 
-    return payload.user_id;
+    return { id: payload.user_id };
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.controller.ts
@@ -49,7 +49,7 @@ export class KycController {
   async startKyc(
     @Req() request: RequestWithUser,
   ): Promise<StartSessionResponseDto> {
-    return await this.kycService.initSession(request.user);
+    return await this.kycService.initSession(request.user.id);
   }
 
   @ApiOperation({
@@ -101,7 +101,7 @@ export class KycController {
     @Req() request: RequestWithUser,
   ): Promise<KycSignedAddressDto> {
     const signedAddressData = await this.kycService.getSignedAddress(
-      request.user,
+      request.user.id,
     );
     return signedAddressData;
   }

--- a/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/kyc/kyc.repository.ts
@@ -10,10 +10,16 @@ export class KycRepository extends BaseRepository<KycEntity> {
     super(KycEntity, dataSource);
   }
 
+  async findOneByUserId(userId: number): Promise<KycEntity | null> {
+    const kycEntity = await this.findOne({ where: { userId } });
+
+    return kycEntity;
+  }
+
   async findOneBySessionId(sessionId: string): Promise<KycEntity | null> {
     const kycEntity = await this.findOne({
       where: {
-        sessionId: sessionId,
+        sessionId,
       },
     });
 

--- a/packages/apps/reputation-oracle/server/src/modules/nda/nda.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/nda.controller.ts
@@ -65,7 +65,7 @@ export class NDAController {
   })
   @Post('sign')
   async signNDA(@Req() request: RequestWithUser, @Body() nda: NDASignatureDto) {
-    await this.ndaService.signNDA(request.user, nda);
+    await this.ndaService.signNDA(request.user.id, nda);
     return { message: 'NDA signed successfully' };
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/nda/nda.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/nda.service.spec.ts
@@ -4,7 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { NDAConfigService } from '../../config';
 import { generateWorkerUser } from '../user/fixtures';
-import { UserEntity, UserRepository } from '../user';
+import { UserRepository } from '../user';
 
 import { NDASignatureDto } from './nda.dto';
 import { NDAError, NDAErrorMessage } from './nda.error';
@@ -39,8 +39,9 @@ describe('NDAService', () => {
       const nda: NDASignatureDto = {
         url: mockNdaConfigService.latestNdaUrl,
       };
+      mockUserRepository.findOneById.mockResolvedValue(user);
 
-      await service.signNDA(user, nda);
+      await service.signNDA(user.id, nda);
 
       expect(user.ndaSignedUrl).toBe(mockNdaConfigService.latestNdaUrl);
       expect(mockUserRepository.updateOne).toHaveBeenCalledWith(user);
@@ -52,10 +53,11 @@ describe('NDAService', () => {
       const invalidNda: NDASignatureDto = {
         url: faker.internet.url(),
       };
+      mockUserRepository.findOneById.mockResolvedValue(user);
 
-      await expect(
-        service.signNDA(user as UserEntity, invalidNda),
-      ).rejects.toThrow(new NDAError(NDAErrorMessage.INVALID_NDA, user.id));
+      await expect(service.signNDA(user.id, invalidNda)).rejects.toThrow(
+        new NDAError(NDAErrorMessage.INVALID_NDA, user.id),
+      );
     });
 
     it('should return ok if the user has already signed the NDA', async () => {
@@ -65,8 +67,9 @@ describe('NDAService', () => {
       const nda: NDASignatureDto = {
         url: mockNdaConfigService.latestNdaUrl,
       };
+      mockUserRepository.findOneById.mockResolvedValue(user);
 
-      await service.signNDA(user as UserEntity, nda);
+      await service.signNDA(user.id, nda);
 
       expect(mockUserRepository.updateOne).not.toHaveBeenCalled();
     });

--- a/packages/apps/reputation-oracle/server/src/modules/nda/nda.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/nda/nda.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { UserEntity, UserRepository } from '../user';
+import { UserNotFoundError, UserRepository } from '../user';
 import { NDAConfigService } from '../../config';
 import { NDASignatureDto } from './nda.dto';
 import { NDAError, NDAErrorMessage } from './nda.error';
@@ -12,10 +12,15 @@ export class NDAService {
     private readonly ndaConfigService: NDAConfigService,
   ) {}
 
-  async signNDA(user: UserEntity, nda: NDASignatureDto) {
+  async signNDA(userId: number, nda: NDASignatureDto) {
+    const user = await this.userRepository.findOneById(userId);
+    if (!user) {
+      throw new UserNotFoundError(userId);
+    }
+
     const latestNdaUrl = this.ndaConfigService.latestNdaUrl;
     if (nda.url !== latestNdaUrl) {
-      throw new NDAError(NDAErrorMessage.INVALID_NDA, user.id);
+      throw new NDAError(NDAErrorMessage.INVALID_NDA, userId);
     }
     if (user.ndaSignedUrl === latestNdaUrl) {
       return;

--- a/packages/apps/reputation-oracle/server/src/modules/user/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/index.ts
@@ -2,6 +2,7 @@ export { SiteKeyRepository } from './site-key.repository';
 export { SiteKeyType } from './site-key.entity';
 export type * from './types';
 export { UserEntity, UserStatus, Role as UserRole } from './user.entity';
+export { UserNotFoundError } from './user.error';
 export { UserModule } from './user.module';
 export { UserRepository } from './user.repository';
 export { UserService, OperatorStatus } from './user.service';

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -70,7 +70,7 @@ export class UserController {
   async registerLabeler(
     @Req() request: RequestWithUser,
   ): Promise<RegisterLabelerResponseDto> {
-    const siteKey = await this.userService.registerLabeler(request.user);
+    const siteKey = await this.userService.registerLabeler(request.user.id);
 
     return { siteKey };
   }
@@ -95,7 +95,7 @@ export class UserController {
     @Body() data: RegisterAddressRequestDto,
   ): Promise<void> {
     await this.userService.registerAddress(
-      request.user,
+      request.user.id,
       data.address,
       data.signature,
     );
@@ -114,9 +114,9 @@ export class UserController {
   @HttpCode(200)
   async enableOperator(
     @Body() data: EnableOperatorDto,
-    @Request() req: RequestWithUser,
+    @Request() request: RequestWithUser,
   ): Promise<void> {
-    await this.userService.enableOperator(req.user, data.signature);
+    await this.userService.enableOperator(request.user.id, data.signature);
   }
 
   @ApiOperation({
@@ -132,9 +132,9 @@ export class UserController {
   @HttpCode(200)
   async disableOperator(
     @Body() data: DisableOperatorDto,
-    @Request() req: RequestWithUser,
+    @Request() request: RequestWithUser,
   ): Promise<void> {
-    await this.userService.disableOperator(req.user, data.signature);
+    await this.userService.disableOperator(request.user.id, data.signature);
   }
 
   @ApiOperation({
@@ -189,7 +189,7 @@ export class UserController {
     @Body() data: RegistrationInExchangeOracleDto,
   ): Promise<RegistrationInExchangeOracleResponseDto> {
     await this.userService.registrationInExchangeOracle(
-      request.user,
+      request.user.id,
       data.oracleAddress,
     );
 
@@ -215,7 +215,7 @@ export class UserController {
     @Req() request: RequestWithUser,
   ): Promise<RegistrationInExchangeOraclesResponseDto> {
     const oracleAddresses =
-      await this.userService.getRegistrationInExchangeOracles(request.user);
+      await this.userService.getRegistrationInExchangeOracles(request.user.id);
 
     return { oracleAddresses };
   }

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.error.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.error.ts
@@ -33,3 +33,11 @@ export class InvalidWeb3SignatureError extends BaseError {
     this.userId = userId;
   }
 }
+
+export class UserNotFoundError extends BaseError {
+  userId: number;
+  constructor(userId: number) {
+    super(`User not found: ${userId}`);
+    this.userId = userId;
+  }
+}


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->
Part of #2803 
## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->
Removed user fetching from JwtHttpStrategy. `userId` is being passed instead and handled by services accordingly
## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

- [x] unit tests
- [x] deployed locally and tested affected endpoints

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->
N/A
## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->
Just in case, need to monitor affected endpoints