### PR TITLE
[SDK][Python] Fix failing tests due to unused import

### DIFF
--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/utils.py
@@ -10,7 +10,6 @@ import requests
 from human_protocol_sdk.constants import (
     ARTIFACTS_FOLDER,
     DEFAULT_CONFIRMATION_POLL_INTERVAL,
-    SUBGRAPH_API_KEY_PLACEHOLDER,
     ChainId,
 )
 from validators import url as URL


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
Clean up code and fix tests by removing unused `SUBGRAPH_API_KEY_PLACEHOLDER` constant.

## How has this been tested?
Ran tests

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None