### PR TITLE
[CVAT] Fix empty GT frames in point annotation task

### DIFF
--- a/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py
+++ b/packages/examples/cvat/exchange-oracle/src/handlers/job_creation.py
@@ -478,7 +478,9 @@ class PointsTaskBuilder(SimpleTaskBuilder):
                 sample_points.extend(bbox_center.points)
 
             # Join points into a single annotation for compatibility with CVAT capabilities
-            updated_anns = [dm.Points(sample_points, label=label_id)]
+            updated_anns = []
+            if sample_points:
+                updated_anns.append(dm.Points(sample_points, label=label_id))
 
             updated_gt_dataset.put(gt_sample.wrap(annotations=updated_anns))
 


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->

## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->

- Fixed a possible error in annotation uploading for a CVAT GT job if there are empty GT frames during task creation

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->

## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->