### PR TITLE
fix: sdk cd to publish

### DIFF
--- a/.github/workflows/cd-core.yaml
+++ b/.github/workflows/cd-core.yaml
@@ -24,8 +24,7 @@ jobs:
           file: ./packages/core/package.json
           field: version
           value: ${{ github.event.release.tag_name }}
-      - uses: JS-DevTools/npm-publish@v3
-        with:
-          package: ./packages/core/package.json
-          access: public
-          token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish package
+        run: yarn workspace @human-protocol/core npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cd-node-sdk.yaml
+++ b/.github/workflows/cd-node-sdk.yaml
@@ -23,14 +23,14 @@ jobs:
         run: yarn install --immutable
       - name: Build core package
         run: yarn build:core
-      - name: Change Node.js SDK version
+      - name: Change Node.js SDK version from release tag
         uses: jossef/action-set-json-field@v2
         if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           file: ./packages/sdk/typescript/human-protocol-sdk/package.json
           field: version
           value: ${{ github.event.release.tag_name }}
-      - name: Change Node.js SDK version
+      - name: Change Node.js SDK version from workflow input
         uses: jossef/action-set-json-field@v2
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
@@ -38,11 +38,8 @@ jobs:
           field: version
           value: ${{ github.event.inputs.release_version }}
       - name: Build SDK package
-        run: yarn build
-        working-directory: ./packages/sdk/typescript/human-protocol-sdk
-      - uses: JS-DevTools/npm-publish@v3
-        name: Publish
-        with:
-          package: ./packages/sdk/typescript/human-protocol-sdk/package.json
-          access: public
-          token: ${{ secrets.NPM_TOKEN }}
+        run: yarn workspace @human-protocol/sdk build
+      - name: Publish package
+        run: yarn workspace @human-protocol/sdk npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Issue tracking
No

## Context behind the change
SDK package fails to be installed because its "core" package dependency isn't replaces properly while doing "publish". It's due to CI using some custom publish action instead of relying on native mechanism in `yarn` that should properly replace deps when doing publish in workspaces.

## How has this been tested?
To be tested via workflow dispatch.

## Release plan
Merge & release 4.1.2

## Potential risks; What to monitor; Rollback plan
We need to run action to see if it works, but in worst case it just fails