### PR TITLE
[Docs] Fix tag validation

### DIFF
--- a/scripts/gitbook-sync-sdk.mjs
+++ b/scripts/gitbook-sync-sdk.mjs
@@ -23,7 +23,7 @@ if (!GITBOOK_ORG_ID) fail("Missing GITBOOK_ORG_ID");
 if (!GIT_REF) fail("Missing GIT_REF");
 
 const tag = GIT_REF.replace(/^refs\/tags\//, "");
-if (!/^sdk@/.test(tag)) fail(`Tag must start with sdk@: ${tag}`);
+if (!/^js\/sdk@/.test(tag)) fail(`Tag must start with js/sdk@: ${tag}`);
 const version = tag.split("@")[1];
 if (!version) fail("Cannot derive version from tag");
 


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
Github's action to publish documents was failing. Tag validation has been corrected to require the prefix “js/sdk@”.

## How has this been tested?
N/A

## Release plan
Generate a new tag for the latest deployment to publish docs.

## Potential risks; What to monitor; Rollback plan
None