### PR TITLE
fix: add auth registry

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: yarn
+          # Necessary to set up registry for auth
+          registry-url: "https://registry.npmjs.org"
       # Ensure npm 11.5.1 or later is installed to support OIDC
       - name: Update npm
         run: npm install -g npm@latest


### PR DESCRIPTION
Follow-up to https://github.com/humanprotocol/human-protocol/pull/3627.
It appears that `registry-url` param for `setup-node` action is different from what is set on yarn config and it's necessary to have proper auth