### PR TITLE
[Human APP] Add temporal error banner for CVAT task

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/worker/jobs/jobs.page.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/jobs/jobs.page.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import React, { useEffect, useState } from 'react';
 import { Box, Grid, Paper, Stack, Tab, Tabs, Typography } from '@mui/material';
+import ErrorIcon from '@mui/icons-material/Error';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { TableQueryContextProvider } from '@/shared/components/ui/table/table-query-context';
@@ -20,6 +21,27 @@ function generateTabA11yProps(index: number) {
     id: `tab-${index.toString()}`,
     'aria-controls': `jobs-tabpanel-${index.toString()}`,
   };
+}
+
+function CvatErrorBanner({ isDarkMode }: { isDarkMode: boolean }) {
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      flexDirection={{ xs: 'column', sm: 'row' }}
+      mt={2}
+      p={2}
+      gap={1}
+      bgcolor={isDarkMode ? '#CDC7FF14' : '#1406B20A'}
+    >
+      <ErrorIcon />
+      <Typography variant="body1">
+        We know what went down and we are fixing it - We will update via our
+        status page
+      </Typography>
+    </Box>
+  );
 }
 
 export function JobsPage() {
@@ -60,6 +82,8 @@ export function JobsPage() {
     ({ address }) => address === oracle_address
   )?.name;
 
+  const isCVAT = oracleName === 'CVAT';
+
   if (isPending) {
     return <PageCardLoader />;
   }
@@ -91,7 +115,8 @@ export function JobsPage() {
               <Typography variant="h6">{oracleName}</Typography>
             </Box>
           )}
-          <Stack>
+          {isCVAT && <CvatErrorBanner isDarkMode={isDarkMode} />}
+          <Stack display={isCVAT ? 'none' : 'block'}>
             <TableQueryContextProvider>
               <Box sx={{ width: '100%' }}>
                 <Box

--- a/packages/apps/human-app/frontend/src/modules/worker/jobs/jobs.page.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/jobs/jobs.page.tsx
@@ -33,6 +33,7 @@ function CvatErrorBanner({ isDarkMode }: { isDarkMode: boolean }) {
       mt={2}
       p={2}
       gap={1}
+      textAlign={{ xs: 'center', sm: 'unset' }}
       bgcolor={isDarkMode ? '#CDC7FF14' : '#1406B20A'}
     >
       <ErrorIcon />


### PR DESCRIPTION
## Issue tracking
Not ticketed

## Context behind the change
Just adds a temporal error banner for CVAT task

## How has this been tested?
locally mocking cvat task

Desktop | Mobile
-|-
![img](https://github.com/user-attachments/assets/eeef2b32-f90a-45f3-80fa-4116a7ce6964)|![img](https://github.com/user-attachments/assets/c2de924e-7013-4c75-bed2-100602fbf263)

## Release plan
do not merge

## Potential risks; What to monitor; Rollback plan
no risks