### PR TITLE
[SDK] publish docs to GitBook

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,3 +1,4 @@
-root: ./docs
+root: ./docs/sdk
 structure:
+  readme: README.md
   summary: SUMMARY.md

--- a/.github/workflows/cd-gitbook-sdk-docs.yaml
+++ b/.github/workflows/cd-gitbook-sdk-docs.yaml
@@ -1,0 +1,29 @@
+name: Publish SDK Docs to GitBook
+
+on:
+  push:
+    tags:
+      - "sdk@*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish-docs:
+    name: Sync docs to GitBook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Publish docs
+        env:
+          GITBOOK_API_TOKEN: ${{ secrets.GITBOOK_API_TOKEN }}
+          GITBOOK_ORG_ID: ${{ secrets.GITBOOK_ORG_ID }}
+          PARENT_SPACE_ID: ${{ secrets.GITBOOK_PARENT_SPACE_ID }}
+          GITBOOK_SITE_ID: ${{ secrets.GITBOOK_SITE_ID }}
+          GIT_REF: ${{ github.ref }}
+          SPACE_VISIBILITY: ${{ secrets.GITBOOK_SPACE_VISIBILITY }}
+          MAKE_DEFAULT: ${{ vars.GITBOOK_MAKE_DEFAULT }}
+        run: node scripts/gitbook-sync-sdk.mjs

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -33,6 +33,6 @@ pip install human-protocol-sdk
 
 - Content is imported from the repository at release time.
 
