### PR TITLE
update block number calculation for query filter

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/governance-banner/hooks/use-active-proposal-query.ts
+++ b/packages/apps/human-app/frontend/src/modules/governance-banner/hooks/use-active-proposal-query.ts
@@ -30,7 +30,7 @@ async function fetchActiveProposalFn() {
   const logs = await contract.queryFilter(
     filter,
     env.VITE_NETWORK === 'mainnet'
-      ? 68058296
+      ? (await provider.getBlockNumber()) - 100000
       : (await provider.getBlockNumber()) - 10000,
     'latest'
   );


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
Change the block number from which the governance logs are fetch to avoid timeouts.
Since the blocktime in polygon is 2s, voting delay is 1 day (86400s) and the duration of proposals is1 day (86400s), we won't need 
more than 86400/2+86400/2= 86400 blocks and we rounded it 100k.

## How has this been tested?
Run locally

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA