### PR TITLE
[Subgraph] Wrong information in transaction data

### DIFF
--- a/packages/sdk/typescript/subgraph/src/mapping/utils/transaction.ts
+++ b/packages/sdk/typescript/subgraph/src/mapping/utils/transaction.ts
@@ -72,6 +72,7 @@ export function createTransaction(
     Address.fromBytes(transaction.to) == to
   ) {
     transaction.method = method;
+    transaction.from = from;
     transaction.value = value !== null ? value : BigInt.fromI32(0);
     transaction.token = token;
     transaction.escrow = escrow;


### PR DESCRIPTION
## Issue tracking
#3421 

## Context behind the change
When receiving multiple events in one transaction, transaction from value was not showing the right value. This was due to it was setting the one from the first event that subgraph receives. In order to show it properly, we have to set the right from value when transaction is mainMethod, overwriting  the value from the first event.

## How has this been tested?
Ran tests

## Release plan
Deploy new SDK version

## Potential risks; What to monitor; Rollback plan
None