-## Changelock
+## Changelog
 
 - [CHANGELOG](changelog.md) — release notes and changes.

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,0 +1,38 @@
+# HUMAN Protocol SDK
+
+Welcome to the official documentation for HUMAN Protocol SDK.
+
+## Overview
+
+- Covers both TypeScript and Python SDKs used to build on HUMAN Protocol.
+- Use the sidebar to browse guides and API references; search to quickly find classes and functions.
+
+## Install
+
+### Typescript
+
+```bash
+npm install @human-protocol/sdk
+# or
+yarn add @human-protocol/sdk
+```
+
+### Python
+
+```bash
+pip install human-protocol-sdk
+```
+
+## Links
+
+- [NPM package](https://www.npmjs.com/package/@human-protocol/sdk)
+- [PyPI package](https://pypi.org/project/human-protocol-sdk/)
+- [GitHub repository](https://github.com/humanprotocol/human-protocol)
+
+## Versioning
+
+- Content is imported from the repository at release time.
+
+## Changelock
+
+- [CHANGELOG](changelog.md) — release notes and changes.

--- a/docs/sdk/SUMMARY.md
+++ b/docs/sdk/SUMMARY.md
@@ -1,5 +1,7 @@
 # Table of contents
 
+- [HUMAN Protocol SDK](README.md)
+
 ## Typescript SDK
 
 - [Encryption](typescript/encryption/README.md)

--- a/scripts/gitbook-sync-sdk.mjs
+++ b/scripts/gitbook-sync-sdk.mjs
@@ -12,7 +12,7 @@ const {
   GITBOOK_SITE_ID,
   GIT_REF,
   SPACE_VISIBILITY = "public",
-  SPACE_ICON_URL = "https://firebasestorage.googleapis.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FULrmzCkJk7WEl6FnhbTZ%2Ficon%2FvYf8cnyycn97DBMRLNJr%2Fhp-sdk-docs-logo.png?alt=media&token=24fd7851-0806-4528-b912-e714c43e5152",
+  SPACE_ICON_URL = "https://firebasestorage.googleapis.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FULrmzCkJk7WEl6FnhbTZ%2Ficon%2FvYf8cnyycn97DBMRLNJr%2Fhp-sdk-docs-logo.png?alt=media",
   REPO_URL = "https://github.com/humanprotocol/human-protocol",
   GITBOOK_API_BASE = "https://api.gitbook.com/v1",
   MAKE_DEFAULT = "false",

--- a/scripts/gitbook-sync-sdk.mjs
+++ b/scripts/gitbook-sync-sdk.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+const {
+  GITBOOK_API_TOKEN,
+  GITBOOK_ORG_ID,
+  PARENT_SPACE_ID,
+  GITBOOK_SITE_ID,
+  GIT_REF,
+  SPACE_VISIBILITY = "public",
+  SPACE_ICON_URL = "https://firebasestorage.googleapis.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FULrmzCkJk7WEl6FnhbTZ%2Ficon%2FvYf8cnyycn97DBMRLNJr%2Fhp-sdk-docs-logo.png?alt=media&token=24fd7851-0806-4528-b912-e714c43e5152",
+  REPO_URL = "https://github.com/humanprotocol/human-protocol",
+  GITBOOK_API_BASE = "https://api.gitbook.com/v1",
+  MAKE_DEFAULT = "false",
+} = process.env;
+
+if (!GITBOOK_API_TOKEN) fail("Missing GITBOOK_API_TOKEN");
+if (!GITBOOK_ORG_ID) fail("Missing GITBOOK_ORG_ID");
+if (!GIT_REF) fail("Missing GIT_REF");
+
+const tag = GIT_REF.replace(/^refs\/tags\//, "");
+if (!/^sdk@/.test(tag)) fail(`Tag must start with sdk@: ${tag}`);
+const version = tag.split("@")[1];
+if (!version) fail("Cannot derive version from tag");
+
+const headers = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/plain, */*",
+  Authorization: `Bearer ${GITBOOK_API_TOKEN}`,
+};
+const api = async (path, init = {}) => {
+  const res = await fetch(`${GITBOOK_API_BASE}${path}`, {
+    ...init,
+    headers: { ...headers, ...(init.headers || {}) },
+  });
+  const text = await res.text().catch(() => "");
+  if (!res.ok) {
+    throw new Error(`${path} -> ${res.status} ${res.statusText}: ${text}`);
+  }
+  if (res.status === 204) return { status: res.status };
+  if (!text) return { status: res.status };
+  const ct = res.headers.get("content-type") || "";
+  if (ct.includes("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch (_) {
+      return { status: res.status, body: text };
+    }
+  }
+  return { status: res.status, body: text };
+};
+
+async function createSpace() {
+  const body = { title: `v${version}`, visibility: SPACE_VISIBILITY };
+  if (PARENT_SPACE_ID) body.parent = PARENT_SPACE_ID;
+  return api(`/orgs/${GITBOOK_ORG_ID}/spaces`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function importDocs(spaceId) {
+  return api(`/spaces/${spaceId}/git/import`, {
+    method: "POST",
+    body: JSON.stringify({
+      url: REPO_URL,
+      ref: `refs/tags/${tag}`,
+    }),
+  });
+}
+
+async function setSpaceIconFromUrl(spaceId, iconUrl) {
+  return api(`/spaces/${spaceId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ icon: iconUrl }),
+  });
+}
+
+async function createSiteSpace(siteId, spaceId) {
+  return api(`/orgs/${GITBOOK_ORG_ID}/sites/${siteId}/site-spaces`, {
+    method: "POST",
+    body: JSON.stringify({ spaceId }),
+  });
+}
+
+async function setSectionDefaultSiteSpace(siteId, siteSpaceId) {
+  return api(`/orgs/${GITBOOK_ORG_ID}/sites/${siteId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ defaultSiteSpace: siteSpaceId }),
+  });
+}
+
+(async () => {
+  try {
+    const space = await createSpace();
+    console.log(`Importing docs for version ${version} into space ${space.id}`);
+    const imp = await importDocs(space.id);
+
+    await setSpaceIconFromUrl(space.id, SPACE_ICON_URL);
+
+    if (GITBOOK_SITE_ID) {
+      const siteSpace = await createSiteSpace(GITBOOK_SITE_ID, space.id);
+      if (MAKE_DEFAULT === "true") {
+        await setSectionDefaultSiteSpace(GITBOOK_SITE_ID, siteSpace.id);
+      }
+    }
+  } catch (e) {
+    console.error(e.stack || e.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Issue tracking
Close #3483

## Context behind the change
- Add GitHub Actions workflow 
- Add script for publishing SDK documentation to GitBook
- Unify the first page of documents

## How has this been tested?
Launched several times via act 

## Release plan
Add some github secrets:
`GITBOOK_API_TOKEN=
GITBOOK_ORG_ID=
GITBOOK_PARENT_SPACE_ID=
GITBOOK_SITE_ID=
MAKE_DEFAULT=true`

## Potential risks; What to monitor; Rollback plan
None