### PR TITLE
[Job Launcher] Fix rate limit

### DIFF
--- a/packages/apps/job-launcher/server/src/main.ts
+++ b/packages/apps/job-launcher/server/src/main.ts
@@ -1,4 +1,3 @@
-import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 
@@ -9,9 +8,10 @@ import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { ServerConfigService } from './common/config/server-config.service';
 import logger, { nestLoggerOverride } from './logger';
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
-  const app = await NestFactory.create<INestApplication>(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     cors: {
       exposedHeaders: ['Content-Disposition'],
     },
@@ -19,6 +19,7 @@ async function bootstrap() {
   });
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
 
+  app.set('trust proxy', 2);
   app.use(json({ limit: '5mb' }));
   app.use(urlencoded({ limit: '5mb', extended: true }));
 


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
Change application type to NestExpressApplication and set trust proxy.
Since we're using cloudflare and render, requests are going through 2 different proxies, so rate limits were not being applied.

## How has this been tested?
Launched 4 different requests till I receive `Too many requests` error

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None