### PR TITLE
fix: do not use compose bake

### DIFF
--- a/docker-setup/Makefile
+++ b/docker-setup/Makefile
@@ -2,6 +2,7 @@
 	infra-up infra-stop \
 	build-services services-up services-stop
 
+export COMPOSE_BAKE=false
 DOCKER_PARALLEL ?= 4
 
 check-env-file:


### PR DESCRIPTION
## Issue tracking
No

## Context behind the change
Starting from v2.38.x Docker Compose delegates build process to Buildx Bake by default and because of that neither `COMPOSE_PARALLEL_LIMIT` nor `--parallel` configuration options not supported, so when we attempt to build all of our docker service locally by running `make services-up` it can eventually fail due to exceeding RAM on developer machine. In order to workaround it - disable usage of Buildx Bake for now. Later we have next options:
- split our scripts to have `build-service` that requires services list and `build-all-services` that will batch all services in groups under the hood
- maybe there will be some native way to control concurrency, but highly likely we will need to do it manually on our end

Ref to Docker Compose issues: https://github.com/docker/compose/issues/13043

## How has this been tested?
- [x] run `make build-services` with latest Docker Compose; make sure build finishes and RAM not exceeded

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No