### PR TITLE
feat: skip regular ci/cd trigger on tag push

### DIFF
--- a/.github/workflows/cd-cvat-exchange-oracle.yaml
+++ b/.github/workflows/cd-cvat-exchange-oracle.yaml
@@ -3,6 +3,7 @@ name: Deploy CVAT Exchange Oracle
 on:
   push:
     branches: [ develop, main, cvat-milestone-2 ]
+    tags-ignore: '*'
     paths:
       - 'packages/examples/cvat/exchange-oracle/**'
   pull_request:

--- a/.github/workflows/cd-cvat-recording-oracle.yaml
+++ b/.github/workflows/cd-cvat-recording-oracle.yaml
@@ -3,6 +3,7 @@ name: Deploy CVAT Recording Oracle
 on:
   push:
     branches: [ develop, main, cvat-milestone-2 ]
+    tags-ignore: '*'
     paths:
       - 'packages/examples/cvat/recording-oracle/**'
   pull_request:

--- a/.github/workflows/cd-job-launcher-server.yaml
+++ b/.github/workflows/cd-job-launcher-server.yaml
@@ -3,6 +3,7 @@ name: Deploy Job launcher server
 on:
   push:
     branches: [ develop, main ]
+    tags-ignore: '*'
     paths:
       - 'packages/apps/job-launcher/server/**'
   pull_request:

--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+    tags-ignore: '*'
     paths-ignore:
       - "docs/**"
       - "packages/apps/**"

--- a/.github/workflows/cd-python-sdk.yaml
+++ b/.github/workflows/cd-python-sdk.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+    tags-ignore: '*'
     paths:
       - "packages/sdk/python/human-protocol-sdk/**"
 

--- a/.github/workflows/cd-reputation-oracle.yaml
+++ b/.github/workflows/cd-reputation-oracle.yaml
@@ -3,6 +3,7 @@ name: Deploy Reputation oracle
 on:
   push:
     branches: [ develop, main ]
+    tags-ignore: '*'
     paths:
       - 'packages/apps/reputation-oracle/server/**'
   pull_request:

--- a/.github/workflows/ci-lint-cvat-exchange-oracle.yaml
+++ b/.github/workflows/ci-lint-cvat-exchange-oracle.yaml
@@ -2,6 +2,7 @@ name: CVAT Exchange Oracle Lint
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/examples/cvat/exchange-oracle/**'
       - '.github/workflows/ci-lint-cvat-exchange-oracle.yaml'

--- a/.github/workflows/ci-lint-cvat-recording-oracle.yaml
+++ b/.github/workflows/ci-lint-cvat-recording-oracle.yaml
@@ -2,6 +2,7 @@ name: CVAT Recording Oracle Lint
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/examples/cvat/recording-oracle/**'
       - '.github/workflows/ci-lint-cvat-recording-oracle.yaml'

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -2,6 +2,7 @@ name: Lint check
 
 on:
   push:
+    tags-ignore: '*'
     paths-ignore:
       - 'packages/examples/cvat/**'
 

--- a/.github/workflows/ci-test-core.yaml
+++ b/.github/workflows/ci-test-core.yaml
@@ -2,6 +2,7 @@ name: Protocol check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/core/**'
 

--- a/.github/workflows/ci-test-cvat-exchange-oracle.yaml
+++ b/.github/workflows/ci-test-cvat-exchange-oracle.yaml
@@ -2,6 +2,7 @@ name: CVAT Exchange Oracle Tests
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/examples/cvat/exchange-oracle/**'
       - 'packages/sdk/python/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-cvat-recording-oracle.yaml
+++ b/.github/workflows/ci-test-cvat-recording-oracle.yaml
@@ -2,6 +2,7 @@ name: CVAT Recording Oracle Tests
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/examples/cvat/recording-oracle/**'
       - 'packages/core/**'

--- a/.github/workflows/ci-test-dashboard.yaml
+++ b/.github/workflows/ci-test-dashboard.yaml
@@ -2,6 +2,7 @@ name: Dashboard Check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/human-protocol-sdk/**"

--- a/.github/workflows/ci-test-faucet-server.yaml
+++ b/.github/workflows/ci-test-faucet-server.yaml
@@ -2,6 +2,7 @@ name: Faucet server check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/human-protocol-sdk/**"

--- a/.github/workflows/ci-test-fortune.yaml
+++ b/.github/workflows/ci-test-fortune.yaml
@@ -2,6 +2,7 @@ name: Fortune check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/human-protocol-sdk/**"

--- a/.github/workflows/ci-test-human-app.yaml
+++ b/.github/workflows/ci-test-human-app.yaml
@@ -2,6 +2,7 @@ name: Human App Check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/human-protocol-sdk/**"

--- a/.github/workflows/ci-test-job-launcher.yaml
+++ b/.github/workflows/ci-test-job-launcher.yaml
@@ -2,6 +2,7 @@ name: Job Launcher Check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/human-protocol-sdk/**"

--- a/.github/workflows/ci-test-node-sdk.yaml
+++ b/.github/workflows/ci-test-node-sdk.yaml
@@ -2,6 +2,7 @@ name: Node.js SDK check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/core/**'
       - 'packages/sdk/typescript/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-python-sdk.yaml
+++ b/.github/workflows/ci-test-python-sdk.yaml
@@ -2,6 +2,7 @@ name: Python SDK check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - 'packages/core/**'
       - 'packages/sdk/python/human-protocol-sdk/**'

--- a/.github/workflows/ci-test-reputation-oracle.yaml
+++ b/.github/workflows/ci-test-reputation-oracle.yaml
@@ -2,6 +2,7 @@ name: Reputation Oracle Check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/human-protocol-sdk/**"

--- a/.github/workflows/ci-test-subgraph.yaml
+++ b/.github/workflows/ci-test-subgraph.yaml
@@ -2,6 +2,7 @@ name: Subgraph check
 
 on:
   push:
+    tags-ignore: '*'
     paths:
       - "packages/core/**"
       - "packages/sdk/typescript/subgraph/**"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Atm after we release packages we also push new tags on `main` branch. With current GA triggers it results to double-run of CI actions like lint, tests, etc., which is just waste of resources. To optimize it - exclude running these actions on tag push, since we are only interested on branch pushed

## How has this been tested?
When merged

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Should be none