### PR TITLE
[SDK][Typescript] Add chainId into getEscrow returned object

### DIFF
--- a/.changeset/stale-glasses-slide.md
+++ b/.changeset/stale-glasses-slide.md
@@ -1,0 +1,25 @@
+---
+"@human-protocol/sdk": minor
+---
+
+# Changelog
+
+### Changed
+
+- EscrowUtils.getEscrow now includes `chainId` in the returned object.
+
+# How to upgrade
+
+## TypeScript
+
+### yarn
+
+```bash
+yarn upgrade @human-protocol/sdk
+```
+
+### npm
+
+```bash
+npm update @human-protocol/sdk
+```

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -1812,6 +1812,7 @@ export class EscrowUtils {
       GET_ESCROW_BY_ADDRESS_QUERY(),
       { escrowAddress: escrowAddress.toLowerCase() }
     );
+    escrow.chainId = networkData.chainId;
 
     return escrow || null;
   }

--- a/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
@@ -2966,7 +2966,7 @@ describe('EscrowUtils', () => {
 
       const result = await EscrowUtils.getEscrow(chainId, ethers.ZeroAddress);
 
-      expect(result).toEqual(escrow);
+      expect(result).toEqual({ ...escrow, chainId });
       expect(gqlFetchSpy).toHaveBeenCalledWith(
         NETWORKS[ChainId.LOCALHOST]?.subgraphUrl,
         GET_ESCROW_BY_ADDRESS_QUERY(),


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
Fix EscrowUtils.getEscrow to include chainId in the returned object

## How has this been tested?
Ran unit tests and launched examples locally

## Release plan
Deploy new SDK version

## Potential risks; What to monitor; Rollback plan
None