### PR TITLE
[Reputation Oracle] feat: validate restore password token as uuid

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/validators/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/validators/index.ts
@@ -1,6 +1,13 @@
 import { applyDecorators } from '@nestjs/common';
 import { Transform } from 'class-transformer';
-import { IsEmail, IsEnum, ValidationOptions } from 'class-validator';
+import {
+  IsEmail,
+  IsEnum,
+  IsString,
+  MaxLength,
+  MinLength,
+  ValidationOptions,
+} from 'class-validator';
 
 export * from './password';
 export * from './web3';
@@ -28,6 +35,18 @@ export function IsLowercasedEnum(
         return value.map((v: string) => v.toLowerCase());
       }
       return value.toLowerCase();
+    }),
+  );
+}
+
+export function IsValidPassword() {
+  return applyDecorators(
+    IsString(),
+    MinLength(8, {
+      message: 'Password must be at least 8 characters long.',
+    }),
+    MaxLength(128, {
+      message: 'Password must be at most 128 characters',
     }),
   );
 }

--- a/packages/apps/reputation-oracle/server/src/modules/auth/dto/password.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/dto/password.dto.ts
@@ -1,6 +1,6 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MinLength } from 'class-validator';
+import { IsString, IsUUID, MinLength } from 'class-validator';
 
 import { IsLowercasedEmail } from '@/common/validators';
 
@@ -29,7 +29,7 @@ export class RestorePasswordDto {
   password: string;
 
   @ApiProperty()
-  @IsString()
+  @IsUUID()
   token: string;
 
   @ApiProperty({ name: 'h_captcha_token' })

--- a/packages/apps/reputation-oracle/server/src/modules/auth/dto/password.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/dto/password.dto.ts
@@ -1,17 +1,7 @@
-import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsUUID, MinLength } from 'class-validator';
+import { IsString, IsUUID } from 'class-validator';
 
-import { IsLowercasedEmail } from '@/common/validators';
-
-export function ValidPassword() {
-  return applyDecorators(
-    IsString(),
-    MinLength(8, {
-      message: 'Password must be at least 8 characters long.',
-    }),
-  );
-}
+import { IsLowercasedEmail, IsValidPassword } from '@/common/validators';
 
 export class ForgotPasswordDto {
   @ApiProperty()
@@ -25,7 +15,7 @@ export class ForgotPasswordDto {
 
 export class RestorePasswordDto {
   @ApiProperty()
-  @ValidPassword()
+  @IsValidPassword()
   password: string;
 
   @ApiProperty()

--- a/packages/apps/reputation-oracle/server/src/modules/auth/dto/sign-in.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/dto/sign-in.dto.ts
@@ -1,7 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsEthereumAddress, IsOptional, IsString } from 'class-validator';
 
-import { IsLowercasedEmail, IsValidWeb3Signature } from '@/common/validators';
+import {
+  IsLowercasedEmail,
+  IsValidPassword,
+  IsValidWeb3Signature,
+} from '@/common/validators';
 
 export class Web2SignInDto {
   @ApiProperty()
@@ -9,7 +13,7 @@ export class Web2SignInDto {
   email: string;
 
   @ApiProperty()
-  @IsString()
+  @IsValidPassword()
   password: string;
 
   @ApiPropertyOptional({ name: 'h_captcha_token' })

--- a/packages/apps/reputation-oracle/server/src/modules/auth/dto/sign-up.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/auth/dto/sign-up.dto.ts
@@ -5,10 +5,9 @@ import { UserRole } from '@/common/enums';
 import {
   IsLowercasedEmail,
   IsLowercasedEnum,
+  IsValidPassword,
   IsValidWeb3Signature,
 } from '@/common/validators';
-
-import { ValidPassword } from './password.dto';
 
 export class Web2SignUpDto {
   @ApiProperty()
@@ -16,7 +15,7 @@ export class Web2SignUpDto {
   email: string;
 
   @ApiProperty()
-  @ValidPassword()
+  @IsValidPassword()
   password: string;
 
   @ApiProperty({ name: 'h_captcha_token' })

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.controller.ts
@@ -28,7 +28,7 @@ import {
   DisableOperatorDto,
   PrepareSignatureDto,
   RegisterAddressRequestDto,
-  SignatureBodyDto,
+  PreparedSignatureResponseDto,
   RegisterLabelerResponseDto,
   EnableOperatorDto,
   RegistrationInExchangeOracleDto,
@@ -146,14 +146,14 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: 'Typed structured data object generated successfully',
-    type: SignatureBodyDto,
+    type: PreparedSignatureResponseDto,
   })
   @Public()
   @Post('/prepare-signature')
   @HttpCode(200)
   async prepareSignature(
     @Body() data: PrepareSignatureDto,
-  ): Promise<SignatureBodyDto> {
+  ): Promise<PreparedSignatureResponseDto> {
     let nonce: string | undefined;
     if (data.type === SignatureType.SIGNIN) {
       const user = await this.userService.findOperatorUser(data.address);

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEthereumAddress, IsOptional, IsString } from 'class-validator';
+import { IsEthereumAddress, IsString } from 'class-validator';
 
 import { SignatureType } from '@/common/enums';
 import { IsLowercasedEnum, IsValidWeb3Signature } from '@/common/validators';
@@ -31,25 +31,6 @@ export class DisableOperatorDto {
   signature: string;
 }
 
-export class SignatureBodyDto {
-  @ApiProperty()
-  @IsEthereumAddress()
-  from: string;
-
-  @ApiProperty()
-  @IsEthereumAddress()
-  to: string;
-
-  @ApiProperty()
-  @IsString()
-  contents: string;
-
-  @ApiProperty()
-  @IsOptional()
-  @IsString()
-  nonce?: string | undefined;
-}
-
 export class PrepareSignatureDto {
   @ApiProperty()
   @IsEthereumAddress()
@@ -60,6 +41,20 @@ export class PrepareSignatureDto {
   })
   @IsLowercasedEnum(SignatureType)
   type: SignatureType;
+}
+
+export class PreparedSignatureResponseDto {
+  @ApiProperty()
+  from: string;
+
+  @ApiProperty()
+  to: string;
+
+  @ApiProperty()
+  contents: string;
+
+  @ApiProperty()
+  nonce?: string | undefined;
 }
 
 export class RegistrationInExchangeOracleDto {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Token can be sent as any string, which leads to querying DB with weird values in case if somebody tries to send them and it ends up in unhandled exception. To address it - added uuid format validation.
Also tightened password validation.

> [!NOTE]
> Interesting finding while testing: `class-validator` uses `validator` library under the hood and it validates uuid not just for "uuid-like" string (it can be achieved with `loose` version param), but for actual value, so `hCaptchaToken` that is used for development is invalid because it doesn't correspond to RFC of uuid.

## How has this been tested?
- [x] e2e locally: send weird value and make sure only `uuid` can pass

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No