### PR TITLE
[Reputation Oracle] fix: logger mock

### DIFF
--- a/packages/apps/reputation-oracle/server/src/logger/__mocks__/index.ts
+++ b/packages/apps/reputation-oracle/server/src/logger/__mocks__/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../types';
 
 const logger: Logger = {
-  child: jest.fn(() => logger),
+  child: () => logger,
   info: jest.fn(),
   debug: jest.fn(),
   error: jest.fn(),


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
In case `jest.resetAllMocks` is called, current implementation of `logger.child` mock won't be able to return logger instance anymore, so fixing it it return itself

## How has this been tested?
- [x] unit tests

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No