### PR TITLE
[Reputation Oracle] feat: add db ttl cron job

### DIFF
--- a/packages/apps/reputation-oracle/server/src/database/migrations/1747301407259-AddDbTtlCronJob.ts
+++ b/packages/apps/reputation-oracle/server/src/database/migrations/1747301407259-AddDbTtlCronJob.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDbTtlCronJob1747301407259 implements MigrationInterface {
+  name = 'AddDbTtlCronJob1747301407259';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "hmt"."cron-jobs_cron_job_type_enum" RENAME TO "cron-jobs_cron_job_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "hmt"."cron-jobs_cron_job_type_enum" AS ENUM('process-pending-incoming-webhook', 'process-pending-outgoing-webhook', 'process-pending-escrow-completion-tracking', 'process-paid-escrow-completion-tracking', 'process-awaiting-escrow-payouts', 'process-requested-abuse', 'process-classified-abuse', 'delete-expired-database-records')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."cron-jobs" ALTER COLUMN "cron_job_type" TYPE "hmt"."cron-jobs_cron_job_type_enum" USING "cron_job_type"::"text"::"hmt"."cron-jobs_cron_job_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "hmt"."cron-jobs_cron_job_type_enum_old"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "hmt"."cron-jobs_cron_job_type_enum_old" AS ENUM('process-pending-incoming-webhook', 'process-pending-outgoing-webhook', 'process-pending-escrow-completion-tracking', 'process-paid-escrow-completion-tracking', 'process-awaiting-escrow-payouts', 'process-requested-abuse', 'process-classified-abuse')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hmt"."cron-jobs" ALTER COLUMN "cron_job_type" TYPE "hmt"."cron-jobs_cron_job_type_enum_old" USING "cron_job_type"::"text"::"hmt"."cron-jobs_cron_job_type_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "hmt"."cron-jobs_cron_job_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "hmt"."cron-jobs_cron_job_type_enum_old" RENAME TO "cron-jobs_cron_job_type_enum"`,
+    );
+  }
+}

--- a/packages/apps/reputation-oracle/server/src/modules/auth/auth.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/auth.module.ts
@@ -31,5 +31,6 @@ import { TokenRepository } from './token.repository';
   ],
   providers: [JwtHttpStrategy, AuthService, TokenRepository],
   controllers: [AuthController],
+  exports: [TokenRepository],
 })
 export class AuthModule {}

--- a/packages/apps/reputation-oracle/server/src/modules/auth/index.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/index.ts
@@ -1,1 +1,2 @@
 export { AuthModule } from './auth.module';
+export { TokenRepository } from './token.repository';

--- a/packages/apps/reputation-oracle/server/src/modules/auth/token.repository.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/token.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, FindManyOptions } from 'typeorm';
+import { DataSource, FindManyOptions, LessThan } from 'typeorm';
 
 import { BaseRepository } from '../../database';
 import { TokenEntity, TokenType } from './token.entity';
@@ -47,5 +47,11 @@ export class TokenRepository extends BaseRepository<TokenEntity> {
     userId: number,
   ): Promise<void> {
     await this.delete({ type, userId });
+  }
+
+  async deleteExpired(): Promise<void> {
+    await this.delete({
+      expiresAt: LessThan(new Date()),
+    });
   }
 }

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/constants.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/constants.ts
@@ -6,4 +6,5 @@ export enum CronJobType {
   ProcessAwaitingEscrowPayouts = 'process-awaiting-escrow-payouts',
   ProcessRequestedAbuse = 'process-requested-abuse',
   ProcessClassifiedAbuse = 'process-classified-abuse',
+  DeleteExpiredDbRecords = 'delete-expired-database-records',
 }

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { AbuseModule } from '../abuse';
+import { AuthModule } from '../auth';
 import { EscrowCompletionModule } from '../escrow-completion';
 import { IncomingWebhookModule, OutgoingWebhookModule } from '../webhook';
 
@@ -13,6 +14,7 @@ import { CronJobRepository } from './cron-job.repository';
     OutgoingWebhookModule,
     EscrowCompletionModule,
     AbuseModule,
+    AuthModule,
   ],
   providers: [CronJobService, CronJobRepository],
 })

--- a/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -233,7 +233,7 @@ export class CronJobService {
     await this.completeCronJob(cronJob);
   }
 
-  @Cron('*/5 * * * *')
+  @Cron('29,58 * * * *')
   async deleteExpiredDatabaseRecords(): Promise<void> {
     const isCronJobRunning = await this.isCronJobRunning(
       CronJobType.DeleteExpiredDbRecords,


### PR DESCRIPTION
## Issue tracking
Part of #2803

## Context behind the change
PG doesn't support TTL functionality in a native way, so we considered next options:
1) use `pg_cron` (or similar extension) to run scheduled removals
2) writing DB triggers
3) partition data and drop partitions
4) use cron in app to delete records

2 & 3 are over-engineering atm and `pg_cron` can't be installed on our instance unfortunately, so we ended up to nubmer 4.

It's expected to have single cron job to delete expired entities from all necessary tables, so this is why `deleteExpiredDatabaseRecords` has it's own unit tests block.

## How has this been tested?
- [x] unit tests
- [x] run cron job locally and make sure that stale entities removed from the table 

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
When releasing this feature it might introduce some load on DB because will run for the first time, but taking into account we don't have too much items - should be fine.