### PR TITLE
[Job Launcher][Server] Fix webhook on escrow creation

### DIFF
--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -27,7 +27,11 @@ import {
   JobStatusFilter,
 } from '../../common/enums/job';
 import { PaymentCurrency, PaymentType } from '../../common/enums/payment';
-import { EventType, OracleType } from '../../common/enums/webhook';
+import {
+  EventType,
+  OracleType,
+  WebhookStatus,
+} from '../../common/enums/webhook';
 import {
   ConflictError,
   NotFoundError,
@@ -884,6 +888,17 @@ describe('JobService', () => {
         ...jobEntity,
         status: JobStatus.LAUNCHED,
         escrowAddress,
+      });
+      expect(mockWebhookRepository.createUnique).toHaveBeenCalledWith({
+        chainId: jobEntity.chainId,
+        escrowAddress,
+        eventType: EventType.ESCROW_CREATED,
+        oracleType: OracleType.FORTUNE,
+        hasSignature: true,
+        oracleAddress: jobEntity.exchangeOracle,
+        retriesCount: 0,
+        waitUntil: expect.any(Date),
+        status: WebhookStatus.PENDING,
       });
 
       getOracleFeeSpy.mockRestore();

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -67,6 +67,7 @@ import { StorageService } from '../storage/storage.service';
 import { UserEntity } from '../user/user.entity';
 import { Web3Service } from '../web3/web3.service';
 import { WebhookDataDto } from '../webhook/webhook.dto';
+import { WebhookEntity } from '../webhook/webhook.entity';
 import { WebhookRepository } from '../webhook/webhook.repository';
 import { WhitelistService } from '../whitelist/whitelist.service';
 import {
@@ -365,6 +366,18 @@ export class JobService {
     jobEntity.status = JobStatus.LAUNCHED;
     jobEntity.escrowAddress = escrowAddress;
     await this.jobRepository.updateOne(jobEntity);
+
+    const oracleType = this.getOracleType(jobEntity.requestType);
+    const webhookEntity = new WebhookEntity();
+    Object.assign(webhookEntity, {
+      escrowAddress: jobEntity.escrowAddress,
+      chainId: jobEntity.chainId,
+      eventType: EventType.ESCROW_CREATED,
+      oracleType: oracleType,
+      hasSignature: oracleType !== OracleType.HCAPTCHA ? true : false,
+      oracleAddress: jobEntity.exchangeOracle,
+    });
+    await this.webhookRepository.createUnique(webhookEntity);
 
     return jobEntity;
   }

--- a/packages/apps/job-launcher/server/src/modules/storage/storage.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/storage/storage.service.spec.ts
@@ -220,6 +220,7 @@ describe('StorageService', () => {
         'solution',
         expect.any(String),
         expect.any(String),
+        undefined,
         {
           'Content-Type': ContentType.APPLICATION_JSON,
           'Cache-Control': 'no-store',


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When creating an escrow, webhook creation was removed. It has been restored to send the webhook to Exchange Oracle.

## How has this been tested?
Deployed locally and created some escrows, also ran unit tests. 

## Release plan
Deploy new JL server code

## Potential risks; What to monitor; Rollback plan
None