### PR TITLE
[HUMAN App] Fix: add reason field to ReportAbuseCommand

### DIFF
--- a/packages/apps/human-app/server/src/modules/abuse/model/abuse.model.ts
+++ b/packages/apps/human-app/server/src/modules/abuse/model/abuse.model.ts
@@ -39,6 +39,8 @@ export class ReportAbuseCommand {
   data: ReportAbuseParams;
   @AutoMap()
   token: string;
+  @AutoMap()
+  reason: string;
 }
 
 export class ReportAbuseData {


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
Add reason field to ReportAbuseCommand. This missing field was causing a validation error in Reputation Oracle.

## How has this been tested?
Staging env

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA