### PR TITLE
Invalid property name in API validation messages

### DIFF
--- a/packages/apps/dashboard/server/src/modules/details/dto/validation/role-validation.ts
+++ b/packages/apps/dashboard/server/src/modules/details/dto/validation/role-validation.ts
@@ -12,7 +12,7 @@ export class IsValidRoleConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage() {
-    return `Role must be one of the following values: ${Object.values(
+    return `role must be one of the following values: ${Object.values(
       Role,
     ).join(', ')}`;
   }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/errors/index.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/errors/index.ts
@@ -11,8 +11,10 @@ export class BaseError extends Error {
 }
 
 export class ValidationError extends BaseError {
-  constructor(message: string, stack?: string) {
+  public errors?: string[];
+  constructor(message: string, stack?: string, errors?: string[]) {
     super(message, stack);
+    this.errors = errors;
   }
 }
 

--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -60,11 +60,15 @@ export class ExceptionFilter implements IExceptionFilter {
 
     response.removeHeader('Cache-Control');
 
-    response.status(status).json({
+    const payload: any = {
       status_code: status,
       timestamp: new Date().toISOString(),
       message: message,
       path: request.url,
-    });
+    };
+    if (exception instanceof ValidationError && exception.errors?.length) {
+      payload.validation_errors = exception.errors;
+    }
+    response.status(status).json(payload);
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/interceptors/snake-case.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/interceptors/snake-case.ts
@@ -6,7 +6,10 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { CaseConverter } from '../utils/case-converter';
+import {
+  transformKeysFromCamelToSnake,
+  transformKeysFromSnakeToCamel,
+} from '../utils/case-converter';
 
 @Injectable()
 export class SnakeCaseInterceptor implements NestInterceptor {
@@ -14,15 +17,15 @@ export class SnakeCaseInterceptor implements NestInterceptor {
     const request = context.switchToHttp().getRequest();
 
     if (request.body) {
-      request.body = CaseConverter.transformToCamelCase(request.body);
+      request.body = transformKeysFromSnakeToCamel(request.body);
     }
 
     if (request.query) {
-      request.query = CaseConverter.transformToCamelCase(request.query);
+      request.query = transformKeysFromSnakeToCamel(request.query);
     }
 
     return next
       .handle()
-      .pipe(map((data) => CaseConverter.transformToSnakeCase(data)));
+      .pipe(map((data) => transformKeysFromCamelToSnake(data)));
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
@@ -5,6 +5,7 @@ import {
   ValidationPipeOptions,
 } from '@nestjs/common';
 import { ValidationError } from '../errors';
+import { CaseConverter } from '../utils/case-converter';
 
 @Injectable()
 export class HttpValidationPipe extends ValidationPipe {
@@ -20,30 +21,23 @@ export class HttpValidationPipe extends ValidationPipe {
     });
   }
 
-  private formatErrorsSnakeCase(
-    errors: ValidError[],
-    parentPath?: string,
-  ): string[] {
-    const out: string[] = [];
-    for (const err of errors) {
-      const currentProp = err.property
-        ? err.property.replace(/([A-Z])/g, '_$1').toLowerCase()
-        : '';
-      const path = [parentPath, currentProp].filter(Boolean).join('.');
+  private formatErrorsSnakeCase(errors: ValidError[]): string[] {
+    const rawMessages = this.flattenValidationErrors(errors);
+    return rawMessages.map((msg) => {
+      const firstSpace = msg.indexOf(' ');
+      if (firstSpace === -1) return msg;
 
-      if (err.constraints) {
-        for (const msg of Object.values(err.constraints)) {
-          const adjusted = err.property
-            ? msg.replace(new RegExp(`^${err.property}\\s+`, 'i'), '')
-            : msg;
-          out.push(path ? `${path} ${adjusted}` : adjusted);
-        }
-      }
+      const rawPath = msg.slice(0, firstSpace);
+      const rest = msg.slice(firstSpace + 1);
 
-      if (err.children && err.children.length) {
-        out.push(...this.formatErrorsSnakeCase(err.children, path));
-      }
-    }
-    return out;
+      const transformedPath = rawPath
+        .split('.')
+        .map((segment) =>
+          segment.replace(/^[A-Za-z0-9_]+/, CaseConverter.transformToSnakeCase),
+        )
+        .join('.');
+
+      return `${transformedPath} ${rest}`;
+    });
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
@@ -22,20 +22,12 @@ export class HttpValidationPipe extends ValidationPipe {
   }
 
   private formatErrorsSnakeCase(errors: ValidError[]): string[] {
-    const rawMessages = this.flattenValidationErrors(errors);
-    return rawMessages.map((msg) => {
-      const firstSpace = msg.indexOf(' ');
-      if (firstSpace === -1) return msg;
-
-      const rawPath = msg.slice(0, firstSpace);
-      const rest = msg.slice(firstSpace + 1);
-
-      const transformedPath = rawPath
-        .split('.')
-        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
-        .join('.');
-
-      return `${transformedPath} ${rest}`;
-    });
+    return errors
+      .flatMap((error) => this.mapChildrenToValidationErrors(error))
+      .flatMap((error) =>
+        Object.values(error.constraints || {}).map((msg) =>
+          msg.replace(error.property, camelToSnake(error.property)),
+        ),
+      );
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
@@ -5,7 +5,7 @@ import {
   ValidationPipeOptions,
 } from '@nestjs/common';
 import { ValidationError } from '../errors';
-import { CaseConverter } from '../utils/case-converter';
+import { camelToSnake } from '../utils/case-converter';
 
 @Injectable()
 export class HttpValidationPipe extends ValidationPipe {
@@ -32,9 +32,7 @@ export class HttpValidationPipe extends ValidationPipe {
 
       const transformedPath = rawPath
         .split('.')
-        .map((segment) =>
-          segment.replace(/^[A-Za-z0-9_]+/, CaseConverter.transformToSnakeCase),
-        )
+        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
         .join('.');
 
       return `${transformedPath} ${rest}`;

--- a/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/pipes/validation.ts
@@ -11,12 +11,39 @@ export class HttpValidationPipe extends ValidationPipe {
   constructor(options?: ValidationPipeOptions) {
     super({
       exceptionFactory: (errors: ValidError[]): ValidationError => {
-        const flattenErrors = this.flattenValidationErrors(errors);
-        throw new ValidationError(flattenErrors.join(', '));
+        const messages = this.formatErrorsSnakeCase(errors);
+        throw new ValidationError('Validation error', undefined, messages);
       },
       transform: true,
       whitelist: true,
       ...options,
     });
+  }
+
+  private formatErrorsSnakeCase(
+    errors: ValidError[],
+    parentPath?: string,
+  ): string[] {
+    const out: string[] = [];
+    for (const err of errors) {
+      const currentProp = err.property
+        ? err.property.replace(/([A-Z])/g, '_$1').toLowerCase()
+        : '';
+      const path = [parentPath, currentProp].filter(Boolean).join('.');
+
+      if (err.constraints) {
+        for (const msg of Object.values(err.constraints)) {
+          const adjusted = err.property
+            ? msg.replace(new RegExp(`^${err.property}\\s+`, 'i'), '')
+            : msg;
+          out.push(path ? `${path} ${adjusted}` : adjusted);
+        }
+      }
+
+      if (err.children && err.children.length) {
+        out.push(...this.formatErrorsSnakeCase(err.children, path));
+      }
+    }
+    return out;
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/common/utils/case-converter.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/utils/case-converter.spec.ts
@@ -1,0 +1,173 @@
+import { faker } from '@faker-js/faker';
+
+import * as CaseConverter from './case-converter';
+
+describe('Case converting utilities', () => {
+  describe('transformKeysFromSnakeToCamel', () => {
+    it.each([
+      'string',
+      42,
+      BigInt(0),
+      new Date(),
+      Symbol('test'),
+      true,
+      null,
+      undefined,
+    ])('should not transform basic value [%#]', (value: unknown) => {
+      expect(CaseConverter.transformKeysFromSnakeToCamel(value)).toEqual(value);
+    });
+
+    it('should not transform simple array', () => {
+      const input = faker.helpers.multiple(() => faker.string.sample());
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual(input);
+    });
+
+    it('should transform array of objects', () => {
+      const input = faker.helpers.multiple(() => ({
+        test_case: faker.string.sample(),
+      }));
+      const expectedOutput = input.map((v) => ({
+        testCase: v.test_case,
+      }));
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('should transform plain object to camelCase', () => {
+      const input = {
+        random_string: faker.string.sample(),
+        random_number: faker.number.float(),
+        random_boolean: faker.datatype.boolean(),
+        always_null: null,
+      };
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual({
+        randomString: input.random_string,
+        randomNumber: input.random_number,
+        randomBoolean: input.random_boolean,
+        alwaysNull: null,
+      });
+    });
+
+    it('should transform input with nested data', () => {
+      const randomString = faker.string.sample();
+
+      const input = {
+        nested_object: {
+          with_array: [
+            {
+              of_objects: {
+                with_random_string: randomString,
+              },
+            },
+          ],
+        },
+      };
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual({
+        nestedObject: {
+          withArray: [
+            {
+              ofObjects: {
+                withRandomString: randomString,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('transformKeysFromCamelToSnake', () => {
+    it.each([
+      'string',
+      42,
+      BigInt(0),
+      new Date(),
+      Symbol('test'),
+      true,
+      null,
+      undefined,
+    ])('should not transform primitive [%#]', (value: unknown) => {
+      expect(CaseConverter.transformKeysFromCamelToSnake(value)).toEqual(value);
+    });
+
+    it('should not transform simple array', () => {
+      const input = faker.helpers.multiple(() => faker.string.sample());
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual(input);
+    });
+
+    it('should transform array of objects', () => {
+      const input = faker.helpers.multiple(() => ({
+        testCase: faker.string.sample(),
+      }));
+      const expectedOutput = input.map((v) => ({
+        test_case: v.testCase,
+      }));
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('should transform plain object to camelCase', () => {
+      const input = {
+        randomString: faker.string.sample(),
+        randomNumber: faker.number.float(),
+        randomBoolean: faker.datatype.boolean(),
+        alwaysNull: null,
+      };
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual({
+        random_string: input.randomString,
+        random_number: input.randomNumber,
+        random_boolean: input.randomBoolean,
+        always_null: null,
+      });
+    });
+
+    it('should transform input with nested data', () => {
+      const randomString = faker.string.sample();
+
+      const input = {
+        nestedObject: {
+          withArray: [
+            {
+              ofObjects: {
+                withRandomString: randomString,
+              },
+            },
+          ],
+        },
+      };
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual({
+        nested_object: {
+          with_array: [
+            {
+              of_objects: {
+                with_random_string: randomString,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/packages/apps/fortune/exchange-oracle/server/src/common/utils/case-converter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/utils/case-converter.ts
@@ -1,37 +1,50 @@
 export class CaseConverter {
-  static transformToCamelCase(obj: any): any {
-    if (Array.isArray(obj)) {
-      return obj.map((item) => CaseConverter.transformToCamelCase(item));
-    } else if (typeof obj === 'object' && obj !== null) {
-      return Object.keys(obj).reduce(
+  static transformToCamelCase(input: any): any {
+    if (typeof input === 'string') {
+      return input.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+    } else if (Array.isArray(input)) {
+      return input.map((item) => CaseConverter.transformToCamelCase(item));
+    } else if (typeof input === 'object' && input !== null) {
+      return Object.keys(input).reduce(
         (acc: Record<string, any>, key: string) => {
           const camelCaseKey = key.replace(/_([a-z])/g, (g) =>
             g[1].toUpperCase(),
           );
-          acc[camelCaseKey] = CaseConverter.transformToCamelCase(obj[key]);
+          acc[camelCaseKey] = CaseConverter.transformToCamelCase(input[key]);
           return acc;
         },
         {},
       );
     } else {
-      return obj;
+      return input;
     }
   }
 
-  static transformToSnakeCase(obj: any): any {
-    if (Array.isArray(obj)) {
-      return obj.map((item) => CaseConverter.transformToSnakeCase(item));
-    } else if (typeof obj === 'object' && obj !== null) {
-      return Object.keys(obj).reduce(
+  static transformToSnakeCase(input: any): any {
+    function camelToSnakeKey(id: string): string {
+      if (!id) return id;
+      const parts = id
+        .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .split(/[\s_-]+/)
+        .filter(Boolean);
+      return parts.map((p) => p.toLowerCase()).join('_');
+    }
+    if (typeof input === 'string') {
+      return camelToSnakeKey(input);
+    } else if (Array.isArray(input)) {
+      return input.map((item) => CaseConverter.transformToSnakeCase(item));
+    } else if (typeof input === 'object' && input !== null) {
+      return Object.keys(input).reduce(
         (acc: Record<string, any>, key: string) => {
-          const snakeCaseKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
-          acc[snakeCaseKey] = CaseConverter.transformToSnakeCase(obj[key]);
+          const snakeCaseKey = camelToSnakeKey(key);
+          acc[snakeCaseKey] = CaseConverter.transformToSnakeCase(input[key]);
           return acc;
         },
         {},
       );
     } else {
-      return obj;
+      return input;
     }
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/webhook/webhook.service.ts
@@ -11,7 +11,7 @@ import { HEADER_SIGNATURE_KEY } from '../../common/constant';
 import { ErrorWebhook } from '../../common/constant/errors';
 import { EventType, WebhookStatus } from '../../common/enums/webhook';
 import { ValidationError } from '../../common/errors';
-import { CaseConverter } from '../../common/utils/case-converter';
+import { transformKeysFromCamelToSnake } from '../../common/utils/case-converter';
 import { formatAxiosError } from '../../common/utils/http';
 import { signMessage } from '../../common/utils/signature';
 import { JobService } from '../job/job.service';
@@ -107,7 +107,7 @@ export class WebhookService {
         reason: webhook.failureDetail,
       };
     }
-    const transformedWebhook = CaseConverter.transformToSnakeCase(webhookData);
+    const transformedWebhook: any = transformKeysFromCamelToSnake(webhookData);
 
     const signedBody = await signMessage(
       transformedWebhook,

--- a/packages/apps/fortune/recording-oracle/src/common/errors/index.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/errors/index.ts
@@ -9,8 +9,10 @@ export class BaseError extends Error {
 }
 
 export class ValidationError extends BaseError {
-  constructor(message: string, stack?: string) {
+  public errors?: string[];
+  constructor(message: string, stack?: string, errors?: string[]) {
     super(message, stack);
+    this.errors = errors;
   }
 }
 

--- a/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
@@ -57,11 +57,15 @@ export class ExceptionFilter implements IExceptionFilter {
 
     response.removeHeader('Cache-Control');
 
-    response.status(status).json({
+    const payload: any = {
       status_code: status,
       timestamp: new Date().toISOString(),
       message: message,
       path: request.url,
-    });
+    };
+    if (exception instanceof ValidationError && exception.errors?.length) {
+      payload.validation_errors = exception.errors;
+    }
+    response.status(status).json(payload);
   }
 }

--- a/packages/apps/fortune/recording-oracle/src/common/interceptors/snake-case.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/interceptors/snake-case.ts
@@ -6,7 +6,10 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { CaseConverter } from '../utils/case-converter';
+import {
+  transformKeysFromCamelToSnake,
+  transformKeysFromSnakeToCamel,
+} from '../utils/case-converter';
 
 @Injectable()
 export class SnakeCaseInterceptor implements NestInterceptor {
@@ -14,15 +17,15 @@ export class SnakeCaseInterceptor implements NestInterceptor {
     const request = context.switchToHttp().getRequest();
 
     if (request.body) {
-      request.body = CaseConverter.transformToCamelCase(request.body);
+      request.body = transformKeysFromSnakeToCamel(request.body);
     }
 
     if (request.query) {
-      request.query = CaseConverter.transformToCamelCase(request.query);
+      request.query = transformKeysFromSnakeToCamel(request.query);
     }
 
     return next
       .handle()
-      .pipe(map((data) => CaseConverter.transformToSnakeCase(data)));
+      .pipe(map((data) => transformKeysFromCamelToSnake(data)));
   }
 }

--- a/packages/apps/fortune/recording-oracle/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/pipes/validation.ts
@@ -1,11 +1,11 @@
 import {
   Injectable,
-  ValidationError as ValidError,
   ValidationPipe,
   ValidationPipeOptions,
+  ValidationError as ValidError,
 } from '@nestjs/common';
 import { ValidationError } from '../errors';
-import { CaseConverter } from '../utils/case-converter';
+import { camelToSnake } from '../utils/case-converter';
 
 @Injectable()
 export class HttpValidationPipe extends ValidationPipe {
@@ -34,9 +34,7 @@ export class HttpValidationPipe extends ValidationPipe {
 
       const transformedPath = rawPath
         .split('.')
-        .map((segment) =>
-          segment.replace(/^[A-Za-z0-9_]+/, CaseConverter.transformToSnakeCase),
-        )
+        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
         .join('.');
 
       return `${transformedPath} ${rest}`;

--- a/packages/apps/fortune/recording-oracle/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/pipes/validation.ts
@@ -24,20 +24,12 @@ export class HttpValidationPipe extends ValidationPipe {
   }
 
   private formatErrorsSnakeCase(errors: ValidError[]): string[] {
-    const rawMessages = this.flattenValidationErrors(errors);
-    return rawMessages.map((msg) => {
-      const firstSpace = msg.indexOf(' ');
-      if (firstSpace === -1) return msg;
-
-      const rawPath = msg.slice(0, firstSpace);
-      const rest = msg.slice(firstSpace + 1);
-
-      const transformedPath = rawPath
-        .split('.')
-        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
-        .join('.');
-
-      return `${transformedPath} ${rest}`;
-    });
+    return errors
+      .flatMap((error) => this.mapChildrenToValidationErrors(error))
+      .flatMap((error) =>
+        Object.values(error.constraints || {}).map((msg) =>
+          msg.replace(error.property, camelToSnake(error.property)),
+        ),
+      );
   }
 }

--- a/packages/apps/fortune/recording-oracle/src/common/pipes/validation.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/pipes/validation.ts
@@ -11,8 +11,8 @@ export class HttpValidationPipe extends ValidationPipe {
   constructor(options?: ValidationPipeOptions) {
     super({
       exceptionFactory: (errors: ValidError[]): ValidationError => {
-        const flattenErrors = this.flattenValidationErrors(errors);
-        throw new ValidationError(flattenErrors.join(', '));
+        const messages = this.formatErrorsSnakeCase(errors);
+        throw new ValidationError('Validation error', undefined, messages);
       },
       transform: true,
       whitelist: true,
@@ -20,5 +20,32 @@ export class HttpValidationPipe extends ValidationPipe {
       forbidUnknownValues: true,
       ...options,
     });
+  }
+
+  private formatErrorsSnakeCase(
+    errors: ValidError[],
+    parentPath?: string,
+  ): string[] {
+    const out: string[] = [];
+    for (const err of errors) {
+      const currentProp = err.property
+        ? err.property.replace(/([A-Z])/g, '_$1').toLowerCase()
+        : '';
+      const path = [parentPath, currentProp].filter(Boolean).join('.');
+
+      if (err.constraints) {
+        for (const msg of Object.values(err.constraints)) {
+          const adjusted = err.property
+            ? msg.replace(new RegExp(`^${err.property}\\s+`, 'i'), '')
+            : msg;
+          out.push(path ? `${path} ${adjusted}` : adjusted);
+        }
+      }
+
+      if (err.children && err.children.length) {
+        out.push(...this.formatErrorsSnakeCase(err.children, path));
+      }
+    }
+    return out;
   }
 }

--- a/packages/apps/fortune/recording-oracle/src/common/utils/case-converter.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/case-converter.spec.ts
@@ -1,0 +1,173 @@
+import { faker } from '@faker-js/faker';
+
+import * as CaseConverter from './case-converter';
+
+describe('Case converting utilities', () => {
+  describe('transformKeysFromSnakeToCamel', () => {
+    it.each([
+      'string',
+      42,
+      BigInt(0),
+      new Date(),
+      Symbol('test'),
+      true,
+      null,
+      undefined,
+    ])('should not transform basic value [%#]', (value: unknown) => {
+      expect(CaseConverter.transformKeysFromSnakeToCamel(value)).toEqual(value);
+    });
+
+    it('should not transform simple array', () => {
+      const input = faker.helpers.multiple(() => faker.string.sample());
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual(input);
+    });
+
+    it('should transform array of objects', () => {
+      const input = faker.helpers.multiple(() => ({
+        test_case: faker.string.sample(),
+      }));
+      const expectedOutput = input.map((v) => ({
+        testCase: v.test_case,
+      }));
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('should transform plain object to camelCase', () => {
+      const input = {
+        random_string: faker.string.sample(),
+        random_number: faker.number.float(),
+        random_boolean: faker.datatype.boolean(),
+        always_null: null,
+      };
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual({
+        randomString: input.random_string,
+        randomNumber: input.random_number,
+        randomBoolean: input.random_boolean,
+        alwaysNull: null,
+      });
+    });
+
+    it('should transform input with nested data', () => {
+      const randomString = faker.string.sample();
+
+      const input = {
+        nested_object: {
+          with_array: [
+            {
+              of_objects: {
+                with_random_string: randomString,
+              },
+            },
+          ],
+        },
+      };
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual({
+        nestedObject: {
+          withArray: [
+            {
+              ofObjects: {
+                withRandomString: randomString,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('transformKeysFromCamelToSnake', () => {
+    it.each([
+      'string',
+      42,
+      BigInt(0),
+      new Date(),
+      Symbol('test'),
+      true,
+      null,
+      undefined,
+    ])('should not transform primitive [%#]', (value: unknown) => {
+      expect(CaseConverter.transformKeysFromCamelToSnake(value)).toEqual(value);
+    });
+
+    it('should not transform simple array', () => {
+      const input = faker.helpers.multiple(() => faker.string.sample());
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual(input);
+    });
+
+    it('should transform array of objects', () => {
+      const input = faker.helpers.multiple(() => ({
+        testCase: faker.string.sample(),
+      }));
+      const expectedOutput = input.map((v) => ({
+        test_case: v.testCase,
+      }));
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('should transform plain object to camelCase', () => {
+      const input = {
+        randomString: faker.string.sample(),
+        randomNumber: faker.number.float(),
+        randomBoolean: faker.datatype.boolean(),
+        alwaysNull: null,
+      };
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual({
+        random_string: input.randomString,
+        random_number: input.randomNumber,
+        random_boolean: input.randomBoolean,
+        always_null: null,
+      });
+    });
+
+    it('should transform input with nested data', () => {
+      const randomString = faker.string.sample();
+
+      const input = {
+        nestedObject: {
+          withArray: [
+            {
+              ofObjects: {
+                withRandomString: randomString,
+              },
+            },
+          ],
+        },
+      };
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual({
+        nested_object: {
+          with_array: [
+            {
+              of_objects: {
+                with_random_string: randomString,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/packages/apps/fortune/recording-oracle/src/common/utils/case-converter.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/case-converter.ts
@@ -1,37 +1,50 @@
 export class CaseConverter {
-  static transformToCamelCase(obj: any): any {
-    if (Array.isArray(obj)) {
-      return obj.map((item) => CaseConverter.transformToCamelCase(item));
-    } else if (typeof obj === 'object' && obj !== null) {
-      return Object.keys(obj).reduce(
+  static transformToCamelCase(input: any): any {
+    if (typeof input === 'string') {
+      return input.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+    } else if (Array.isArray(input)) {
+      return input.map((item) => CaseConverter.transformToCamelCase(item));
+    } else if (typeof input === 'object' && input !== null) {
+      return Object.keys(input).reduce(
         (acc: Record<string, any>, key: string) => {
           const camelCaseKey = key.replace(/_([a-z])/g, (g) =>
             g[1].toUpperCase(),
           );
-          acc[camelCaseKey] = CaseConverter.transformToCamelCase(obj[key]);
+          acc[camelCaseKey] = CaseConverter.transformToCamelCase(input[key]);
           return acc;
         },
         {},
       );
     } else {
-      return obj;
+      return input;
     }
   }
 
-  static transformToSnakeCase(obj: any): any {
-    if (Array.isArray(obj)) {
-      return obj.map((item) => CaseConverter.transformToSnakeCase(item));
-    } else if (typeof obj === 'object' && obj !== null) {
-      return Object.keys(obj).reduce(
+  static transformToSnakeCase(input: any): any {
+    function camelToSnakeKey(id: string): string {
+      if (!id) return id;
+      const parts = id
+        .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .split(/[\s_-]+/)
+        .filter(Boolean);
+      return parts.map((p) => p.toLowerCase()).join('_');
+    }
+    if (typeof input === 'string') {
+      return camelToSnakeKey(input);
+    } else if (Array.isArray(input)) {
+      return input.map((item) => CaseConverter.transformToSnakeCase(item));
+    } else if (typeof input === 'object' && input !== null) {
+      return Object.keys(input).reduce(
         (acc: Record<string, any>, key: string) => {
-          const snakeCaseKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
-          acc[snakeCaseKey] = CaseConverter.transformToSnakeCase(obj[key]);
+          const snakeCaseKey = camelToSnakeKey(key);
+          acc[snakeCaseKey] = CaseConverter.transformToSnakeCase(input[key]);
           return acc;
         },
         {},
       );
     } else {
-      return obj;
+      return input;
     }
   }
 }

--- a/packages/apps/fortune/recording-oracle/src/common/utils/webhook.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/utils/webhook.ts
@@ -4,7 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import logger from '../../logger';
 import { WebhookDto } from '../../modules/webhook/webhook.dto';
 import { HEADER_SIGNATURE_KEY } from '../constants';
-import { CaseConverter } from './case-converter';
+import { transformKeysFromCamelToSnake } from './case-converter';
 import { signMessage } from './signature';
 import { formatAxiosError } from './http';
 
@@ -14,7 +14,7 @@ export async function sendWebhook(
   webhookBody: WebhookDto,
   privateKey: string,
 ): Promise<boolean> {
-  const snake_case_body = CaseConverter.transformToSnakeCase(webhookBody);
+  const snake_case_body: any = transformKeysFromCamelToSnake(webhookBody);
   const signedBody = await signMessage(snake_case_body, privateKey);
   try {
     await firstValueFrom(

--- a/packages/apps/job-launcher/server/src/common/errors/index.ts
+++ b/packages/apps/job-launcher/server/src/common/errors/index.ts
@@ -11,8 +11,10 @@ export class BaseError extends Error {
 }
 
 export class ValidationError extends BaseError {
-  constructor(message: string, stack?: string) {
+  public errors?: string[];
+  constructor(message: string, stack?: string, errors?: string[]) {
     super(message, stack);
+    this.errors = errors;
   }
 }
 

--- a/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
@@ -60,11 +60,17 @@ export class ExceptionFilter implements IExceptionFilter {
 
     response.removeHeader('Cache-Control');
 
-    response.status(status).json({
+    const payload: any = {
       statusCode: status,
       timestamp: new Date().toISOString(),
       message: message,
       path: request.url,
-    });
+    };
+
+    if (exception instanceof ValidationError && exception.errors?.length) {
+      payload.validation_errors = exception.errors;
+    }
+
+    response.status(status).json(payload);
   }
 }

--- a/packages/apps/job-launcher/server/src/common/interceptors/snake-case.ts
+++ b/packages/apps/job-launcher/server/src/common/interceptors/snake-case.ts
@@ -7,7 +7,10 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { CaseConverter } from '../utils/case-converter';
+import {
+  transformKeysFromCamelToSnake,
+  transformKeysFromSnakeToCamel,
+} from '../utils/case-converter';
 
 @Injectable()
 export class SnakeCaseInterceptor implements NestInterceptor {
@@ -15,11 +18,11 @@ export class SnakeCaseInterceptor implements NestInterceptor {
     const request = context.switchToHttp().getRequest();
 
     if (request.body) {
-      request.body = CaseConverter.transformToCamelCase(request.body);
+      request.body = transformKeysFromSnakeToCamel(request.body);
     }
 
     if (request.query) {
-      request.query = CaseConverter.transformToCamelCase(request.query);
+      request.query = transformKeysFromSnakeToCamel(request.query);
     }
 
     return next.handle().pipe(
@@ -27,7 +30,7 @@ export class SnakeCaseInterceptor implements NestInterceptor {
         if (data instanceof StreamableFile) {
           return data;
         }
-        return CaseConverter.transformToSnakeCase(data);
+        return transformKeysFromCamelToSnake(data);
       }),
     );
   }

--- a/packages/apps/job-launcher/server/src/common/pipes/validation.ts
+++ b/packages/apps/job-launcher/server/src/common/pipes/validation.ts
@@ -5,7 +5,7 @@ import {
   ValidationPipeOptions,
 } from '@nestjs/common';
 import { ValidationError } from '../errors';
-import { CaseConverter } from '../utils/case-converter';
+import { camelToSnake } from '../utils/case-converter';
 
 @Injectable()
 export class HttpValidationPipe extends ValidationPipe {
@@ -34,9 +34,7 @@ export class HttpValidationPipe extends ValidationPipe {
 
       const transformedPath = rawPath
         .split('.')
-        .map((segment) =>
-          segment.replace(/^[A-Za-z0-9_]+/, CaseConverter.transformToSnakeCase),
-        )
+        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
         .join('.');
 
       return `${transformedPath} ${rest}`;

--- a/packages/apps/job-launcher/server/src/common/pipes/validation.ts
+++ b/packages/apps/job-launcher/server/src/common/pipes/validation.ts
@@ -24,20 +24,12 @@ export class HttpValidationPipe extends ValidationPipe {
   }
 
   private formatErrorsSnakeCase(errors: ValidError[]): string[] {
-    const rawMessages = this.flattenValidationErrors(errors);
-    return rawMessages.map((msg) => {
-      const firstSpace = msg.indexOf(' ');
-      if (firstSpace === -1) return msg;
-
-      const rawPath = msg.slice(0, firstSpace);
-      const rest = msg.slice(firstSpace + 1);
-
-      const transformedPath = rawPath
-        .split('.')
-        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
-        .join('.');
-
-      return `${transformedPath} ${rest}`;
-    });
+    return errors
+      .flatMap((error) => this.mapChildrenToValidationErrors(error))
+      .flatMap((error) =>
+        Object.values(error.constraints || {}).map((msg) =>
+          msg.replace(error.property, camelToSnake(error.property)),
+        ),
+      );
   }
 }

--- a/packages/apps/job-launcher/server/src/common/pipes/validation.ts
+++ b/packages/apps/job-launcher/server/src/common/pipes/validation.ts
@@ -11,8 +11,8 @@ export class HttpValidationPipe extends ValidationPipe {
   constructor(options?: ValidationPipeOptions) {
     super({
       exceptionFactory: (errors: ValidError[]): ValidationError => {
-        const flattenErrors = this.flattenValidationErrors(errors);
-        throw new ValidationError(flattenErrors.join(', '));
+        const messages = this.formatErrorsSnakeCase(errors);
+        throw new ValidationError('Validation error', undefined, messages);
       },
       transform: true,
       whitelist: true,
@@ -20,5 +20,32 @@ export class HttpValidationPipe extends ValidationPipe {
       forbidUnknownValues: true,
       ...options,
     });
+  }
+
+  private formatErrorsSnakeCase(
+    errors: ValidError[],
+    parentPath?: string,
+  ): string[] {
+    const out: string[] = [];
+    for (const err of errors) {
+      const currentProp = err.property
+        ? err.property.replace(/([A-Z])/g, '_$1').toLowerCase()
+        : '';
+      const path = [parentPath, currentProp].filter(Boolean).join('.');
+
+      if (err.constraints) {
+        for (const msg of Object.values(err.constraints)) {
+          const adjusted = err.property
+            ? msg.replace(new RegExp(`^${err.property}\\s+`, 'i'), '')
+            : msg;
+          out.push(path ? `${path} ${adjusted}` : adjusted);
+        }
+      }
+
+      if (err.children && err.children.length) {
+        out.push(...this.formatErrorsSnakeCase(err.children, path));
+      }
+    }
+    return out;
   }
 }

--- a/packages/apps/job-launcher/server/src/common/utils/case-converter.spec.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/case-converter.spec.ts
@@ -1,0 +1,173 @@
+import { faker } from '@faker-js/faker';
+
+import * as CaseConverter from './case-converter';
+
+describe('Case converting utilities', () => {
+  describe('transformKeysFromSnakeToCamel', () => {
+    it.each([
+      'string',
+      42,
+      BigInt(0),
+      new Date(),
+      Symbol('test'),
+      true,
+      null,
+      undefined,
+    ])('should not transform basic value [%#]', (value: unknown) => {
+      expect(CaseConverter.transformKeysFromSnakeToCamel(value)).toEqual(value);
+    });
+
+    it('should not transform simple array', () => {
+      const input = faker.helpers.multiple(() => faker.string.sample());
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual(input);
+    });
+
+    it('should transform array of objects', () => {
+      const input = faker.helpers.multiple(() => ({
+        test_case: faker.string.sample(),
+      }));
+      const expectedOutput = input.map((v) => ({
+        testCase: v.test_case,
+      }));
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('should transform plain object to camelCase', () => {
+      const input = {
+        random_string: faker.string.sample(),
+        random_number: faker.number.float(),
+        random_boolean: faker.datatype.boolean(),
+        always_null: null,
+      };
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual({
+        randomString: input.random_string,
+        randomNumber: input.random_number,
+        randomBoolean: input.random_boolean,
+        alwaysNull: null,
+      });
+    });
+
+    it('should transform input with nested data', () => {
+      const randomString = faker.string.sample();
+
+      const input = {
+        nested_object: {
+          with_array: [
+            {
+              of_objects: {
+                with_random_string: randomString,
+              },
+            },
+          ],
+        },
+      };
+
+      const output = CaseConverter.transformKeysFromSnakeToCamel(input);
+
+      expect(output).toEqual({
+        nestedObject: {
+          withArray: [
+            {
+              ofObjects: {
+                withRandomString: randomString,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('transformKeysFromCamelToSnake', () => {
+    it.each([
+      'string',
+      42,
+      BigInt(0),
+      new Date(),
+      Symbol('test'),
+      true,
+      null,
+      undefined,
+    ])('should not transform primitive [%#]', (value: unknown) => {
+      expect(CaseConverter.transformKeysFromCamelToSnake(value)).toEqual(value);
+    });
+
+    it('should not transform simple array', () => {
+      const input = faker.helpers.multiple(() => faker.string.sample());
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual(input);
+    });
+
+    it('should transform array of objects', () => {
+      const input = faker.helpers.multiple(() => ({
+        testCase: faker.string.sample(),
+      }));
+      const expectedOutput = input.map((v) => ({
+        test_case: v.testCase,
+      }));
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('should transform plain object to camelCase', () => {
+      const input = {
+        randomString: faker.string.sample(),
+        randomNumber: faker.number.float(),
+        randomBoolean: faker.datatype.boolean(),
+        alwaysNull: null,
+      };
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual({
+        random_string: input.randomString,
+        random_number: input.randomNumber,
+        random_boolean: input.randomBoolean,
+        always_null: null,
+      });
+    });
+
+    it('should transform input with nested data', () => {
+      const randomString = faker.string.sample();
+
+      const input = {
+        nestedObject: {
+          withArray: [
+            {
+              ofObjects: {
+                withRandomString: randomString,
+              },
+            },
+          ],
+        },
+      };
+
+      const output = CaseConverter.transformKeysFromCamelToSnake(input);
+
+      expect(output).toEqual({
+        nested_object: {
+          with_array: [
+            {
+              of_objects: {
+                with_random_string: randomString,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/packages/apps/job-launcher/server/src/common/utils/case-converter.ts
+++ b/packages/apps/job-launcher/server/src/common/utils/case-converter.ts
@@ -1,37 +1,50 @@
 export class CaseConverter {
-  static transformToCamelCase(obj: any): any {
-    if (Array.isArray(obj)) {
-      return obj.map((item) => CaseConverter.transformToCamelCase(item));
-    } else if (typeof obj === 'object' && obj !== null) {
-      return Object.keys(obj).reduce(
+  static transformToCamelCase(input: any): any {
+    if (typeof input === 'string') {
+      return input.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+    } else if (Array.isArray(input)) {
+      return input.map((item) => CaseConverter.transformToCamelCase(item));
+    } else if (typeof input === 'object' && input !== null) {
+      return Object.keys(input).reduce(
         (acc: Record<string, any>, key: string) => {
           const camelCaseKey = key.replace(/_([a-z])/g, (g) =>
             g[1].toUpperCase(),
           );
-          acc[camelCaseKey] = CaseConverter.transformToCamelCase(obj[key]);
+          acc[camelCaseKey] = CaseConverter.transformToCamelCase(input[key]);
           return acc;
         },
         {},
       );
     } else {
-      return obj;
+      return input;
     }
   }
 
-  static transformToSnakeCase(obj: any): any {
-    if (Array.isArray(obj)) {
-      return obj.map((item) => CaseConverter.transformToSnakeCase(item));
-    } else if (typeof obj === 'object' && obj !== null) {
-      return Object.keys(obj).reduce(
+  static transformToSnakeCase(input: any): any {
+    function camelToSnakeKey(id: string): string {
+      if (!id) return id;
+      const parts = id
+        .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .split(/[\s_-]+/)
+        .filter(Boolean);
+      return parts.map((p) => p.toLowerCase()).join('_');
+    }
+    if (typeof input === 'string') {
+      return camelToSnakeKey(input);
+    } else if (Array.isArray(input)) {
+      return input.map((item) => CaseConverter.transformToSnakeCase(item));
+    } else if (typeof input === 'object' && input !== null) {
+      return Object.keys(input).reduce(
         (acc: Record<string, any>, key: string) => {
-          const snakeCaseKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
-          acc[snakeCaseKey] = CaseConverter.transformToSnakeCase(obj[key]);
+          const snakeCaseKey = camelToSnakeKey(key);
+          acc[snakeCaseKey] = CaseConverter.transformToSnakeCase(input[key]);
           return acc;
         },
         {},
       );
     } else {
-      return obj;
+      return input;
     }
   }
 }

--- a/packages/apps/job-launcher/server/src/modules/auth/auth.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/auth/auth.dto.ts
@@ -43,9 +43,7 @@ export class RefreshDto {
 
 export class ValidatePasswordDto {
   @ApiProperty()
-  @MinLength(8, {
-    message: 'Password must be at least 8 characters long.',
-  })
+  @MinLength(8)
   public password: string;
 }
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.dto.ts
@@ -57,6 +57,7 @@ export class JobDto {
 
   @ApiPropertyOptional({
     type: String,
+    name: 'reputation_oracle',
     description: 'Address of the reputation oracle',
   })
   @IsEthereumAddress()
@@ -65,6 +66,7 @@ export class JobDto {
 
   @ApiPropertyOptional({
     type: String,
+    name: 'exchange_oracle',
     description: 'Address of the exchange oracle',
   })
   @IsEthereumAddress()
@@ -73,6 +75,7 @@ export class JobDto {
 
   @ApiPropertyOptional({
     type: String,
+    name: 'recording_oracle',
     description: 'Address of the recording oracle',
   })
   @IsEthereumAddress()
@@ -154,16 +157,22 @@ export class StorageDataDto {
 export class CvatDataDto {
   @ApiProperty()
   @IsObject()
+  @ValidateNested()
+  @Type(() => StorageDataDto)
   public dataset: StorageDataDto;
 
   @ApiPropertyOptional()
   @IsObject()
   @IsOptional()
+  @ValidateNested()
+  @Type(() => StorageDataDto)
   public points?: StorageDataDto;
 
   @ApiPropertyOptional()
   @IsObject()
   @IsOptional()
+  @ValidateNested()
+  @Type(() => StorageDataDto)
   public boxes?: StorageDataDto;
 }
 
@@ -175,11 +184,15 @@ export class JobCvatDto extends JobDto {
 
   @ApiProperty()
   @IsObject()
+  @ValidateNested()
+  @Type(() => CvatDataDto)
   public data: CvatDataDto;
 
   @ApiProperty({ type: [Label] })
   @IsArray()
   @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => Label)
   public labels: Label[];
 
   @ApiProperty({ name: 'min_quality' })
@@ -190,6 +203,8 @@ export class JobCvatDto extends JobDto {
 
   @ApiProperty({ name: 'ground_truth' })
   @IsObject()
+  @ValidateNested()
+  @Type(() => StorageDataDto)
   public groundTruth: StorageDataDto;
 
   @ApiProperty({ name: 'user_guide' })
@@ -211,6 +226,8 @@ class AudinoLabel {
 class AudinoDataDto {
   @ApiProperty()
   @IsObject()
+  @ValidateNested()
+  @Type(() => StorageDataDto)
   public dataset: StorageDataDto;
 }
 
@@ -222,6 +239,8 @@ export class JobAudinoDto extends JobDto {
 
   @ApiProperty()
   @IsObject()
+  @ValidateNested()
+  @Type(() => AudinoDataDto)
   public data: AudinoDataDto;
 
   @ApiProperty({ type: [AudinoLabel] })
@@ -328,10 +347,14 @@ class CommonDetails {
 export class JobDetailsDto {
   @ApiProperty({ description: 'Details of the job' })
   @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => CommonDetails)
   public details: CommonDetails;
 
   @ApiProperty({ description: 'Manifest details' })
   @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => ManifestDetails)
   public manifest: ManifestDetails;
 }
 
@@ -475,6 +498,8 @@ class JobCaptchaAnnotationsDto {
 export class JobCaptchaDto extends JobDto {
   @ApiProperty()
   @IsObject()
+  @ValidateNested()
+  @Type(() => StorageDataDto)
   data: StorageDataDto;
 
   @ApiProperty({ name: 'accuracy_target' })

--- a/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/webhook/webhook.service.ts
@@ -14,7 +14,7 @@ import { HEADER_SIGNATURE_KEY } from '../../common/constants';
 import { ErrorWebhook } from '../../common/constants/errors';
 import { EventType, WebhookStatus } from '../../common/enums/webhook';
 import { ServerError, ValidationError } from '../../common/errors';
-import { CaseConverter } from '../../common/utils/case-converter';
+import { transformKeysFromCamelToSnake } from '../../common/utils/case-converter';
 import { formatAxiosError } from '../../common/utils/http';
 import { signMessage } from '../../common/utils/signature';
 import { JobRepository } from '../job/job.repository';
@@ -60,7 +60,7 @@ export class WebhookService {
     }
 
     // Build the webhook data object based on the oracle type.
-    const webhookData = CaseConverter.transformToSnakeCase({
+    const webhookData: any = transformKeysFromCamelToSnake({
       escrowAddress: webhook.escrowAddress,
       chainId: webhook.chainId,
       eventType: webhook.eventType,

--- a/packages/apps/reputation-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/reputation-oracle/server/src/common/pipes/validation.ts
@@ -7,6 +7,8 @@ import {
   type ValidationPipeOptions,
 } from '@nestjs/common';
 
+import { camelToSnake } from '../../utils/case-converters';
+
 @Injectable()
 export class HttpValidationPipe extends ValidationPipe {
   constructor(options?: ValidationPipeOptions) {
@@ -24,30 +26,21 @@ export class HttpValidationPipe extends ValidationPipe {
     });
   }
 
-  private formatErrorsSnakeCase(
-    errors: ValidationError[],
-    parentPath?: string,
-  ): string[] {
-    const out: string[] = [];
-    for (const err of errors) {
-      const currentProp = err.property
-        ? err.property.replace(/([A-Z])/g, '_$1').toLowerCase()
-        : '';
-      const path = [parentPath, currentProp].filter(Boolean).join('.');
+  private formatErrorsSnakeCase(errors: ValidationError[]): string[] {
+    const rawMessages = this.flattenValidationErrors(errors);
+    return rawMessages.map((msg) => {
+      const firstSpace = msg.indexOf(' ');
+      if (firstSpace === -1) return msg;
 
-      if (err.constraints) {
-        for (const msg of Object.values(err.constraints)) {
-          const adjusted = err.property
-            ? msg.replace(new RegExp(`^${err.property}\\s+`, 'i'), '')
-            : msg;
-          out.push(path ? `${path} ${adjusted}` : adjusted);
-        }
-      }
+      const rawPath = msg.slice(0, firstSpace);
+      const rest = msg.slice(firstSpace + 1);
 
-      if (err.children && err.children.length) {
-        out.push(...this.formatErrorsSnakeCase(err.children, path));
-      }
-    }
-    return out;
+      const transformedPath = rawPath
+        .split('.')
+        .map((segment) => segment.replace(/^[A-Za-z0-9_]+/, camelToSnake))
+        .join('.');
+
+      return `${transformedPath} ${rest}`;
+    });
   }
 }

--- a/packages/apps/reputation-oracle/server/src/common/pipes/validation.ts
+++ b/packages/apps/reputation-oracle/server/src/common/pipes/validation.ts
@@ -12,10 +12,9 @@ export class HttpValidationPipe extends ValidationPipe {
   constructor(options?: ValidationPipeOptions) {
     super({
       exceptionFactory: (errors: ValidationError[]) => {
-        const flattenErrors = this.flattenValidationErrors(errors);
-
+        const messages = this.formatErrorsSnakeCase(errors);
         return new HttpException(
-          { validationErrors: flattenErrors, message: 'Validation error' },
+          { validationErrors: messages, message: 'Validation error' },
           HttpStatus.BAD_REQUEST,
         );
       },
@@ -23,5 +22,32 @@ export class HttpValidationPipe extends ValidationPipe {
       whitelist: true,
       ...options,
     });
+  }
+
+  private formatErrorsSnakeCase(
+    errors: ValidationError[],
+    parentPath?: string,
+  ): string[] {
+    const out: string[] = [];
+    for (const err of errors) {
+      const currentProp = err.property
+        ? err.property.replace(/([A-Z])/g, '_$1').toLowerCase()
+        : '';
+      const path = [parentPath, currentProp].filter(Boolean).join('.');
+
+      if (err.constraints) {
+        for (const msg of Object.values(err.constraints)) {
+          const adjusted = err.property
+            ? msg.replace(new RegExp(`^${err.property}\\s+`, 'i'), '')
+            : msg;
+          out.push(path ? `${path} ${adjusted}` : adjusted);
+        }
+      }
+
+      if (err.children && err.children.length) {
+        out.push(...this.formatErrorsSnakeCase(err.children, path));
+      }
+    }
+    return out;
   }
 }

--- a/packages/apps/reputation-oracle/server/src/common/validators/index.ts
+++ b/packages/apps/reputation-oracle/server/src/common/validators/index.ts
@@ -4,8 +4,7 @@ import {
   IsEmail,
   IsEnum,
   IsString,
-  MaxLength,
-  MinLength,
+  Length,
   ValidationOptions,
 } from 'class-validator';
 
@@ -40,13 +39,5 @@ export function IsLowercasedEnum(
 }
 
 export function IsValidPassword() {
-  return applyDecorators(
-    IsString(),
-    MinLength(8, {
-      message: 'Password must be at least 8 characters long.',
-    }),
-    MaxLength(128, {
-      message: 'Password must be at most 128 characters',
-    }),
-  );
+  return applyDecorators(IsString(), Length(8, 128));
 }

--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.guard.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.guard.spec.ts
@@ -69,7 +69,7 @@ describe('HCaptchaGuard', () => {
         thrownError = error;
       }
       expect(thrownError).toBeInstanceOf(HttpException);
-      expect(thrownError.message).toBe('hCaptcha token not provided');
+      expect(thrownError.message).toBe('h_captcha_token not provided');
       expect(thrownError.status).toBe(HttpStatus.BAD_REQUEST);
     });
 
@@ -91,7 +91,7 @@ describe('HCaptchaGuard', () => {
         thrownError = error;
       }
       expect(thrownError).toBeInstanceOf(HttpException);
-      expect(thrownError.message).toBe('Invalid hCaptcha token');
+      expect(thrownError.message).toBe('Invalid h_captcha_token');
       expect(thrownError.status).toBe(HttpStatus.BAD_REQUEST);
     });
   });

--- a/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.guard.ts
+++ b/packages/apps/reputation-oracle/server/src/integrations/hcaptcha/hcaptcha.guard.ts
@@ -24,14 +24,17 @@ export class HCaptchaGuard implements CanActivate {
     const hCaptchaToken: string = body['h_captcha_token'];
     if (!hCaptchaToken) {
       throw new HttpException(
-        'hCaptcha token not provided',
+        'h_captcha_token not provided',
         HttpStatus.BAD_REQUEST,
       );
     }
 
     const isTokenValid = await this.hCaptchaService.verifyToken(hCaptchaToken);
     if (!isTokenValid) {
-      throw new HttpException('Invalid hCaptcha token', HttpStatus.BAD_REQUEST);
+      throw new HttpException(
+        'Invalid h_captcha_token',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     return true;

--- a/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/user/user.dto.ts
@@ -62,9 +62,7 @@ export class RegistrationInExchangeOracleDto {
     name: 'oracle_address',
     description: 'Ethereum address of the oracle',
   })
-  @IsEthereumAddress({
-    message: 'oracle_address must be an Ethereum address',
-  })
+  @IsEthereumAddress()
   oracleAddress: string;
 
   @ApiProperty({ name: 'h_captcha_token' })

--- a/packages/apps/reputation-oracle/server/src/utils/case-converters.ts
+++ b/packages/apps/reputation-oracle/server/src/utils/case-converters.ts
@@ -6,7 +6,7 @@ type CaseTransformer = (input: string) => string;
  * TODO: check if replacing it with lodash.camelCase
  * won't break anything
  */
-const snakeToCamel: CaseTransformer = (input) => {
+export const snakeToCamel: CaseTransformer = (input) => {
   return input.replace(/_([a-z])/g, (_match, letter) => letter.toUpperCase());
 };
 
@@ -14,7 +14,7 @@ const snakeToCamel: CaseTransformer = (input) => {
  * TODO: check if replacing it with lodash.snakeCase
  * won't break anything
  */
-const camelToSnake: CaseTransformer = (input) => {
+export const camelToSnake: CaseTransformer = (input) => {
   return input.replace(/([A-Z])/g, '_$1').toLowerCase();
 };
 


### PR DESCRIPTION
## Issue tracking
Close #3381

## Context behind the change
- Refactor validation error handling to include detailed error messages for all oracles 
- Improve class validation response structure for JL, Exchange Oracle and Reputation Oracle


## How has this been tested?
Deployed locally and made some calls to make sure all error messages are in snake_case

## Release plan
Deploy again all services

## Potential risks; What to monitor; Rollback plan
None