### PR TITLE
[Dashboard] Transactions wrong data

### DIFF
--- a/packages/apps/dashboard/client/src/features/searchResults/ui/WalletTransactions/TransactionsTableBody.tsx
+++ b/packages/apps/dashboard/client/src/features/searchResults/ui/WalletTransactions/TransactionsTableBody.tsx
@@ -136,8 +136,8 @@ const TransactionsTableBody: FC<Props> = ({ data, isLoading, error }) => {
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <ArrowForwardIcon sx={{ color: 'text.primary' }} />
                   <AbbreviateClipboard
-                    value={elem.receiver || elem.to}
-                    link={`/search/${data.chainId}/${elem.receiver || elem.to}`}
+                    value={internalTx.receiver || internalTx.to}
+                    link={`/search/${data.chainId}/${internalTx.receiver || internalTx.to}`}
                   />
                 </Box>
               </TableCell>


### PR DESCRIPTION
## Issue tracking
Closes #3418 

## Context behind the change
In the transactions table, internal transaction's `to` field had wrong value. instead, it should use `internalTx.to`, not `tx.to`

## How has this been tested?
locally;
on the localhost or preview, go to [this search result](http://localhost:3004/search/80002/0x4708354213453af0cdC33eb75d94fBC00045841E), scroll down to the transactions table, then expand the first tx, that has internal tx, and make sure `to` field has a different value

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->