### PR TITLE
[SDK][Typescript] Change contract visibility in EscrowClient and KVStoreClient

### DIFF
--- a/.changeset/eleven-clubs-itch.md
+++ b/.changeset/eleven-clubs-itch.md
@@ -1,0 +1,5 @@
+---
+"@human-protocol/sdk": patch
+---
+
+Change contract visibility from private to public in EscrowClient and KVStoreClient

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow.ts
@@ -146,7 +146,7 @@ import {
  * ```
  */
 export class EscrowClient extends BaseEthersClient {
-  private escrowFactoryContract: EscrowFactory;
+  public escrowFactoryContract: EscrowFactory;
 
   /**
    * **EscrowClient constructor**

--- a/packages/sdk/typescript/human-protocol-sdk/src/kvstore.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/kvstore.ts
@@ -96,7 +96,7 @@ import { IKVStore, SubgraphOptions } from './interfaces';
  */
 
 export class KVStoreClient extends BaseEthersClient {
-  private contract: KVStore;
+  public contract: KVStore;
 
   /**
    * **KVStoreClient constructor**


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Change contract visibility from private to public in EscrowClient and KVStoreClient

## How has this been tested?
Ran tests locally

## Release plan
Deploy new TS SDK version

## Potential risks; What to monitor; Rollback plan
None