### PR TITLE
chore: bump changed packages version

### DIFF
--- a/.changeset/grumpy-hotels-help.md
+++ b/.changeset/grumpy-hotels-help.md
@@ -1,7 +1,0 @@
----
-'@human-protocol/sdk': patch
-'@human-protocol/logger': patch
-'@human-protocol/core': patch
----
-
-chore: changesets added for better release management

--- a/.changeset/metal-fans-lay.md
+++ b/.changeset/metal-fans-lay.md
@@ -1,5 +1,0 @@
----
-"@human-protocol/sdk": minor
----
-
-feat: read kvstore data using kvstore client

--- a/.changeset/petite-comics-float.md
+++ b/.changeset/petite-comics-float.md
@@ -1,5 +1,0 @@
----
-'@human-protocol/sdk': minor
----
-
-chore: use exact core dep version for sdk

--- a/.changeset/plenty-melons-fetch.md
+++ b/.changeset/plenty-melons-fetch.md
@@ -1,5 +1,0 @@
----
-"@human-protocol/sdk": patch
----
-
-feat: fixed gas price on aurora testnet

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@human-protocol/core",
   "description": "Human Protocol Core Smart Contracts",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "files": [
     "contracts/**/*.sol",
     "abis/**/*.json",

--- a/packages/libs/logger/package.json
+++ b/packages/libs/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@human-protocol/logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Unified logging package for HUMAN Protocol",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/packages/sdk/typescript/human-protocol-sdk/package.json
+++ b/packages/sdk/typescript/human-protocol-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@human-protocol/sdk",
   "description": "Human Protocol SDK",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Used `yarn changeset version` to bump packages for upcoming release

## How has this been tested?
- [x] checked new versions are correct

## Release plan
Merge. Publish packages via new GitHub action

## Potential risks; What to monitor; Rollback plan
As mentioned in [parent PR](https://github.com/humanprotocol/human-protocol/pull/3539)