### PR TITLE
feat: improve unhandled exceptions logging

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -52,7 +52,10 @@ export class ExceptionFilter implements IExceptionFilter {
     const message = exception.message || 'Internal server error';
 
     if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
-      this.logger.error('Unhandled exception', exception);
+      this.logger.error('Unhandled exception', {
+        error: exception,
+        path: request.url,
+      });
     }
 
     response.removeHeader('Cache-Control');

--- a/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
@@ -49,7 +49,10 @@ export class ExceptionFilter implements IExceptionFilter {
     const message = exception.message || 'Internal server error';
 
     if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
-      this.logger.error('Unhandled exception', exception);
+      this.logger.error('Unhandled exception', {
+        error: exception,
+        path: request.url,
+      });
     }
 
     response.removeHeader('Cache-Control');

--- a/packages/apps/human-app/server/src/common/filter/exceptions.filter.ts
+++ b/packages/apps/human-app/server/src/common/filter/exceptions.filter.ts
@@ -16,6 +16,7 @@ export class ExceptionFilter implements IExceptionFilter {
   catch(exception: any, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
+    const request = ctx.getRequest();
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message: any = 'Internal Server Error';
@@ -31,12 +32,17 @@ export class ExceptionFilter implements IExceptionFilter {
       let formattedError = exception;
       if (exception instanceof AxiosError) {
         formattedError = errorUtils.formatError(exception);
+        formattedError.outgoingRequestUrl = exception.config?.url;
       }
-      this.logger.error('Unhandled exception', formattedError);
+      this.logger.error('Unhandled exception', {
+        error: formattedError,
+        path: request.url,
+      });
     }
 
     if (typeof status !== 'number' || status < 100 || status >= 600) {
       this.logger.error('Invalid status code in exception filter', {
+        path: request.url,
         status,
       });
       status = HttpStatus.INTERNAL_SERVER_ERROR;

--- a/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
@@ -52,7 +52,10 @@ export class ExceptionFilter implements IExceptionFilter {
     const message = exception.message || 'Internal server error';
 
     if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
-      this.logger.error('Unhandled exception', exception);
+      this.logger.error('Unhandled exception', {
+        error: exception,
+        path: request.url,
+      });
     }
 
     response.removeHeader('Cache-Control');

--- a/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
@@ -56,7 +56,10 @@ export class ExceptionFilter implements IExceptionFilter {
         );
       }
     } else {
-      this.logger.error('Unhandled exception', exception);
+      this.logger.error('Unhandled exception', {
+        error: exception,
+        path: request.url,
+      });
     }
 
     response.removeHeader('Cache-Control');


### PR DESCRIPTION
## Issue tracking
Freestyle.

## Context behind the change
- added request url to unhandled exception logs so we can see on which route it takes place
- now logging of unhandled Axios errors in HUMAN App also includes the outgoing request url, so we can see what is the external resource that might have potential issue (recently we got alerts about CA errors, but can't see what is the source)

## How has this been tested?
- [x] existing unit tests build and pass; no need for extra tests since it just changes logs format

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No