### PR TITLE
[Job Launcher] fix: do not log non-5xx errors

### DIFF
--- a/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
@@ -36,10 +36,11 @@ export class ExceptionFilter implements IExceptionFilter {
       return HttpStatus.UNPROCESSABLE_ENTITY;
     } else if (exception instanceof DatabaseError) {
       return HttpStatus.UNPROCESSABLE_ENTITY;
-    } else if (exception.statusCode) {
-      return exception.statusCode;
     }
-    return HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const exceptionStatusCode = exception.statusCode || exception.status;
+
+    return exceptionStatusCode || HttpStatus.INTERNAL_SERVER_ERROR;
   }
 
   catch(exception: any, host: ArgumentsHost) {


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/humanprotocol/human-protocol/pull/3497

## Context behind the change
JL in case of errors doesn't handle status code properly, which leads to wrong status code and exception logging.

## How has this been tested?
- [x] existing tests pass (no need in extra tests, same fix as for Fortune services)

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No