### PR TITLE
[HUMAN App] fix: refetch hCaptcha stats once user solved captcha

### DIFF
--- a/packages/apps/human-app/frontend/src/modules/worker/hcaptcha-labeling/hooks/use-solve-hcaptcha-mutation.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/hcaptcha-labeling/hooks/use-solve-hcaptcha-mutation.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { ResponseError } from '@/shared/types/global.type';
 import * as hCaptchaLabelingService from '../services/hcaptcha-labeling.service';
 import { type VerifyHCaptchaLabelingBody } from '../types';
@@ -7,14 +7,22 @@ export function useSolveHCaptchaMutation(callbacks: {
   onSuccess: () => void | Promise<void>;
   onError: (error: ResponseError) => void | Promise<void>;
 }) {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (data: VerifyHCaptchaLabelingBody) =>
       hCaptchaLabelingService.verifyHCaptchaLabeling(data),
-    onSuccess: async () => {
-      await callbacks.onSuccess();
+    onSuccess: () => {
+      void callbacks.onSuccess();
+      void queryClient.invalidateQueries({
+        queryKey: ['getHCaptchaUsersStats'],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['dailyHmtSpent'],
+      });
     },
-    onError: async (error) => {
-      await callbacks.onError(error);
+    onError: (error) => {
+      void callbacks.onError(error);
     },
   });
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
React-query doesn't re-refetch data unless its query is stale (that could be achieved by `invalidateQuery` call) or `refetch` called directly. In https://github.com/humanprotocol/human-protocol/pull/3484 we removed `invalidateQuery` calls that were invalidating all queries, leaving only those that necessary, but missed the one for hCaptcha stats and it led to a situation where users stats are not updated and captcha is unintentionally available. Invalidate these queries now and re-fetch stats (according to server caching policies)

## How has this been tested?
- [x] check that stats re-fetched on Vercel

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Monitor hCaptcha labeling for a couple of days.