### PR TITLE
[HUMAN App] feat: avoid same oracle displaying in oracle discovery

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/worker/services/oracles.service.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/services/oracles.service.ts
@@ -72,6 +72,16 @@ async function getOracles(selectedJobTypes: string[]) {
       }
     }
 
+    const oracleAddresses = new Set<string>();
+    oracles = oracles.filter(({ address: oracleAddress }) => {
+      if (oracleAddresses.has(oracleAddress)) {
+        return false;
+      }
+
+      oracleAddresses.add(oracleAddress);
+      return true;
+    });
+
     return oracles;
   } catch (error) {
     if (error instanceof ApiClientError) {


### PR DESCRIPTION
## Issue tracking
Closes #2804

## Context behind the change
Atm UI has functionality to filter UI job by chain & also we do not expect that in our version of protocol there might be oracle with different setup in different chains, instead we run same oracle in different chains (atm only on testnets). So it is fine to just remove duplicates from UI and filter jobs by chain_id later.

## How has this been tested?
- [x] use [Vercel preview](https://human-pdn80rtt7-humanprotocol.vercel.app/worker/jobs-discovery) to verify that only one oracle item is displayed on oracles page

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No