### PR TITLE
[UI apps] fix: rewrites for spa

### DIFF
--- a/packages/apps/human-app/frontend/serve.json
+++ b/packages/apps/human-app/frontend/serve.json
@@ -1,7 +1,13 @@
 {
   "public": "dist",
-  "symlinks": true,
+  "symlinks": false,
   "trailingSlash": false,
+  "rewrites": [
+    {
+      "source": "**",
+      "destination": "/index.html"
+    }
+  ],
   "headers": [
     {
       "source": "**/*.html",

--- a/packages/apps/job-launcher/client/serve.json
+++ b/packages/apps/job-launcher/client/serve.json
@@ -1,7 +1,13 @@
 {
   "public": "dist",
-  "symlinks": true,
+  "symlinks": false,
   "trailingSlash": false,
+  "rewrites": [
+    {
+      "source": "**",
+      "destination": "/index.html"
+    }
+  ],
   "headers": [
     {
       "source": "**/*.html",

--- a/packages/apps/staking/serve.json
+++ b/packages/apps/staking/serve.json
@@ -1,7 +1,13 @@
 {
   "public": "dist",
-  "symlinks": true,
+  "symlinks": false,
   "trailingSlash": false,
+  "rewrites": [
+    {
+      "source": "**",
+      "destination": "/index.html"
+    }
+  ],
   "headers": [
     {
       "source": "**/*.html",


### PR DESCRIPTION
## Issue tracking
N/A
Follow up to https://github.com/humanprotocol/human-protocol/pull/3644

## Context behind the change
After we changed `serve` package to have all config via `serve.json`, it appeared that `rewrites` option was missing (counterpart of `-s` options for `serve` command), so when our SPA opened on some sub-path that should be handled by UI router - we get 404 instead. In order to fix that - add `rewrites` option to config.

## How has this been tested?
- [x] locally; `yarn build & yarn start:prod` for HUMAN App; open app, click `sign in` to get to new route, update the page and make sure it's the same route, not 404

## Release plan
1. Merge
2. Double-check on staging (Vercel preview is different from what we have there)
3. Update start command to be `yarn start:prod` so we make sure config is applied

## Potential risks; What to monitor; Rollback plan
No