### PR TITLE
Add the ability to complete the escrow without payouts

### DIFF
--- a/packages/core/contracts/Escrow.sol
+++ b/packages/core/contracts/Escrow.sol
@@ -254,7 +254,11 @@ contract Escrow is IEscrow, ReentrancyGuard {
      */
     function complete() external override notExpired adminOrReputationOracle {
         require(
-            status == EscrowStatuses.Paid || status == EscrowStatuses.Partial,
+            status == EscrowStatuses.Paid ||
+                status == EscrowStatuses.Partial ||
+                (status == EscrowStatuses.Pending &&
+                    bytes(intermediateResultsUrl).length > 0 &&
+                    reservedFunds == 0),
             'Invalid status'
         );
         _finalize();


### PR DESCRIPTION
## Issue tracking
Closes #3638 

## Context behind the change
Add the ability to complete the escrow without payouts for situations where participants didn't reach stablished criterias

## How has this been tested?
Unit tests

## Release plan
- Deploy contracts

## Potential risks; What to monitor; Rollback plan
NA