### PR TITLE
[Faucet] Improve IP handling

### DIFF
--- a/packages/apps/faucet/server/src/index.ts
+++ b/packages/apps/faucet/server/src/index.ts
@@ -28,6 +28,8 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, '..', 'client', 'build')));
 const port = process.env.APP_PORT;
 
+app.set('trust proxy', 1);
+
 // set up rate limiter: maximum of five requests per second
 app.use(
   RateLimit({

--- a/packages/apps/faucet/server/src/index.ts
+++ b/packages/apps/faucet/server/src/index.ts
@@ -35,7 +35,6 @@ app.use(
     max: 5,
   })
 );
-app.set('trust proxy', true);
 
 // init cache
 const blockList = new NodeCache();
@@ -108,20 +107,14 @@ app.post('/faucet', async (request: Request, response: Response) => {
 
   // extract ip
   let ipAddress = request.ip;
-  console.log(
-    'IP:',
-    ipAddress,
-    'X-Forwarded-For:',
-    request.headers['x-forwarded-for'],
-    'All headers:',
-    request.headers
-  );
   if (!ipAddress)
     return response.status(200).json({
       status: false,
       message: 'Testnet ETH request fail. Please try again!',
     });
   ipAddress = ipAddress.replace(/\./g, '_');
+  console.log('IP after replace:', ipAddress);
+  console.log(blockList.keys());
 
   // check ip address availability
   if (blockList.has(ipAddress)) {

--- a/packages/apps/faucet/server/src/index.ts
+++ b/packages/apps/faucet/server/src/index.ts
@@ -115,8 +115,6 @@ app.post('/faucet', async (request: Request, response: Response) => {
       message: 'Testnet ETH request fail. Please try again!',
     });
   ipAddress = ipAddress.replace(/\./g, '_');
-  console.log('IP after replace:', ipAddress);
-  console.log(blockList.keys());
 
   // check ip address availability
   if (blockList.has(ipAddress)) {

--- a/packages/apps/faucet/server/src/index.ts
+++ b/packages/apps/faucet/server/src/index.ts
@@ -35,6 +35,7 @@ app.use(
     max: 5,
   })
 );
+app.set('trust proxy', true);
 
 // init cache
 const blockList = new NodeCache();
@@ -106,7 +107,15 @@ app.post('/faucet', async (request: Request, response: Response) => {
     });
 
   // extract ip
-  let ipAddress = request.ip || request.socket.remoteAddress;
+  let ipAddress = request.ip;
+  console.log(
+    'IP:',
+    ipAddress,
+    'X-Forwarded-For:',
+    request.headers['x-forwarded-for'],
+    'All headers:',
+    request.headers
+  );
   if (!ipAddress)
     return response.status(200).json({
       status: false,


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
Express was using the server's IP for all requests, causing everyone to be blocked by the rate limit as if they shared the same IP.
It was fixed by setting app.set('trust proxy', 1), so Express now correctly uses the real client IP for rate limiting

## How has this been tested?
Deployed and made some requests to confirm it's working

## Release plan
Deploy Faucet server

## Potential risks; What to monitor; Rollback plan
None