### PR TITLE
[Reputation Oracle] fix: get improted provider ref

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -7,7 +7,6 @@ import {
   OperatorUtils,
 } from '@human-protocol/sdk';
 import { Injectable } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 
 import crypto from 'crypto';
 import { ethers } from 'ethers';
@@ -61,7 +60,12 @@ export class EscrowCompletionService {
     private readonly storageService: StorageService,
     private readonly outgoingWebhookService: OutgoingWebhookService,
     private readonly reputationService: ReputationService,
-    private readonly moduleRef: ModuleRef,
+    private readonly audinoResultsProcessor: AudinoResultsProcessor,
+    private readonly cvatResultsProcessor: CvatResultsProcessor,
+    private readonly fortuneResultsProcessor: FortuneResultsProcessor,
+    private readonly audinoPayoutsCalculator: AudinoPayoutsCalculator,
+    private readonly cvatPayoutsCalculator: CvatPayoutsCalculator,
+    private readonly fortunePayoutsCalculator: FortunePayoutsCalculator,
   ) {}
 
   async createEscrowCompletion(
@@ -437,15 +441,15 @@ export class EscrowCompletionService {
     jobRequestType: JobRequestType,
   ): EscrowResultsProcessor {
     if (manifestUtils.isFortuneJobType(jobRequestType)) {
-      return this.moduleRef.get(FortuneResultsProcessor);
+      return this.fortuneResultsProcessor;
     }
 
     if (manifestUtils.isCvatJobType(jobRequestType)) {
-      return this.moduleRef.get(CvatResultsProcessor);
+      return this.cvatResultsProcessor;
     }
 
     if (manifestUtils.isAudinoJobType(jobRequestType)) {
-      return this.moduleRef.get(AudinoResultsProcessor);
+      return this.audinoResultsProcessor;
     }
 
     throw new Error(
@@ -457,15 +461,15 @@ export class EscrowCompletionService {
     jobRequestType: JobRequestType,
   ): EscrowPayoutsCalculator {
     if (manifestUtils.isFortuneJobType(jobRequestType)) {
-      return this.moduleRef.get(FortunePayoutsCalculator);
+      return this.fortunePayoutsCalculator;
     }
 
     if (manifestUtils.isCvatJobType(jobRequestType)) {
-      return this.moduleRef.get(CvatPayoutsCalculator);
+      return this.cvatPayoutsCalculator;
     }
 
     if (manifestUtils.isAudinoJobType(jobRequestType)) {
-      return this.moduleRef.get(AudinoPayoutsCalculator);
+      return this.audinoPayoutsCalculator;
     }
 
     throw new Error(


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
After https://github.com/humanprotocol/human-protocol/pull/3390 RepO fails to get some providers from the module DI container because `moduleRef` by default is _scoped to the current module only_ (which is not clear on "how" from [their docs](https://docs.nestjs.com/fundamentals/module-ref)). In order to retrieve a provider from a global context (i.e. from imported modules) the `string: false` should be passed, so in order to avoid confusing we decided to get back explicit providers injection

## How has this been tested?
- [x] CI tests pass

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Should be none