### PR TITLE
[Subgraph] add indexerHints section with prune option in template.yaml

### DIFF
--- a/.changeset/forty-plums-pay.md
+++ b/.changeset/forty-plums-pay.md
@@ -1,0 +1,6 @@
+---
+"@human-protocol/python-sdk": patch
+"@human-protocol/sdk": patch
+---
+
+Add prune to subgraph and update ids for the new version

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -57,7 +57,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/ethereum/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmeCB3KX49nRAkzgqancc3yL3VMJvt65YtL1zrLCFgr2n5"
+            "https://gateway.thegraph.com/api/deployments/id/QmNhLQEfBJQ46fngBh4YCttk8kNkveFy5uvAeUmyAdX1kD"
         ),
         "hmt_address": "0xd1ba9BAC957322D6e8c07a160a3A8dA11A0d2867",
         "factory_address": "0xD9c75a1Aa4237BB72a41E5E26bd8384f10c1f55a",
@@ -73,7 +73,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/sepolia/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmcMntqZSTh8wJddxgp2hYcdw78wZFU86LHTHzJ1bTVUDc"
+            "https://gateway.thegraph.com/api/deployments/id/QmQghdr7hxqrjFde8DN15TzfrJLCfwvzmUH9RzWwH1mKzk"
         ),
         "hmt_address": "0x792abbcC99c01dbDec49c9fa9A828a186Da45C33",
         "factory_address": "0x5987A5558d961ee674efe4A8c8eB7B1b5495D3bf",
@@ -89,7 +89,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/bsc/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmRexbu8eLZ1iE7ZLMtKxAr9GJnQ1JVrXhybKq6JkJ9XLE"
+            "https://gateway.thegraph.com/api/deployments/id/QmTioC9Z1HzKSCnEKL3BP9iHqbgZt1ceLU2VE4Mv6sxNkd"
         ),
         "hmt_address": "0x711Fd6ab6d65A98904522d4e3586F492B989c527",
         "factory_address": "0x92FD968AcBd521c232f5fB8c33b342923cC72714",
@@ -105,7 +105,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/bsc-testnet/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmfFBXsAP7nbckFx34XYcNq2hRnfoVNrfqCvuk7hmAtYJT"
+            "https://gateway.thegraph.com/api/deployments/id/QmPyUYRjAvzDdeenXMGHcCRD2v4qwZbKMEkVkY3Jq6VLwn"
         ),
         "hmt_address": "0xE3D74BBFa45B4bCa69FF28891fBE392f4B4d4e4d",
         "factory_address": "0x2bfA592DBDaF434DDcbb893B1916120d181DAD18",
@@ -123,7 +123,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/polygon/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmUwHMDjnDHDB5cowGqd96SRJ1sZegoAPanjxBWUyLZghv"
+            "https://gateway.thegraph.com/api/deployments/id/QmQNkWNE5FPtqbtSkdtR6AEBJz9N7WDz1X7pfvQqYAcUZJ"
         ),
         "hmt_address": "0xc748B2A084F8eFc47E086ccdDD9b7e67aEb571BF",
         "factory_address": "0xBDBfD2cC708199C5640C6ECdf3B0F4A4C67AdfcB",
@@ -141,7 +141,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/amoy/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmTJfcvVVmw8fe5CwRP6tZD5FzE2ESrm3ryygS1YZMYhM7"
+            "https://gateway.thegraph.com/api/deployments/id/QmcLwLMw3UzCSbNbjegrpNu6PB3kAd67xquuyaVWvc5Q7Q"
         ),
         "hmt_address": "0x792abbcC99c01dbDec49c9fa9A828a186Da45C33",
         "factory_address": "0xAFf5a986A530ff839d49325A5dF69F96627E8D29",

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/cancel.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/cancel.py
@@ -70,6 +70,4 @@ query GetCancellationRefundEventByEscrow(
     }}
 }}
 {cancellation_refund_fragment}
-""".format(
-        cancellation_refund_fragment=cancellation_refund_fragment
-    )
+""".format(cancellation_refund_fragment=cancellation_refund_fragment)

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
@@ -97,9 +97,7 @@ query GetEscrow(
     }}
 }}
 {escrow_fragment}
-""".format(
-        escrow_fragment=escrow_fragment
-    )
+""".format(escrow_fragment=escrow_fragment)
 
 
 def get_status_query(

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/reward.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/reward.py
@@ -14,6 +14,4 @@ query GetRewardAddedEvents($slasherAddress: String!) {{
     }}
 }}
 {reward_added_event_fragment}
