### PR TITLE
use status from rpc instead of subgraph to avoid lags in subgraph sync

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -274,7 +274,7 @@ export class EscrowCompletionService {
           chainId,
           escrowAddress,
           eventType:
-            escrowData.status === EscrowStatus[EscrowStatus.Cancelled]
+            escrowStatus === EscrowStatus.Cancelled
               ? OutgoingWebhookEventType.ESCROW_CANCELED
               : OutgoingWebhookEventType.ESCROW_COMPLETED,
         };


### PR DESCRIPTION
## Issue tracking
Closes #3662

## Context behind the change
It was using the status from subgraph but it might not be synced by the execution of this code, so it has been changed to use the status obtained by RPC.

## How has this been tested?
Locally

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA