### PR TITLE
[SDK][Typescript] Fix operator reputation networks

### DIFF
--- a/.changeset/hot-animals-trade.md
+++ b/.changeset/hot-animals-trade.md
@@ -1,0 +1,5 @@
+---
+"@human-protocol/sdk": patch
+---
+
+Update LEADER_FRAGMENT to include address field in reputationNetworks

--- a/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/operator.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/operator.ts
@@ -15,7 +15,9 @@ const LEADER_FRAGMENT = gql`
     jobTypes
     registrationNeeded
     registrationInstructions
-    reputationNetworks
+    reputationNetworks {
+      address
+    }
     name
     category
     staker {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Update `LEADER_FRAGMENT` to include address field in reputationNetworks. It's fine in Python SDK

## How has this been tested?
Queried operator methods locally 

## Release plan
Deploy new Typescript SDK version 

## Potential risks; What to monitor; Rollback plan
None