### PR TITLE
[Human App][Server] register HttpModule with custom paramsSerializer in ExchangeOracleModule

### DIFF
--- a/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.module.ts
+++ b/packages/apps/human-app/server/src/integrations/exchange-oracle/exchange-oracle.module.ts
@@ -6,7 +6,15 @@ import { EscrowUtilsModule } from '../escrow/escrow-utils.module';
 import { KvStoreModule } from '../kv-store/kv-store.module';
 
 @Module({
-  imports: [HttpModule, EscrowUtilsModule, KvStoreModule],
+  imports: [
+    HttpModule.register({
+      paramsSerializer: {
+        indexes: null,
+      },
+    }),
+    EscrowUtilsModule,
+    KvStoreModule,
+  ],
   providers: [ExchangeOracleGateway, ExchangeOracleProfile],
   exports: [ExchangeOracleGateway],
 })


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
After upgrading `@nestjs/axios`, array query params started being encoded as fields[]=…, so the exchange oracle ignored requested fields. We re-registered the HttpModule inside ExchangeOracleModule with a custom params serializer that repeats keys without brackets, restoring the expected request format

## How has this been tested?
Deployed Human App locally.

## Release plan
Redeploy Human App server

## Potential risks; What to monitor; Rollback plan
None