### PR TITLE
chore: properly trigger cd-packages action

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -8,10 +8,11 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "packages/core/**"
-      - "packages/libs/**"
-      - "packages/sdk/typescript/human-protocol-sdk/**"
+    paths-ignore:
+      - "docs/**"
+      - "packages/apps/**"
+      - "packages/examples/**"
+      - "packages/sdk/python/**"
 
 jobs:
   publish:


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When changing a workflow file, or yarn version or `npmrc` it should be also possible to trigger `cd-packages` action. Adjusting `paths` for that

## How has this been tested?
N/A

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
N/A