### PR TITLE
[SDK][Python] Avoid MismatchedABI error due to decimal values

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow/escrow_client.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow/escrow_client.py
@@ -53,7 +53,6 @@ Module
 
 import logging
 from typing import Optional, List, Union
-from decimal import Decimal
 
 from human_protocol_sdk.constants import (
     ESCROW_BULK_PAYOUT_MAX_ITEMS,
@@ -122,9 +121,9 @@ class EscrowConfig:
         recording_oracle_address: str,
         reputation_oracle_address: str,
         exchange_oracle_address: str,
-        recording_oracle_fee: Decimal,
-        reputation_oracle_fee: Decimal,
-        exchange_oracle_fee: Decimal,
+        recording_oracle_fee: int,
+        reputation_oracle_fee: int,
+        exchange_oracle_fee: int,
         manifest: str,
         hash: str,
     ):
@@ -362,7 +361,7 @@ class EscrowClient:
     def fund(
         self,
         escrow_address: str,
-        amount: Decimal,
+        amount: int,
         tx_options: Optional[TxParams] = None,
     ) -> None:
         """
@@ -428,7 +427,7 @@ class EscrowClient:
         escrow_address: str,
         url: str,
         hash: str,
-        funds_to_reserve: Optional[Decimal] = None,
+        funds_to_reserve: Optional[int] = None,
         tx_options: Optional[TxParams] = None,
     ) -> None:
         """
@@ -570,7 +569,7 @@ class EscrowClient:
         self,
         escrow_address: str,
         recipients: List[str],
-        amounts: List[Decimal],
+        amounts: List[int],
         final_results_url: str,
         final_results_hash: str,
         payout_id: Union[str, int],
@@ -679,7 +678,7 @@ class EscrowClient:
         self,
         escrow_address: str,
         recipients: List[str],
-        amounts: List[Decimal],
+        amounts: List[int],
         final_results_url: str,
         final_results_hash: str,
         payoutId: str,
@@ -802,7 +801,7 @@ class EscrowClient:
         self,
         escrow_address: str,
         recipients: List[str],
-        amounts: List[Decimal],
+        amounts: List[int],
         final_results_url: str,
         final_results_hash: str,
     ) -> None:
@@ -1047,7 +1046,7 @@ class EscrowClient:
         except Exception as e:
             handle_error(e, EscrowClientError)
 
-    def get_balance(self, escrow_address: str) -> Decimal:
+    def get_balance(self, escrow_address: str) -> int:
         """
         Gets the balance for a specified escrow address.
 
@@ -1089,7 +1088,7 @@ class EscrowClient:
 
         return self._get_escrow_contract(escrow_address).functions.getBalance().call()
 
-    def get_reserved_funds(self, escrow_address: str) -> Decimal:
+    def get_reserved_funds(self, escrow_address: str) -> int:
         """
         Gets the reserved funds for a specified escrow address.
 

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking/staking_client.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/staking/staking_client.py
@@ -54,7 +54,6 @@ Module
 import logging
 import os
 
-from decimal import Decimal
 from typing import Optional
 
 import web3
@@ -133,9 +132,7 @@ class StakingClient:
         )
 
     @requires_signer
-    def approve_stake(
-        self, amount: Decimal, tx_options: Optional[TxParams] = None
-    ) -> None:
+    def approve_stake(self, amount: int, tx_options: Optional[TxParams] = None) -> None:
         """Approves HMT token for Staking.
 
         :param amount: Amount to approve
@@ -185,7 +182,7 @@ class StakingClient:
             handle_error(e, StakingClientError)
 
     @requires_signer
-    def stake(self, amount: Decimal, tx_options: Optional[TxParams] = None) -> None:
+    def stake(self, amount: int, tx_options: Optional[TxParams] = None) -> None:
         """Stakes HMT token.
 
         :param amount: Amount to stake
@@ -238,7 +235,7 @@ class StakingClient:
             handle_error(e, StakingClientError)
 
     @requires_signer
-    def unstake(self, amount: Decimal, tx_options: Optional[TxParams] = None) -> None:
+    def unstake(self, amount: int, tx_options: Optional[TxParams] = None) -> None:
         """Unstakes HMT token.
 
         :param amount: Amount to unstake
@@ -340,7 +337,7 @@ class StakingClient:
         slasher: str,
         staker: str,
         escrow_address: str,
-        amount: Decimal,
+        amount: int,
         tx_options: Optional[TxParams] = None,
     ) -> None:
         """Slashes HMT token.

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
@@ -76,7 +76,7 @@ def get_hmt_balance(wallet_addr, token_addr, w3):
     :param token_addr: ERC-20 contract
     :param w3: Web3 instance
 
-    :return: Decimal with HMT balance
+    :return: HMT balance (wei)
     """
 
     abi = [


### PR DESCRIPTION
## Issue tracking
Close #3613

## Context behind the change
Change `Decimal` to `int` for fee and amount parameters in escrow and staking clients

## How has this been tested?
Executed staking and escrow calls locally to make sure they work fine. 

## Release plan
Deploy new Python version. 

## Potential risks; What to monitor; Rollback plan
None