### PR TITLE
[Job Launcher] syncJobStatuses cron job is failing

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/cron-job/cron-job.service.ts
@@ -509,7 +509,7 @@ export class CronJobService {
         const key = `${event.chainId}-${ethers.getAddress(event.escrowAddress)}`;
         const job = jobMap.get(key);
 
-        const eventTimestamp = new Date(event.timestamp * 1000).getTime();
+        const eventTimestamp = event.timestamp;
         if (eventTimestamp > latestEventTimestamp) {
           latestEventTimestamp = eventTimestamp;
         }


### PR DESCRIPTION
## Issue tracking
Close #3670 

## Context behind the change
Sync Job Status cron job was failing due to miss-calculation with timestamps.
Now we use original timestamp format for event processing.

## How has this been tested?
Ran some queries in a script to make sure calculations are fine now. 

## Release plan
Deploy new JL version

## Potential risks; What to monitor; Rollback plan
None