### PR TITLE
[Fortune] feat: use shared logger

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/Dockerfile
+++ b/packages/apps/fortune/exchange-oracle/server/Dockerfile
@@ -16,6 +16,7 @@ COPY ${APP_PATH}/package.json ./${APP_PATH}/
 # so we need to copy and build them
 COPY packages/core ./packages/core
 COPY packages/sdk ./packages/sdk
+COPY packages/libs ./packages/libs
 
 RUN yarn install
 

--- a/packages/apps/fortune/exchange-oracle/server/package.json
+++ b/packages/apps/fortune/exchange-oracle/server/package.json
@@ -28,6 +28,7 @@
     "generate-env-doc": "ts-node scripts/generate-env-doc.ts"
   },
   "dependencies": {
+    "@human-protocol/logger": "workspace:*",
     "@human-protocol/sdk": "workspace:*",
     "@nestjs/axios": "^3.1.2",
     "@nestjs/common": "^10.2.7",

--- a/packages/apps/fortune/exchange-oracle/server/src/app.module.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/app.module.ts
@@ -19,6 +19,7 @@ import { UserModule } from './modules/user/user.module';
 import { Web3Module } from './modules/web3/web3.module';
 import { WebhookModule } from './modules/webhook/webhook.module';
 import { HttpValidationPipe } from './common/pipes';
+import Environment from './common/utils/environment';
 
 @Module({
   providers: [
@@ -54,7 +55,7 @@ import { HttpValidationPipe } from './common/pipes';
       /**
        * First value found takes precendece
        */
-      envFilePath: [`.env.${process.env.NODE_ENV}`, '.env.local', '.env'],
+      envFilePath: [`.env.${Environment.name}`, '.env.local', '.env'],
       validationSchema: envValidator,
     }),
     DatabaseModule,

--- a/packages/apps/fortune/exchange-oracle/server/src/common/config/env-schema.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/config/env-schema.ts
@@ -2,7 +2,6 @@ import * as Joi from 'joi';
 
 export const envValidator = Joi.object({
   // General
-  NODE_ENV: Joi.string(),
   HOST: Joi.string(),
   PORT: Joi.string(),
   FE_URL: Joi.string(),

--- a/packages/apps/fortune/exchange-oracle/server/src/common/config/server-config.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/config/server-config.service.ts
@@ -6,14 +6,6 @@ export class ServerConfigService {
   constructor(private configService: ConfigService) {}
 
   /**
-   * The environment in which the server is running (e.g., 'development', 'production').
-   * Default: 'development'
-   */
-  get nodeEnv(): string {
-    return this.configService.get<string>('NODE_ENV', 'development');
-  }
-
-  /**
    * The hostname or IP address on which the server will run.
    * Default: 'localhost'
    */

--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -3,9 +3,10 @@ import {
   Catch,
   ExceptionFilter as IExceptionFilter,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+
+import logger from '../../logger';
 import {
   ValidationError,
   AuthError,
@@ -18,7 +19,7 @@ import {
 
 @Catch()
 export class ExceptionFilter implements IExceptionFilter {
-  private logger = new Logger(ExceptionFilter.name);
+  private readonly logger = logger.child({ context: ExceptionFilter.name });
 
   private getStatus(exception: any): number {
     if (exception instanceof ValidationError) {
@@ -49,10 +50,7 @@ export class ExceptionFilter implements IExceptionFilter {
     const status = this.getStatus(exception);
     const message = exception.message || 'Internal server error';
 
-    this.logger.error(
-      `Exception caught: ${message}`,
-      exception.stack || 'No stack trace available',
-    );
+    this.logger.error('Unhandled exception', exception);
 
     response.status(status).json({
       status_code: status,

--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -50,7 +50,9 @@ export class ExceptionFilter implements IExceptionFilter {
     const status = this.getStatus(exception);
     const message = exception.message || 'Internal server error';
 
-    this.logger.error('Unhandled exception', exception);
+    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+      this.logger.error('Unhandled exception', exception);
+    }
 
     response.status(status).json({
       status_code: status,

--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -36,10 +36,11 @@ export class ExceptionFilter implements IExceptionFilter {
       return HttpStatus.UNPROCESSABLE_ENTITY;
     } else if (exception instanceof DatabaseError) {
       return HttpStatus.UNPROCESSABLE_ENTITY;
-    } else if (exception.statusCode) {
-      return exception.statusCode;
     }
-    return HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const exceptionStatusCode = exception.statusCode || exception.status;
+
+    return exceptionStatusCode || HttpStatus.INTERNAL_SERVER_ERROR;
   }
 
   catch(exception: any, host: ArgumentsHost) {

--- a/packages/apps/fortune/exchange-oracle/server/src/common/guards/signature.auth.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/guards/signature.auth.ts
@@ -1,11 +1,7 @@
 import { EscrowUtils } from '@human-protocol/sdk';
-import {
-  CanActivate,
-  ExecutionContext,
-  Injectable,
-  Logger,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+
 import { AssignmentRepository } from '../../modules/assignment/assignment.repository';
 import { HEADER_SIGNATURE_KEY } from '../constant';
 import { ErrorAssignment, ErrorSignature } from '../constant/errors';
@@ -15,9 +11,8 @@ import { verifySignature } from '../utils/signature';
 
 @Injectable()
 export class SignatureAuthGuard implements CanActivate {
-  private readonly logger = new Logger(SignatureAuthGuard.name);
   constructor(
-    private reflector: Reflector,
+    private readonly reflector: Reflector,
     private readonly assignmentRepository: AssignmentRepository,
   ) {}
 
@@ -59,15 +54,18 @@ export class SignatureAuthGuard implements CanActivate {
         oracleAdresses.push(escrowData.reputationOracle!);
       }
     }
+
+    let isVerified = false;
     try {
-      const isVerified = verifySignature(data, signature, oracleAdresses);
-      if (isVerified) {
-        return true;
-      }
-    } catch (error) {
-      this.logger.error(error);
+      isVerified = verifySignature(data, signature, oracleAdresses);
+    } catch {
+      // noop
     }
 
-    throw new AuthError('Unauthorized');
+    if (!isVerified) {
+      throw new AuthError('Unauthorized');
+    }
+
+    return true;
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/utils/environment.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/utils/environment.ts
@@ -1,0 +1,25 @@
+enum EnvironmentName {
+  LOCAL = 'local',
+  DEVELOPMENT = 'development',
+  TEST = 'test',
+  STAGING = 'staging',
+}
+
+class Environment {
+  static readonly name: string =
+    process.env.NODE_ENV || EnvironmentName.DEVELOPMENT;
+
+  static isDevelopment(): boolean {
+    return [
+      EnvironmentName.DEVELOPMENT,
+      EnvironmentName.TEST,
+      EnvironmentName.LOCAL,
+    ].includes(Environment.name as EnvironmentName);
+  }
+
+  static isTest(): boolean {
+    return Environment.name === EnvironmentName.TEST;
+  }
+}
+
+export default Environment;

--- a/packages/apps/fortune/exchange-oracle/server/src/database/database.module.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/database/database.module.ts
@@ -3,30 +3,24 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import * as path from 'path';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
-import { NS } from '../common/constant';
-
-import { TypeOrmLoggerModule, TypeOrmLoggerService } from './typeorm';
 import { LoggerOptions } from 'typeorm';
+
+import { NS } from '../common/constant';
+import { TypeOrmLoggerModule, TypeOrmLoggerService } from './typeorm';
 import { JobEntity } from '../modules/job/job.entity';
 import { AssignmentEntity } from '../modules/assignment/assignment.entity';
 import { WebhookEntity } from '../modules/webhook/webhook.entity';
 import { CronJobEntity } from '../modules/cron-job/cron-job.entity';
 import { DatabaseConfigService } from '../common/config/database-config.service';
-import { ServerConfigService } from '../common/config/server-config.service';
 
 @Module({
   imports: [
     TypeOrmModule.forRootAsync({
       imports: [TypeOrmLoggerModule, ConfigModule],
-      inject: [
-        TypeOrmLoggerService,
-        DatabaseConfigService,
-        ServerConfigService,
-      ],
+      inject: [TypeOrmLoggerService, DatabaseConfigService],
       useFactory: (
         typeOrmLoggerService: TypeOrmLoggerService,
         databaseConfigService: DatabaseConfigService,
-        serverConfigService: ServerConfigService,
       ) => {
         const loggerOptions = databaseConfigService.logging.split(', ');
         typeOrmLoggerService.setOptions(

--- a/packages/apps/fortune/exchange-oracle/server/src/database/database.module.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/database/database.module.ts
@@ -58,7 +58,6 @@ import { ServerConfigService } from '../common/config/server-config.service';
           username: databaseConfigService.user,
           password: databaseConfigService.password,
           database: databaseConfigService.database,
-          keepConnectionAlive: serverConfigService.nodeEnv === 'test',
           migrationsRun: false,
           ssl: databaseConfigService.ssl,
         };

--- a/packages/apps/fortune/exchange-oracle/server/src/logger/index.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/logger/index.ts
@@ -1,0 +1,24 @@
+import { createLogger, NestLogger, LogLevel } from '@human-protocol/logger';
+
+import Environment from '../common/utils/environment';
+
+const isDevelopment = Environment.isDevelopment();
+
+const defaultLogger = createLogger(
+  {
+    name: 'DefaultLogger',
+    level: isDevelopment ? LogLevel.DEBUG : LogLevel.INFO,
+    pretty: isDevelopment,
+    disabled: Environment.isTest(),
+  },
+  {
+    environment: Environment.name,
+    service: 'fortune-exchange-oracle',
+  },
+);
+
+export const nestLoggerOverride = new NestLogger(
+  defaultLogger.child({ name: 'NestLogger' }),
+);
+
+export default defaultLogger;

--- a/packages/apps/fortune/exchange-oracle/server/src/main.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/main.ts
@@ -1,16 +1,18 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { json, urlencoded } from 'body-parser';
 import { useContainer } from 'class-validator';
 
-import { AppModule } from './app.module';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { ServerConfigService } from './common/config/server-config.service';
+import logger, { nestLoggerOverride } from './logger';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create<INestApplication>(AppModule, {
     cors: true,
+    logger: nestLoggerOverride,
   });
 
   const configService: ConfigService = app.get(ConfigService);
@@ -18,21 +20,6 @@ async function bootstrap() {
 
   const host = serverConfigService.host;
   const port = serverConfigService.port;
-
-  // app.enableCors({
-  //   origin:
-  //     process.env.NODE_ENV === 'development' ||
-  //     process.env.NODE_ENV === 'staging'
-  //       ? [
-  //           `http://localhost:${port}`,
-  //           `http://127.0.0.1:${port}`,
-  //           `http://0.0.0.0:${port}`,
-  //           `http://${host}:${port}`,
-  //         ]
-  //       : [`http://${host}:${port}`],
-  //   credentials: true,
-  //   exposedHeaders: ['Content-Disposition'],
-  // });
 
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
 
@@ -51,7 +38,7 @@ async function bootstrap() {
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
   await app.listen(port, host, async () => {
-    console.info(`API server is running on http://${host}:${port}`);
+    logger.info(`API server is running on http://${host}:${port}`);
   });
 }
 

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/cron-job/cron-job.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
-
+import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+
+import logger from '../../logger';
 import { ErrorCronJob } from '../../common/constant/errors';
 import { CronJobType } from '../../common/enums/cron-job';
 import { WebhookStatus } from '../../common/enums/webhook';
@@ -11,7 +12,7 @@ import { CronJobRepository } from './cron-job.repository';
 
 @Injectable()
 export class CronJobService {
-  private readonly logger = new Logger(CronJobService.name);
+  private readonly logger = logger.child({ context: CronJobService.name });
 
   constructor(
     private readonly cronJobRepository: CronJobRepository,
@@ -19,7 +20,7 @@ export class CronJobService {
     private readonly webhookRepository: WebhookRepository,
   ) {}
 
-  public async startCronJob(cronJobType: CronJobType): Promise<CronJobEntity> {
+  async startCronJob(cronJobType: CronJobType): Promise<CronJobEntity> {
     const cronJob = await this.cronJobRepository.findOneByType(cronJobType);
 
     if (!cronJob) {
@@ -32,14 +33,15 @@ export class CronJobService {
     return this.cronJobRepository.updateOne(cronJob);
   }
 
-  public async isCronJobRunning(cronJobType: CronJobType): Promise<boolean> {
+  async isCronJobRunning(cronJobType: CronJobType): Promise<boolean> {
     const lastCronJob = await this.cronJobRepository.findOneByType(cronJobType);
 
     if (!lastCronJob || lastCronJob.completedAt) {
       return false;
     }
 
-    this.logger.log('Previous cron job is not completed yet');
+    this.logger.warn('Previous cron job is not completed yet', { cronJobType });
+
     return true;
   }
 
@@ -47,7 +49,9 @@ export class CronJobService {
     cronJobEntity: CronJobEntity,
   ): Promise<CronJobEntity> {
     if (cronJobEntity.completedAt) {
-      this.logger.error(ErrorCronJob.Completed, CronJobService.name);
+      this.logger.error(ErrorCronJob.Completed, {
+        cronJobType: cronJobEntity.cronJobType,
+      });
       throw new Error(ErrorCronJob.Completed);
     }
 
@@ -69,7 +73,7 @@ export class CronJobService {
       return;
     }
 
-    this.logger.log('Pending webhooks START');
+    this.logger.info('Pending webhooks START');
     const cronJob = await this.startCronJob(CronJobType.ProcessPendingWebhook);
 
     try {
@@ -80,19 +84,23 @@ export class CronJobService {
       for (const webhookEntity of webhookEntities) {
         try {
           await this.webhookService.sendWebhook(webhookEntity);
-        } catch (err) {
-          this.logger.error(`Error sending webhook: ${err.message}`);
+        } catch (error) {
+          this.logger.error('Error sending webhook', {
+            error,
+            webhookId: webhookEntity.id,
+          });
           await this.webhookService.handleWebhookError(webhookEntity);
           continue;
         }
         webhookEntity.status = WebhookStatus.COMPLETED;
         await this.webhookRepository.updateOne(webhookEntity);
       }
-    } catch (e) {
-      this.logger.error(e);
+    } catch (error) {
+      this.logger.error('Error processing pending webhooks', error);
     }
 
-    this.logger.log('Pending webhooks STOP');
+    this.logger.info('Pending webhooks STOP');
+
     await this.completeCronJob(cronJob);
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -9,7 +9,8 @@ import {
   EscrowClient,
   StorageClient,
 } from '@human-protocol/sdk';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+
 import { PGPConfigService } from '../../common/config/pgp-config.service';
 import { ErrorAssignment, ErrorJob } from '../../common/constant/errors';
 import { SortDirection } from '../../common/enums/collection';
@@ -42,8 +43,6 @@ import { JobRepository } from './job.repository';
 
 @Injectable()
 export class JobService {
-  public readonly logger = new Logger(JobService.name);
-
   constructor(
     private readonly pgpConfigService: PGPConfigService,
     public readonly jobRepository: JobRepository,
@@ -63,7 +62,6 @@ export class JobService {
     );
 
     if (jobEntity) {
-      this.logger.log(ErrorJob.AlreadyExists, JobService.name);
       throw new ConflictError(ErrorJob.AlreadyExists);
     }
 

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/stats/stats.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { JobRepository } from '../job/job.repository';
 import { AssignmentRepository } from '../assignment/assignment.repository';
 import { AssignmentStatsDto, OracleStatsDto } from './stats.dto';
@@ -6,7 +6,6 @@ import { JobStatus } from '../../common/enums/job';
 
 @Injectable()
 export class StatsService {
-  public readonly logger = new Logger(StatsService.name);
   constructor(
     private jobRepository: JobRepository,
     private assignmentRepository: AssignmentRepository,

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/web3/web3.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/web3/web3.service.ts
@@ -1,5 +1,8 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { ChainId } from '@human-protocol/sdk';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { Wallet, ethers } from 'ethers';
+
+import logger from '../../logger';
 import { Web3Env } from '../../common/enums/web3';
 import {
   LOCALHOST_CHAIN_IDS,
@@ -7,20 +10,20 @@ import {
   TESTNET_CHAIN_IDS,
 } from '../../common/constant';
 import { ErrorWeb3 } from '../../common/constant/errors';
-import { ChainId } from '@human-protocol/sdk';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { NetworkConfigService } from '../../common/config/network-config.service';
 
 @Injectable()
 export class Web3Service {
+  private readonly logger = logger.child({ context: Web3Service.name });
+
   private signers: { [key: number]: Wallet } = {};
-  public readonly logger = new Logger(Web3Service.name);
-  public readonly signerAddress: string;
-  public readonly currentWeb3Env: string;
+  readonly signerAddress: string;
+  readonly currentWeb3Env: string;
 
   constructor(
     private readonly web3ConfigService: Web3ConfigService,
-    public readonly networkConfigService: NetworkConfigService,
+    readonly networkConfigService: NetworkConfigService,
   ) {
     const privateKey = this.web3ConfigService.privateKey;
     const validChains = this.getValidChains();
@@ -43,7 +46,7 @@ export class Web3Service {
   public validateChainId(chainId: number): void {
     const validChainIds = this.getValidChains();
     if (!validChainIds.includes(chainId)) {
-      this.logger.log(ErrorWeb3.InvalidChainId, Web3Service.name);
+      this.logger.error(ErrorWeb3.InvalidChainId, { chainId });
       throw new BadRequestException(ErrorWeb3.InvalidChainId);
     }
   }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.module.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.module.ts
@@ -1,4 +1,4 @@
-import { Logger, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 
@@ -25,7 +25,7 @@ import { AssignmentEntity } from '../assignment/assignment.entity';
     AssignmentModule,
   ],
   controllers: [WebhookController],
-  providers: [Logger, WebhookService, WebhookRepository, AssignmentRepository],
+  providers: [WebhookService, WebhookRepository, AssignmentRepository],
   exports: [WebhookService],
 })
 export class WebhookModule {}

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.service.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ChainId, EscrowClient, OperatorUtils } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
+
+import logger from '../../logger';
 import { ServerConfigService } from '../../common/config/server-config.service';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { HEADER_SIGNATURE_KEY } from '../../common/constant';
@@ -21,16 +23,16 @@ import { WebhookRepository } from './webhook.repository';
 
 @Injectable()
 export class WebhookService {
-  private readonly logger = new Logger(WebhookService.name);
+  private readonly logger = logger.child({ context: WebhookService.name });
 
   constructor(
     private readonly webhookRepository: WebhookRepository,
     private readonly jobService: JobService,
-    public readonly web3ConfigService: Web3ConfigService,
-    public readonly serverConfigService: ServerConfigService,
-    public readonly httpService: HttpService,
-    public readonly web3Service: Web3Service,
-    public readonly storageService: StorageService,
+    private readonly web3ConfigService: Web3ConfigService,
+    private readonly serverConfigService: ServerConfigService,
+    private readonly httpService: HttpService,
+    private readonly web3Service: Web3Service,
+    private readonly storageService: StorageService,
   ) {}
 
   public async handleWebhook(webhook: WebhookDto): Promise<void> {
@@ -124,6 +126,7 @@ export class WebhookService {
     } catch (error) {
       const formattedError = formatAxiosError(error);
       this.logger.error('Webhook not sent', {
+        webhookId: webhook.id,
         error: formattedError,
       });
       throw new Error(formattedError.message);

--- a/packages/apps/fortune/exchange-oracle/server/typeorm.config.ts
+++ b/packages/apps/fortune/exchange-oracle/server/typeorm.config.ts
@@ -2,10 +2,13 @@ import { DataSource } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import * as dotenv from 'dotenv';
 
+import Environment from './src/common/utils/environment';
+
 dotenv.config({
-  path: process.env.NODE_ENV
-    ? `.env.${process.env.NODE_ENV as string}`
-    : '.env',
+  /**
+   * First value wins if "override" option is not set
+   */
+  path: [`.env.${Environment.name}`, '.env'],
 });
 
 export default new DataSource({

--- a/packages/apps/fortune/recording-oracle/Dockerfile
+++ b/packages/apps/fortune/recording-oracle/Dockerfile
@@ -16,6 +16,7 @@ COPY ${APP_PATH}/package.json ./${APP_PATH}/
 # so we need to copy and build them
 COPY packages/core ./packages/core
 COPY packages/sdk ./packages/sdk
+COPY packages/libs ./packages/libs
 
 RUN yarn install
 

--- a/packages/apps/fortune/recording-oracle/package.json
+++ b/packages/apps/fortune/recording-oracle/package.json
@@ -23,6 +23,7 @@
     "generate-env-doc": "ts-node scripts/generate-env-doc.ts"
   },
   "dependencies": {
+    "@human-protocol/logger": "workspace:*",
     "@human-protocol/sdk": "workspace:*",
     "@nestjs/axios": "^3.1.2",
     "@nestjs/common": "^10.2.7",

--- a/packages/apps/fortune/recording-oracle/scripts/setup-kv-store.ts
+++ b/packages/apps/fortune/recording-oracle/scripts/setup-kv-store.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { KVStoreClient, KVStoreKeys, Role } from '@human-protocol/sdk';
 import * as dotenv from 'dotenv';
 import { Wallet, ethers } from 'ethers';

--- a/packages/apps/fortune/recording-oracle/src/app.module.ts
+++ b/packages/apps/fortune/recording-oracle/src/app.module.ts
@@ -11,6 +11,7 @@ import { envValidator } from './common/config/env-schema';
 import { EnvConfigModule } from './common/config/config.module';
 import { TransformEnumInterceptor } from './common/interceptors/transform-enum.interceptor';
 import { ExceptionFilter } from './common/exceptions/exception.filter';
+import Environment from './common/utils/environment';
 
 @Module({
   providers: [
@@ -36,7 +37,7 @@ import { ExceptionFilter } from './common/exceptions/exception.filter';
       /**
        * First value found takes precendece
        */
-      envFilePath: [`.env.${process.env.NODE_ENV}`, '.env.local', '.env'],
+      envFilePath: [`.env.${Environment.name}`, '.env.local', '.env'],
       validationSchema: envValidator,
     }),
     JobModule,

--- a/packages/apps/fortune/recording-oracle/src/common/config/env-schema.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/config/env-schema.ts
@@ -2,7 +2,6 @@ import * as Joi from 'joi';
 
 export const envValidator = Joi.object({
   // General
-  NODE_ENV: Joi.string(),
   HOST: Joi.string(),
   PORT: Joi.string(),
   // Web3

--- a/packages/apps/fortune/recording-oracle/src/common/config/server-config.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/config/server-config.service.ts
@@ -6,14 +6,6 @@ export class ServerConfigService {
   constructor(private configService: ConfigService) {}
 
   /**
-   * The environment in which the server is running (e.g., 'development', 'production').
-   * Default: 'development'
-   */
-  get nodeEnv(): string {
-    return this.configService.get<string>('NODE_ENV', 'development');
-  }
-
-  /**
    * The hostname or IP address on which the server will run.
    * Default: 'localhost'
    */

--- a/packages/apps/fortune/recording-oracle/src/common/utils/environment.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/environment.ts
@@ -1,0 +1,25 @@
+enum EnvironmentName {
+  LOCAL = 'local',
+  DEVELOPMENT = 'development',
+  TEST = 'test',
+  STAGING = 'staging',
+}
+
+class Environment {
+  static readonly name: string =
+    process.env.NODE_ENV || EnvironmentName.DEVELOPMENT;
+
+  static isDevelopment(): boolean {
+    return [
+      EnvironmentName.DEVELOPMENT,
+      EnvironmentName.TEST,
+      EnvironmentName.LOCAL,
+    ].includes(Environment.name as EnvironmentName);
+  }
+
+  static isTest(): boolean {
+    return Environment.name === EnvironmentName.TEST;
+  }
+}
+
+export default Environment;

--- a/packages/apps/fortune/recording-oracle/src/common/utils/webhook.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/webhook.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { Logger } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
+
+import logger from '../../logger';
 import { WebhookDto } from '../../modules/webhook/webhook.dto';
 import { HEADER_SIGNATURE_KEY } from '../constants';
 import { CaseConverter } from './case-converter';
@@ -9,7 +10,6 @@ import { formatAxiosError } from './http';
 
 export async function sendWebhook(
   httpService: HttpService,
-  logger: Logger,
   webhookUrl: string,
   webhookBody: WebhookDto,
   privateKey: string,
@@ -25,6 +25,7 @@ export async function sendWebhook(
   } catch (error: any) {
     const formattedError = formatAxiosError(error);
     logger.error('Webhook not sent', {
+      webhookUrl,
       error: formattedError,
     });
     throw new Error(formattedError.message);

--- a/packages/apps/fortune/recording-oracle/src/logger/index.ts
+++ b/packages/apps/fortune/recording-oracle/src/logger/index.ts
@@ -1,0 +1,24 @@
+import { createLogger, NestLogger, LogLevel } from '@human-protocol/logger';
+
+import Environment from '../common/utils/environment';
+
+const isDevelopment = Environment.isDevelopment();
+
+const defaultLogger = createLogger(
+  {
+    name: 'DefaultLogger',
+    level: isDevelopment ? LogLevel.DEBUG : LogLevel.INFO,
+    pretty: isDevelopment,
+    disabled: Environment.isTest(),
+  },
+  {
+    environment: Environment.name,
+    service: 'fortune-recording-oracle',
+  },
+);
+
+export const nestLoggerOverride = new NestLogger(
+  defaultLogger.child({ name: 'NestLogger' }),
+);
+
+export default defaultLogger;

--- a/packages/apps/fortune/recording-oracle/src/main.ts
+++ b/packages/apps/fortune/recording-oracle/src/main.ts
@@ -1,17 +1,19 @@
+import { ConfigService } from '@nestjs/config';
+import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { json, urlencoded } from 'body-parser';
 import { useContainer } from 'class-validator';
 import helmet from 'helmet';
 
-import { INestApplication } from '@nestjs/common';
+import logger, { nestLoggerOverride } from './logger';
 import { AppModule } from './app.module';
 import { ServerConfigService } from './common/config/server-config.service';
-import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create<INestApplication>(AppModule, {
     cors: true,
+    logger: nestLoggerOverride,
   });
 
   const configService: ConfigService = app.get(ConfigService);
@@ -44,7 +46,7 @@ async function bootstrap() {
 
   await app.listen(port, host, async () => {
     // eslint-disable-next-line no-console
-    console.info(`API server is running on http://${host}:${port}`);
+    logger.info(`API server is running on http://${host}:${port}`);
   });
 }
 

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.module.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.module.ts
@@ -1,12 +1,12 @@
 import { HttpModule } from '@nestjs/axios';
-import { Logger, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { JobService } from './job.service';
 import { Web3Module } from '../web3/web3.module';
 import { StorageModule } from '../storage/storage.module';
 
 @Module({
   imports: [HttpModule, Web3Module, StorageModule],
-  providers: [Logger, JobService],
+  providers: [JobService],
   exports: [JobService],
 })
 export class JobModule {}

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
@@ -5,9 +5,11 @@ import {
   KVStoreUtils,
 } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ethers } from 'ethers';
 import * as Minio from 'minio';
+
+import logger from '../../logger';
 import { Web3ConfigService } from '../../common/config/web3-config.service';
 import { ErrorJob } from '../../common/constants/errors';
 import { JobRequestType, SolutionError } from '../../common/enums/job';
@@ -26,8 +28,8 @@ import {
 
 @Injectable()
 export class JobService {
-  public readonly logger = new Logger(JobService.name);
-  public readonly minioClient: Minio.Client;
+  private readonly logger = logger.child({ context: JobService.name });
+  readonly minioClient: Minio.Client;
 
   constructor(
     private web3ConfigService: Web3ConfigService,
@@ -86,16 +88,23 @@ export class JobService {
   }
 
   async processJobSolution(webhook: WebhookDto): Promise<string> {
+    const logger = this.logger.child({
+      action: 'processJobSolution',
+      chainId: webhook.chainId,
+      escrowAddress: webhook.escrowAddress,
+    });
     const signer = this.web3Service.getSigner(webhook.chainId);
     const escrowClient = await EscrowClient.build(signer);
 
     const recordingOracleAddress = await escrowClient.getRecordingOracleAddress(
       webhook.escrowAddress,
     );
-    if (
-      ethers.getAddress(recordingOracleAddress) !== (await signer.getAddress())
-    ) {
-      this.logger.log(ErrorJob.AddressMismatches, JobService.name);
+    const signerAddress = await signer.getAddress();
+    if (ethers.getAddress(recordingOracleAddress) !== signerAddress) {
+      logger.error(ErrorJob.AddressMismatches, {
+        recordingOracleAddress,
+        signerAddress,
+      });
       throw new ValidationError(ErrorJob.AddressMismatches);
     }
 
@@ -104,7 +113,9 @@ export class JobService {
       escrowStatus !== EscrowStatus.Pending &&
       escrowStatus !== EscrowStatus.Partial
     ) {
-      this.logger.log(ErrorJob.InvalidStatus, JobService.name);
+      logger.error(ErrorJob.InvalidStatus, {
+        escrowStatus,
+      });
       throw new ConflictError(ErrorJob.InvalidStatus);
     }
 
@@ -115,12 +126,17 @@ export class JobService {
       await this.storageService.download(manifestUrl);
 
     if (!submissionsRequired || !requestType) {
-      this.logger.log(ErrorJob.InvalidManifest, JobService.name);
+      logger.error(ErrorJob.InvalidManifest, {
+        submissionsRequired,
+        requestType,
+      });
       throw new ValidationError(ErrorJob.InvalidManifest);
     }
 
     if (requestType !== JobRequestType.FORTUNE) {
-      this.logger.log(ErrorJob.InvalidJobType, JobService.name);
+      logger.error(ErrorJob.InvalidJobType, {
+        requestType,
+      });
       throw new ValidationError(ErrorJob.InvalidJobType);
     }
 
@@ -135,10 +151,10 @@ export class JobService {
     }
 
     if (existingJobSolutions.length >= submissionsRequired) {
-      this.logger.log(
-        ErrorJob.AllSolutionsHaveAlreadyBeenSent,
-        JobService.name,
-      );
+      logger.warn(ErrorJob.AllSolutionsHaveAlreadyBeenSent, {
+        submissionsRequired,
+        nExistingJobSolutions: existingJobSolutions.length,
+      });
       throw new ConflictError(ErrorJob.AllSolutionsHaveAlreadyBeenSent);
     }
 
@@ -189,7 +205,6 @@ export class JobService {
       if (reputationOracleWebhook) {
         await sendWebhook(
           this.httpService,
-          this.logger,
           reputationOracleWebhook,
           {
             chainId: webhook.chainId,
@@ -232,7 +247,6 @@ export class JobService {
 
         await sendWebhook(
           this.httpService,
-          this.logger,
           exchangeOracleURL,
           webhookBody,
           this.web3ConfigService.privateKey,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,6 +4194,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@human-protocol/fortune-recording-oracle@workspace:packages/apps/fortune/recording-oracle"
   dependencies:
+    "@human-protocol/logger": "workspace:*"
     "@human-protocol/sdk": "workspace:*"
     "@nestjs/axios": "npm:^3.1.2"
     "@nestjs/cli": "npm:^10.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4134,6 +4134,7 @@ __metadata:
   resolution: "@human-protocol/fortune-exchange-oracle-server@workspace:packages/apps/fortune/exchange-oracle/server"
   dependencies:
     "@golevelup/ts-jest": "npm:^0.6.1"
+    "@human-protocol/logger": "workspace:*"
     "@human-protocol/sdk": "workspace:*"
     "@nestjs/axios": "npm:^3.1.2"
     "@nestjs/cli": "npm:^10.3.2"


### PR DESCRIPTION
## Issue tracking
Follow up to #3387

## Context behind the change
Added shared logger to Fortune for ease of debugging on staging.

## How has this been tested?
- [x] run services locally and check logs format
- [x] run services in Docker and check logs format

## Release plan
- [x] update `NODE_ENV` on render for Fortune services to correspond to actual environment (`staging`)
- [ ] enable logs sending from Fortune services -> DataDog on Render

## Potential risks; What to monitor; Rollback plan
Check that logs are displayed correctly in DD.