-""".format(
-    reward_added_event_fragment=reward_added_event_fragment
-)
+""".format(reward_added_event_fragment=reward_added_event_fragment)

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/transaction.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/transaction.py
@@ -103,6 +103,4 @@ query GetTransaction(
     }}
 }}
 {transaction_fragment}
-""".format(
-        transaction_fragment=transaction_fragment
-    )
+""".format(transaction_fragment=transaction_fragment)

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/worker.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/worker.py
@@ -18,9 +18,7 @@ query GetWorker($address: String!) {{
     }}
 }}
 {worker_fragment}
-""".format(
-        worker_fragment=worker_fragment
-    )
+""".format(worker_fragment=worker_fragment)
 
 
 def get_workers_query(filter: WorkerFilter) -> str:

--- a/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
@@ -36,7 +36,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/ethereum/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmeCB3KX49nRAkzgqancc3yL3VMJvt65YtL1zrLCFgr2n5',
+      'https://gateway.thegraph.com/api/deployments/id/QmNhLQEfBJQ46fngBh4YCttk8kNkveFy5uvAeUmyAdX1kD',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
   },
@@ -51,7 +51,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/sepolia/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmcMntqZSTh8wJddxgp2hYcdw78wZFU86LHTHzJ1bTVUDc',
+      'https://gateway.thegraph.com/api/deployments/id/QmQghdr7hxqrjFde8DN15TzfrJLCfwvzmUH9RzWwH1mKzk',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
   },
@@ -66,7 +66,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/bsc/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmRexbu8eLZ1iE7ZLMtKxAr9GJnQ1JVrXhybKq6JkJ9XLE',
+      'https://gateway.thegraph.com/api/deployments/id/QmTioC9Z1HzKSCnEKL3BP9iHqbgZt1ceLU2VE4Mv6sxNkd',
     oldSubgraphUrl: 'https://api.thegraph.com/subgraphs/name/humanprotocol/bsc',
     oldFactoryAddress: '0xc88bC422cAAb2ac8812de03176402dbcA09533f4',
   },
@@ -81,7 +81,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/bsc-testnet/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmfFBXsAP7nbckFx34XYcNq2hRnfoVNrfqCvuk7hmAtYJT',
+      'https://gateway.thegraph.com/api/deployments/id/QmPyUYRjAvzDdeenXMGHcCRD2v4qwZbKMEkVkY3Jq6VLwn',
     oldSubgraphUrl:
       'https://api.thegraph.com/subgraphs/name/humanprotocol/bsctest',
     oldFactoryAddress: '0xaae6a2646c1f88763e62e0cd08ad050ea66ac46f',
@@ -97,7 +97,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/polygon/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmUwHMDjnDHDB5cowGqd96SRJ1sZegoAPanjxBWUyLZghv',
+      'https://gateway.thegraph.com/api/deployments/id/QmQNkWNE5FPtqbtSkdtR6AEBJz9N7WDz1X7pfvQqYAcUZJ',
     oldSubgraphUrl:
       'https://api.thegraph.com/subgraphs/name/humanprotocol/polygon',
     oldFactoryAddress: '0x45eBc3eAE6DA485097054ae10BA1A0f8e8c7f794',
@@ -113,7 +113,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/amoy/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmTJfcvVVmw8fe5CwRP6tZD5FzE2ESrm3ryygS1YZMYhM7',
+      'https://gateway.thegraph.com/api/deployments/id/QmcLwLMw3UzCSbNbjegrpNu6PB3kAd67xquuyaVWvc5Q7Q',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
   },

--- a/packages/sdk/typescript/subgraph/.prettierignore
+++ b/packages/sdk/typescript/subgraph/.prettierignore
@@ -1,0 +1,2 @@
+# Mustache template; not valid YAML for Prettier's YAML parser
+template.yaml

--- a/packages/sdk/typescript/subgraph/template.yaml
+++ b/packages/sdk/typescript/subgraph/template.yaml
@@ -2,6 +2,8 @@ specVersion: 1.0.0
 description: '{{ description }}'
 schema:
   file: ./schema.graphql
+indexerHints:
+  prune: auto
 dataSources:
   - kind: ethereum
     name: EscrowFactory


### PR DESCRIPTION
## Issue tracking
Close #3764

## Context behind the change
Add `prune: auto` option in `subgraph.yaml`. This will automatically clean up old historical data, keeping the Indexer efficient and our response times shorter

## How has this been tested?
Deployed a test version on polygon and executed a benchmark. Requests times have decreased considerably, practically halving for historical requests.
<img width="831" height="378" alt="image" src="https://github.com/user-attachments/assets/54ca7775-4a91-4f8d-a280-44dc856f78de" />

## Release plan
Deploy new Subgraphs

## Potential risks; What to monitor; Rollback plan
None