### PR TITLE
[HUMAN App] feat: return all oracles for non prd

### DIFF
--- a/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
+++ b/packages/apps/human-app/server/src/modules/oracle-discovery/oracle-discovery.controller.ts
@@ -46,6 +46,10 @@ export class OracleDiscoveryController {
     const command = this.mapper.map(query, GetOraclesQuery, GetOraclesCommand);
     const oracles = await this.oracleDiscoveryService.getOracles(command);
 
+    if (process.env.NODE_ENV !== 'production') {
+      return oracles;
+    }
+
     const isAudinoAvailableForUser = (req?.user?.qualifications ?? []).includes(
       'audino',
     );


### PR DESCRIPTION
## Issue tracking
Related to #3407

## Context behind the change
Follow up to https://github.com/humanprotocol/human-protocol/pull/3408: return all oracles in non-prd env for simplicity.

## How has this been tested?
--

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No