### PR TITLE
[SDK] Handle subgraph errors properly 

### DIFF
--- a/.changeset/crisp-buckets-agree.md
+++ b/.changeset/crisp-buckets-agree.md
@@ -1,0 +1,5 @@
+---
+"@human-protocol/sdk": minor
+---
+
+Added typed subgraph errors (SubgraphRequestError, SubgraphBadIndexerError) and wrapped subgraph request failures with these classes

--- a/packages/apps/dashboard/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/dashboard/server/src/common/filters/exception.filter.ts
@@ -28,7 +28,7 @@ export class ExceptionFilter implements IExceptionFilter {
       status = HttpStatus.BAD_GATEWAY;
       responseBody.message = exception.message;
 
-      this.logger.error('Unhandled subgraph error', {
+      this.logger.error('Subgraph request failed', {
         error: exception,
         path: request.url,
       });

--- a/packages/apps/dashboard/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/dashboard/server/src/common/filters/exception.filter.ts
@@ -6,6 +6,10 @@ import {
   HttpException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import {
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
+} from '@human-protocol/sdk';
 
 import logger from '../../logger';
 
@@ -23,7 +27,22 @@ export class ExceptionFilter implements IExceptionFilter {
       message: 'Internal server error',
     };
 
-    if (exception instanceof HttpException) {
+    if (exception instanceof SubgraphRequestError) {
+      status = HttpStatus.BAD_GATEWAY;
+      responseBody.message = exception.message;
+
+      if (exception instanceof SubgraphBadIndexerError) {
+        this.logger.warn('Subgraph bad indexers', {
+          error: exception,
+          path: request.url,
+        });
+      } else {
+        this.logger.error('Subgraph request failed', {
+          error: exception,
+          path: request.url,
+        });
+      }
+    } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const exceptionResponse = exception.getResponse();
       if (typeof exceptionResponse === 'string') {

--- a/packages/apps/dashboard/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/dashboard/server/src/common/filters/exception.filter.ts
@@ -6,10 +6,7 @@ import {
   HttpException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import {
-  SubgraphBadIndexerError,
-  SubgraphRequestError,
-} from '@human-protocol/sdk';
+import { SubgraphRequestError } from '@human-protocol/sdk';
 
 import logger from '../../logger';
 
@@ -31,17 +28,10 @@ export class ExceptionFilter implements IExceptionFilter {
       status = HttpStatus.BAD_GATEWAY;
       responseBody.message = exception.message;
 
-      if (exception instanceof SubgraphBadIndexerError) {
-        this.logger.warn('Subgraph bad indexers', {
-          error: exception,
-          path: request.url,
-        });
-      } else {
-        this.logger.error('Subgraph request failed', {
-          error: exception,
-          path: request.url,
-        });
-      }
+      this.logger.error('Unhandled subgraph error', {
+        error: exception,
+        path: request.url,
+      });
     } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const exceptionResponse = exception.getResponse();

--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -5,10 +5,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import {
-  SubgraphBadIndexerError,
-  SubgraphRequestError,
-} from '@human-protocol/sdk';
+import { SubgraphRequestError } from '@human-protocol/sdk';
 
 import logger from '../../logger';
 import {
@@ -58,17 +55,10 @@ export class ExceptionFilter implements IExceptionFilter {
     const message = exception.message || 'Internal server error';
 
     if (exception instanceof SubgraphRequestError) {
-      if (exception instanceof SubgraphBadIndexerError) {
-        this.logger.warn('Subgraph bad indexers', {
-          error: exception,
-          path: request.url,
-        });
-      } else {
-        this.logger.error('Subgraph request failed', {
-          error: exception,
-          path: request.url,
-        });
-      }
+      this.logger.error('Subgraph request failed', {
+        error: exception,
+        path: request.url,
+      });
     } else if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
       this.logger.error('Unhandled exception', {
         error: exception,

--- a/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/common/exceptions/exception.filter.ts
@@ -5,6 +5,10 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import {
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
+} from '@human-protocol/sdk';
 
 import logger from '../../logger';
 import {
@@ -36,6 +40,8 @@ export class ExceptionFilter implements IExceptionFilter {
       return HttpStatus.UNPROCESSABLE_ENTITY;
     } else if (exception instanceof DatabaseError) {
       return HttpStatus.UNPROCESSABLE_ENTITY;
+    } else if (exception instanceof SubgraphRequestError) {
+      return HttpStatus.BAD_GATEWAY;
     }
 
     const exceptionStatusCode = exception.statusCode || exception.status;
@@ -51,7 +57,19 @@ export class ExceptionFilter implements IExceptionFilter {
     const status = this.getStatus(exception);
     const message = exception.message || 'Internal server error';
 
-    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+    if (exception instanceof SubgraphRequestError) {
+      if (exception instanceof SubgraphBadIndexerError) {
+        this.logger.warn('Subgraph bad indexers', {
+          error: exception,
+          path: request.url,
+        });
+      } else {
+        this.logger.error('Subgraph request failed', {
+          error: exception,
+          path: request.url,
+        });
+      }
+    } else if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
       this.logger.error('Unhandled exception', {
         error: exception,
         path: request.url,

--- a/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
@@ -5,10 +5,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import {
-  SubgraphBadIndexerError,
-  SubgraphRequestError,
-} from '@human-protocol/sdk';
+import { SubgraphRequestError } from '@human-protocol/sdk';
 
 import logger from '../../logger';
 import {
@@ -55,17 +52,10 @@ export class ExceptionFilter implements IExceptionFilter {
     const message = exception.message || 'Internal server error';
 
     if (exception instanceof SubgraphRequestError) {
-      if (exception instanceof SubgraphBadIndexerError) {
-        this.logger.warn('Subgraph bad indexers', {
-          error: exception,
-          path: request.url,
-        });
-      } else {
-        this.logger.error('Subgraph request failed', {
-          error: exception,
-          path: request.url,
-        });
-      }
+      this.logger.error('Subgraph request failed', {
+        error: exception,
+        path: request.url,
+      });
     } else if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
       this.logger.error('Unhandled exception', {
         error: exception,

--- a/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/exceptions/exception.filter.ts
@@ -5,6 +5,10 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import {
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
+} from '@human-protocol/sdk';
 
 import logger from '../../logger';
 import {
@@ -33,6 +37,8 @@ export class ExceptionFilter implements IExceptionFilter {
       return HttpStatus.CONFLICT;
     } else if (exception instanceof ServerError) {
       return HttpStatus.UNPROCESSABLE_ENTITY;
+    } else if (exception instanceof SubgraphRequestError) {
+      return HttpStatus.BAD_GATEWAY;
     }
 
     const exceptionStatusCode = exception.statusCode || exception.status;
@@ -48,7 +54,19 @@ export class ExceptionFilter implements IExceptionFilter {
     const status = this.getStatus(exception);
     const message = exception.message || 'Internal server error';
 
-    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+    if (exception instanceof SubgraphRequestError) {
+      if (exception instanceof SubgraphBadIndexerError) {
+        this.logger.warn('Subgraph bad indexers', {
+          error: exception,
+          path: request.url,
+        });
+      } else {
+        this.logger.error('Subgraph request failed', {
+          error: exception,
+          path: request.url,
+        });
+      }
+    } else if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
       this.logger.error('Unhandled exception', {
         error: exception,
         path: request.url,

--- a/packages/apps/human-app/server/src/common/filter/exceptions.filter.ts
+++ b/packages/apps/human-app/server/src/common/filter/exceptions.filter.ts
@@ -5,10 +5,7 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
-import {
-  SubgraphBadIndexerError,
-  SubgraphRequestError,
-} from '@human-protocol/sdk';
+import { SubgraphRequestError } from '@human-protocol/sdk';
 import logger from '../../logger';
 import { AxiosError } from 'axios';
 import * as errorUtils from '../utils/error';
@@ -29,17 +26,10 @@ export class ExceptionFilter implements IExceptionFilter {
       status = HttpStatus.BAD_GATEWAY;
       message = exception.message;
 
-      if (exception instanceof SubgraphBadIndexerError) {
-        this.logger.warn('Subgraph bad indexers', {
-          error: errorUtils.formatError(exception),
-          path: request.url,
-        });
-      } else {
-        this.logger.error('Subgraph request failed', {
-          error: errorUtils.formatError(exception),
-          path: request.url,
-        });
-      }
+      this.logger.error('Subgraph request failed', {
+        error: errorUtils.formatError(exception),
+        path: request.url,
+      });
     } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       message = exception.getResponse();

--- a/packages/apps/human-app/server/src/common/filter/exceptions.filter.ts
+++ b/packages/apps/human-app/server/src/common/filter/exceptions.filter.ts
@@ -5,6 +5,10 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
+} from '@human-protocol/sdk';
 import logger from '../../logger';
 import { AxiosError } from 'axios';
 import * as errorUtils from '../utils/error';
@@ -21,7 +25,22 @@ export class ExceptionFilter implements IExceptionFilter {
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message: any = 'Internal Server Error';
 
-    if (exception instanceof HttpException) {
+    if (exception instanceof SubgraphRequestError) {
+      status = HttpStatus.BAD_GATEWAY;
+      message = exception.message;
+
+      if (exception instanceof SubgraphBadIndexerError) {
+        this.logger.warn('Subgraph bad indexers', {
+          error: errorUtils.formatError(exception),
+          path: request.url,
+        });
+      } else {
+        this.logger.error('Subgraph request failed', {
+          error: errorUtils.formatError(exception),
+          path: request.url,
+        });
+      }
+    } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       message = exception.getResponse();
     } else if (exception instanceof AxiosError) {

--- a/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
@@ -5,6 +5,10 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import {
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
+} from '@human-protocol/sdk';
 
 import {
   ValidationError,
@@ -36,6 +40,8 @@ export class ExceptionFilter implements IExceptionFilter {
       return HttpStatus.UNPROCESSABLE_ENTITY;
     } else if (exception instanceof DatabaseError) {
       return HttpStatus.UNPROCESSABLE_ENTITY;
+    } else if (exception instanceof SubgraphRequestError) {
+      return HttpStatus.BAD_GATEWAY;
     }
 
     const exceptionStatusCode = exception.statusCode || exception.status;
@@ -51,7 +57,17 @@ export class ExceptionFilter implements IExceptionFilter {
     const status = this.getStatus(exception);
     const message = exception.message || 'Internal server error';
 
-    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+    if (exception instanceof SubgraphBadIndexerError) {
+      this.logger.warn('Subgraph bad indexers', {
+        error: exception,
+        path: request.url,
+      });
+    } else if (exception instanceof SubgraphRequestError) {
+      this.logger.error('Subgraph request failed', {
+        error: exception,
+        path: request.url,
+      });
+    } else if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
       this.logger.error('Unhandled exception', {
         error: exception,
         path: request.url,

--- a/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
+++ b/packages/apps/job-launcher/server/src/common/exceptions/exception.filter.ts
@@ -5,10 +5,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import {
-  SubgraphBadIndexerError,
-  SubgraphRequestError,
-} from '@human-protocol/sdk';
+import { SubgraphRequestError } from '@human-protocol/sdk';
 
 import {
   ValidationError,
@@ -57,12 +54,7 @@ export class ExceptionFilter implements IExceptionFilter {
     const status = this.getStatus(exception);
     const message = exception.message || 'Internal server error';
 
-    if (exception instanceof SubgraphBadIndexerError) {
-      this.logger.warn('Subgraph bad indexers', {
-        error: exception,
-        path: request.url,
-      });
-    } else if (exception instanceof SubgraphRequestError) {
+    if (exception instanceof SubgraphRequestError) {
       this.logger.error('Subgraph request failed', {
         error: exception,
         path: request.url,

--- a/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
@@ -1,4 +1,8 @@
 import {
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
+} from '@human-protocol/sdk';
+import {
   ArgumentsHost,
   Catch,
   ExceptionFilter as IExceptionFilter,
@@ -31,6 +35,20 @@ export class ExceptionFilter implements IExceptionFilter {
         responseBody.message = 'Unprocessable entity';
       }
       this.logger.error('Database error', exception);
+    } else if (exception instanceof SubgraphRequestError) {
+      status = HttpStatus.BAD_GATEWAY;
+      responseBody.message = exception.message;
+      if (exception instanceof SubgraphBadIndexerError) {
+        this.logger.warn('Subgraph bad indexers', {
+          error: exception,
+          path: request.url,
+        });
+      } else {
+        this.logger.error('Subgraph request failed', {
+          error: exception,
+          path: request.url,
+        });
+      }
     } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const exceptionResponse = exception.getResponse();

--- a/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
+++ b/packages/apps/reputation-oracle/server/src/common/filters/exception.filter.ts
@@ -1,7 +1,4 @@
-import {
-  SubgraphBadIndexerError,
-  SubgraphRequestError,
-} from '@human-protocol/sdk';
+import { SubgraphRequestError } from '@human-protocol/sdk';
 import {
   ArgumentsHost,
   Catch,
@@ -38,17 +35,10 @@ export class ExceptionFilter implements IExceptionFilter {
     } else if (exception instanceof SubgraphRequestError) {
       status = HttpStatus.BAD_GATEWAY;
       responseBody.message = exception.message;
-      if (exception instanceof SubgraphBadIndexerError) {
-        this.logger.warn('Subgraph bad indexers', {
-          error: exception,
-          path: request.url,
-        });
-      } else {
-        this.logger.error('Subgraph request failed', {
-          error: exception,
-          path: request.url,
-        });
-      }
+      this.logger.error('Subgraph request failed', {
+        error: exception,
+        path: request.url,
+      });
     } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const exceptionResponse = exception.getResponse();

--- a/packages/sdk/typescript/human-protocol-sdk/src/error.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/error.ts
@@ -349,3 +349,17 @@ export class InvalidKeyError extends Error {
     super(`Key "${key}" not found for address ${address}`);
   }
 }
+
+export class SubgraphRequestError extends Error {
+  public readonly statusCode?: number;
+  public readonly url: string;
+
+  constructor(message: string, url: string, statusCode?: number) {
+    super(message);
+    this.name = this.constructor.name;
+    this.url = url;
+    this.statusCode = statusCode;
+  }
+}
+
+export class SubgraphBadIndexerError extends SubgraphRequestError {}

--- a/packages/sdk/typescript/human-protocol-sdk/src/index.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/index.ts
@@ -22,6 +22,8 @@ export {
   ContractExecutionError,
   InvalidEthereumAddressError,
   InvalidKeyError,
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
 } from './error';
 
 export {

--- a/packages/sdk/typescript/human-protocol-sdk/src/utils.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/utils.ts
@@ -13,6 +13,8 @@ import {
   NonceExpired,
   NumericFault,
   ReplacementUnderpriced,
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
   TransactionReplaced,
   WarnSubgraphApiKeyNotProvided,
 } from './error';
@@ -117,6 +119,38 @@ export const isIndexerError = (error: any): boolean => {
   return errorMessage.toLowerCase().includes('bad indexers');
 };
 
+const getSubgraphErrorMessage = (error: any): string => {
+  return (
+    error?.response?.errors?.[0]?.message ||
+    error?.message ||
+    error?.toString?.() ||
+    'Subgraph request failed'
+  );
+};
+
+const getSubgraphStatusCode = (error: any): number | undefined => {
+  if (typeof error?.response?.status === 'number') {
+    return error.response.status;
+  }
+
+  if (typeof error?.status === 'number') {
+    return error.status;
+  }
+
+  return undefined;
+};
+
+const toSubgraphError = (error: any, url: string): Error => {
+  const message = getSubgraphErrorMessage(error);
+  const statusCode = getSubgraphStatusCode(error);
+
+  if (isIndexerError(error)) {
+    return new SubgraphBadIndexerError(message, url, statusCode);
+  }
+
+  return new SubgraphRequestError(message, url, statusCode);
+};
+
 const sleep = (ms: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
@@ -154,7 +188,11 @@ export const customGqlFetch = async <T = any>(
     : undefined;
 
   if (!options) {
-    return await gqlFetch<T>(url, query, variables, headers);
+    try {
+      return await gqlFetch<T>(url, query, variables, headers);
+    } catch (error) {
+      throw toSubgraphError(error, url);
+    }
   }
 
   const hasMaxRetries = options.maxRetries !== undefined;
@@ -177,10 +215,11 @@ export const customGqlFetch = async <T = any>(
     try {
       return await gqlFetch<T>(targetUrl, query, variables, headers);
     } catch (error) {
-      lastError = error;
+      const wrappedError = toSubgraphError(error, targetUrl);
+      lastError = wrappedError;
 
       if (attempt === maxRetries || !isIndexerError(error)) {
-        throw error;
+        throw wrappedError;
       }
 
       const delay = baseDelay * attempt;

--- a/packages/sdk/typescript/human-protocol-sdk/test/utils.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/utils.test.ts
@@ -19,6 +19,8 @@ import {
   WarnSubgraphApiKeyNotProvided,
   ErrorRetryParametersMissing,
   ErrorRoutingRequestsToIndexerRequiresApiKey,
+  SubgraphBadIndexerError,
+  SubgraphRequestError,
 } from '../src/error';
 import {
   getSubgraphUrl,
@@ -340,7 +342,7 @@ describe('customGqlFetch', () => {
         maxRetries: 3,
         baseDelay: 10,
       })
-    ).rejects.toThrow('Regular GraphQL error');
+    ).rejects.toThrow(SubgraphRequestError);
 
     expect(gqlFetchSpy).toHaveBeenCalledTimes(1);
   });
@@ -360,7 +362,7 @@ describe('customGqlFetch', () => {
         maxRetries: 2,
         baseDelay: 10,
       })
-    ).rejects.toEqual(badIndexerError);
+    ).rejects.toThrow(SubgraphBadIndexerError);
 
     expect(gqlFetchSpy).toHaveBeenCalledTimes(3);
   });
@@ -400,8 +402,20 @@ describe('customGqlFetch', () => {
         maxRetries: 1,
         baseDelay: 10,
       })
-    ).rejects.toEqual(badIndexerError);
+    ).rejects.toThrow(SubgraphBadIndexerError);
 
     expect(gqlFetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('wraps subgraph request errors even when no retry config is provided', async () => {
+    const gqlFetchSpy = vi
+      .spyOn(gqlFetch, 'default')
+      .mockRejectedValue(new Error('fetch failed'));
+
+    await expect(
+      customGqlFetch(mockUrl, mockQuery, mockVariables)
+    ).rejects.toThrow(SubgraphRequestError);
+
+    expect(gqlFetchSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Issue tracking
Close #3745

## Context behind the change
- Added typed subgraph errors in TS (`SubgraphRequestError`, `SubgraphBadIndexerError`)
- Updated exception filters to avoid logging bad indexers as “Unhandled exception”
- Other subgraph failures are still logged, but under a dedicated subgraph error path

## How has this been tested?
Ran unit tests

## Release plan

- Deploy new SDK version. 
- Add new monitor+alert on DataDog based on new logs

## Potential risks; What to monitor; Rollback plan
None