### PR TITLE
fix: include typechain to core bundle

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "artifacts/@openzeppelin/**/[^.]*.json",
     "artifacts/contracts/**/[^.]*.json",
     "typechain-types/**/*.ts",
-    "dist/typechain-types"
+    "dist/typechain-types/**"
   ],
   "scripts": {
     "clean": "yarn clean:compile && yarn clean:build",


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/humanprotocol/human-protocol/pull/3420

## Context behind the change
Recently we changed `npm publish` to `yarn npm publish` in CI and got tricky behavior: `dist/typechain-types` not included to resulting bundle (not sure why).
Changed the pattern to fix that.

## How has this been tested?
- [x] run `yarn pack --dry-run` to check that necessary folder is included

## Release plan
Merge & publish new `core` version

## Potential risks; What to monitor; Rollback plan
Should be none