### PR TITLE
 [Github Actions] Add token configuration for publish workflow

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GH_GITBOOK_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Add token configuration to create tags after publishing. This way we're not using GITHUB_ACTION token and allow us to chain other workflows such as `cd-gitbook-sdk-docs.yaml`.

## How has this been tested?
N/A

## Release plan
Create a new PAT in github and add it into secrets as `GH_GITBOOK_TOKEN`

## Potential risks; What to monitor; Rollback plan
After publishing a new tag, the `cd-gitbook-sdk-docs.yaml` workflow should be executed.