### PR TITLE
[Github Actions] Enable manual triggering for package publish workflows

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -23,7 +23,6 @@ on:
       - "packages/apps/**"
       - "packages/examples/**"
       - "packages/sdk/python/**"
-  workflow_dispatch:
 
 jobs:
   publish:
@@ -62,7 +61,6 @@ jobs:
         run: yarn workspaces foreach --all --no-private -pt npm publish --tolerate-republish --tag ${NPM_PUBLISH_TAG} --json | tee publish.log
         env:
           SKIP_PREPACK: true
-          NPM_PUBLISH_TAG: ${{ env.NPM_PUBLISH_TAG }}
       - name: Tag published packages
         if: ${{ env.PUSH_GIT_TAGS == 'true' }}
         run: node scripts/tag-published-packages.mjs publish.log

--- a/.github/workflows/cd-python-sdk.yaml
+++ b/.github/workflows/cd-python-sdk.yaml
@@ -15,7 +15,6 @@ on:
       - main
     paths:
       - "packages/sdk/python/human-protocol-sdk/**"
-  workflow_dispatch:
 
 jobs:
   publish-python-sdk:


### PR DESCRIPTION
## Issue tracking
#3671 

## Context behind the change
Added manual triggers to the existing deploy workflows so we can publish betas without pushing to main

## How has this been tested?
Ran `yarn changeset pre enter beta / version / pre exit` to confirm Changesets behaves as expected

## Release plan

1. Apply changesets in prerelease mode:
    `yarn changeset pre enter beta` → `yarn changeset version` → `commit`.

2. Push branch and run manual Actions:
     Publish packages → select branch → confirm npm release.
     Python SDK publish → select branch → confirm PyPI release.
3. Share beta notes in Slack/Docs; remind consumers to install with the beta tag.
4. When beta cycle ends: `yarn changeset pre exit`, run final `yarn changeset version`, follow standard GA release steps.

## Tag strategy / prerelease guidance

- `alpha`: quick internal smoke tests, no commitments.
- `beta`: release candidates for internal/external stakeholders; changes between betas should be coordinated with consumers.
- `test` (or any other custom preid): ad-hoc experiments or chaos testing.

## Potential risks; What to monitor; Rollback plan
None