### PR TITLE
[Reputation Oracle] fix: flaky test

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/qualification/qualification.service.spec.ts
@@ -3,6 +3,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 
+import { generateFutureDate } from '../../../test/fixtures/date';
 import { generateEthWallet } from '../../../test/fixtures/web3';
 import { ServerConfigService } from '../../config';
 import { UserStatus, UserRepository } from '../user';
@@ -54,7 +55,7 @@ describe('QualificationService', () => {
   });
 
   describe('createQualification', () => {
-    it.each([faker.date.future({ years: 1 }), undefined])(
+    it.each([generateFutureDate(2), undefined])(
       'should create a new qualification',
       async (expiresAt) => {
         const newQualification = {

--- a/packages/apps/reputation-oracle/server/test/fixtures/date.ts
+++ b/packages/apps/reputation-oracle/server/test/fixtures/date.ts
@@ -1,0 +1,13 @@
+export function generateFutureDate(daysFromNow = 1): Date {
+  /**
+   * setDate will use integer part if float is passed
+   * so round it here to be explicit
+   */
+  const _daysFromNow = Math.max(Math.floor(daysFromNow), 1);
+  const currentDate = new Date();
+  const futureDate = new Date();
+
+  futureDate.setDate(currentDate.getDate() + _daysFromNow);
+
+  return futureDate;
+}


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Flaky test discovered - [ref](https://github.com/humanprotocol/human-protocol/actions/runs/15043070119/job/42279116757?pr=3338).
Faker's `future` date utils generates a date in a "range" you provide and can be even "later today", but for expiration we need "from some point in the future".

## How has this been tested?
- [x] unit tests and log to make sure that generated value is correct

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
N/A