### PR TITLE
[Fortune] fix: missing dep for fortune

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/package.json
+++ b/packages/apps/fortune/exchange-oracle/server/package.json
@@ -33,6 +33,7 @@
     "@nestjs/axios": "^3.1.2",
     "@nestjs/common": "^10.2.7",
     "@nestjs/core": "^10.3.10",
+    "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^10.0.1",
     "axios": "^1.3.1",
     "class-transformer": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4013,6 +4013,7 @@ __metadata:
     "@nestjs/common": "npm:^10.2.7"
     "@nestjs/core": "npm:^10.3.10"
     "@nestjs/schematics": "npm:^11.0.2"
+    "@nestjs/terminus": "npm:^11.0.0"
     "@nestjs/testing": "npm:^10.4.6"
     "@nestjs/typeorm": "npm:^10.0.1"
     "@types/express": "npm:^4.17.13"


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/humanprotocol/human-protocol/pull/3324

## Context behind the change
Fortune ExcO fails to start (but builds 😬 ) due to missing dependency which is not linked by `yarn` and can't be loaded. Just installed same version as for other services.

## How has this been tested?
- [x] `yarn build` & `yarn start:prod` locally

## Release plan
Together with main PR

## Potential risks; What to monitor; Rollback plan
As in base PR