### PR TITLE
chore: trigger packages publish only packages paths

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "packages/core/**"
+      - "packages/libs/**"
+      - "packages/sdk/typescript/human-protocol-sdk/**"
 
 jobs:
   publish:


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Atm GA for js packages CD is triggered on every push on `main` branch. Adding a `paths` filter here to remove unnecessary triggers

## How has this been tested?
Will check on next merge to `main`

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No