### PR TITLE
[Fortune][Exchange Oracle] Add missing migration to remove paused status

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/database/migrations/1762175785287-removePausedStatus.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/database/migrations/1762175785287-removePausedStatus.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemovePausedStatus1762175785287 implements MigrationInterface {
+  name = 'RemovePausedStatus1762175785287';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."jobs_status_enum"
+            RENAME TO "jobs_status_enum_old"
+        `);
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."jobs_status_enum" AS ENUM('active', 'completed', 'canceled')
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ALTER COLUMN "status" TYPE "hmt"."jobs_status_enum" USING "status"::"text"::"hmt"."jobs_status_enum"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."jobs_status_enum_old"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TYPE "hmt"."jobs_status_enum_old" AS ENUM('active', 'paused', 'completed', 'canceled')
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "hmt"."jobs"
+            ALTER COLUMN "status" TYPE "hmt"."jobs_status_enum_old" USING "status"::"text"::"hmt"."jobs_status_enum_old"
+        `);
+    await queryRunner.query(`
+            DROP TYPE "hmt"."jobs_status_enum"
+        `);
+    await queryRunner.query(`
+            ALTER TYPE "hmt"."jobs_status_enum_old"
+            RENAME TO "jobs_status_enum"
+        `);
+  }
+}


### PR DESCRIPTION
## Issue tracking
Following #3646

## Context behind the change
Generate migration to remove 'paused' status from jobs status enum

## How has this been tested?
Ran migrations locally

## Release plan
Deploy new migrations in exchange oracle

## Potential risks; What to monitor; Rollback plan
None. Already checked there's no paused jobs in STG