### PR TITLE
fix: use annotated tags for packages

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -22,6 +22,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_GITBOOK_TOKEN }}
+      - name: Setup git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/cd-python-sdk.yaml
+++ b/.github/workflows/cd-python-sdk.yaml
@@ -18,6 +18,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_GITBOOK_TOKEN }}
+      - name: Setup git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
@@ -57,4 +61,4 @@ jobs:
             exit 0
           fi
           git tag -a "$TAG" -m "Python SDK $VERSION"
-          git push origin "$TAG"
+          git push origin --tags

--- a/scripts/tag-published-packages.mjs
+++ b/scripts/tag-published-packages.mjs
@@ -15,7 +15,7 @@ function maybeCreateGitTagForPackage({ name, version }) {
     childProcess.execSync(`git rev-parse --verify ${tag}`, { stdio: "ignore" });
     console.warn(`Git tag already exists, skipping: ${tag}`);
   } catch {
-    childProcess.execSync(`git tag ${tag}`);
+    childProcess.execSync(`git tag -a "${tag}" -m "Released JS package: @human-protocol/${name} - ${version}"`);
     console.log(`Created tag: ${tag}`);
   }
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
[Recent python sdk publish job](https://github.com/humanprotocol/human-protocol/actions/runs/19066419271) failed because wasn't able to publish annotated tag due to missing published identity.
Added it here and also changed JS action to follow same approach instead of using lightweight tags

## How has this been tested?
- [x] take logs from last action, run `node tag-published-packages.mjs publish.log` to make sure tag is created with correct meta on local

## Release plan
Merge and verify on next lib publish

## Potential risks; What to monitor; Rollback plan
Should be none