### PR TITLE
[Dashboard Server] fix: transactions response

### DIFF
--- a/packages/apps/dashboard/server/src/modules/details/dto/transaction.dto.ts
+++ b/packages/apps/dashboard/server/src/modules/details/dto/transaction.dto.ts
@@ -1,15 +1,29 @@
-import { Expose, Transform } from 'class-transformer';
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+import { Expose, Transform, Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
-export interface InternalTransaction {
+export class InternalTransaction {
+  @ApiProperty()
+  @Expose()
   from: string;
+  @ApiProperty()
+  @Expose()
   to: string;
+  @ApiProperty()
+  @Transform(({ value }) => value.toString())
+  @Expose()
   value: string;
+  @ApiProperty()
+  @Expose()
   method: string;
-  receiver?: string;
-  escrow?: string;
-  token?: string;
+  @ApiProperty()
+  @Expose()
+  receiver: string | null;
+  @ApiProperty()
+  @Expose()
+  escrow: string | null;
+  @ApiProperty()
+  @Expose()
+  token: string | null;
 }
 
 export class TransactionPaginationDto {
@@ -17,36 +31,31 @@ export class TransactionPaginationDto {
     example:
       '0x020efc94ef6d9d7aa9a4886cc9e1659f4f2b63557133c29d51f387bcb0c4afd7',
   })
-  @IsString()
   @Expose()
-  public txHash: string;
+  txHash: string;
 
-  @ApiProperty({ example: 'Transfer' })
-  @IsString()
+  @ApiProperty({ example: 'bulkTransfer' })
   @Expose()
-  public method: string;
+  method: string;
 
   @ApiProperty({ example: '0xad1F7e45D83624A0c628F1B03477c6E129EddB78' })
-  @IsString()
   @Expose()
-  public from: string;
+  from: string;
 
   @ApiProperty({ example: '0xad1F7e45D83624A0c628F1B03477c6E129EddB78' })
-  @IsString()
   @Expose()
-  public to: string;
+  to: string;
 
-  @ApiProperty({ example: '0xad1F7e45D83624A0c628F1B03477c6E129EddB78' })
-  @IsOptional()
-  @IsString()
+  @ApiProperty({
+    example: '0xad1F7e45D83624A0c628F1B03477c6E129EddB78',
+  })
   @Expose()
-  public receiver?: string;
+  receiver: string | null;
 
   @ApiProperty({ example: 12345 })
   @Transform(({ value }) => Number(value))
-  @IsNumber()
   @Expose()
-  public block: number;
+  block: number;
 
   @ApiProperty({ example: '0.123' })
   @Transform(({ value, obj }) => {
@@ -54,14 +63,14 @@ export class TransactionPaginationDto {
       ? `-${value.toString()}`
       : value.toString();
   })
-  @IsString()
   @Expose()
-  public value: string;
+  value: string;
 
   @ApiProperty({
     type: [Object],
     description: 'List of transfers associated with the transaction',
   })
+  @Type(() => InternalTransaction)
   @Expose()
-  public internalTransactions: InternalTransaction[];
+  internalTransactions: InternalTransaction[];
 }

--- a/packages/apps/dashboard/server/src/modules/stats/stats.service.ts
+++ b/packages/apps/dashboard/server/src/modules/stats/stats.service.ts
@@ -324,7 +324,7 @@ export class StatsService implements OnModuleInit {
 
               dailyData[dailyCacheKey].totalTransactionAmount = (
                 BigInt(dailyData[dailyCacheKey].totalTransactionAmount) +
-                BigInt(record.totalTransactionAmount)
+                record.totalTransactionAmount
               ).toString();
               dailyData[dailyCacheKey].totalTransactionCount +=
                 record.totalTransactionCount;
@@ -346,7 +346,7 @@ export class StatsService implements OnModuleInit {
 
               monthlyData[month].totalTransactionAmount = (
                 BigInt(monthlyData[month].totalTransactionAmount) +
-                BigInt(record.totalTransactionAmount)
+                record.totalTransactionAmount
               ).toString();
               monthlyData[month].totalTransactionCount +=
                 record.totalTransactionCount;


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Got an alert from DD that dashboard server fails with next error:
```
TypeError: Do not know how to serialize a BigInt
```
while handling request to `/details/transactions/0x5b74d007ea08217bcde942a2132df43d568a6dca?chainId=137&skip=0&first=10`

After we changed return types in SDK `value` of transaction became `bigint` and `InternalTransaction` object wasn't handled correctly for response: we need to transform `bigint` to string and also let the "parent" class know about the type it should transform as nested object.

## How has this been tested?
- [x] run dashboard locally and make sure transactions table for operator load on UI

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No