### PR TITLE
[Job Launcher][Server] Send webhooks once escrow is setup

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -376,6 +376,17 @@ export class JobService {
     jobEntity.status = JobStatus.LAUNCHED;
     await this.jobRepository.updateOne(jobEntity);
 
+    const oracleType = this.getOracleType(jobEntity.requestType);
+    const webhookEntity = new WebhookEntity();
+    Object.assign(webhookEntity, {
+      escrowAddress: jobEntity.escrowAddress,
+      chainId: jobEntity.chainId,
+      eventType: EventType.ESCROW_CREATED,
+      oracleType: oracleType,
+      hasSignature: oracleType !== OracleType.HCAPTCHA ? true : false,
+    });
+    await this.webhookRepository.createUnique(webhookEntity);
+
     return jobEntity;
   }
 
@@ -397,20 +408,7 @@ export class JobService {
     });
 
     jobEntity.status = JobStatus.FUNDED;
-    await this.jobRepository.updateOne(jobEntity);
-
-    const oracleType = this.getOracleType(jobEntity.requestType);
-    const webhookEntity = new WebhookEntity();
-    Object.assign(webhookEntity, {
-      escrowAddress: jobEntity.escrowAddress,
-      chainId: jobEntity.chainId,
-      eventType: EventType.ESCROW_CREATED,
-      oracleType: oracleType,
-      hasSignature: oracleType !== OracleType.HCAPTCHA ? true : false,
-    });
-    await this.webhookRepository.createUnique(webhookEntity);
-
-    return jobEntity;
+    return this.jobRepository.updateOne(jobEntity);
   }
 
   public async requestToCancelJobById(


### PR DESCRIPTION
## Issue tracking
#3361

## Context behind the change
Refactor outgoing webhook creation  moving it from from fund to setup

## How has this been tested?
Ran unit tests

## Release plan
None

## Potential risks; What to monitor; Rollback plan 
Check that the webhook is created after setting up the job