### PR TITLE
Fix Docker workspace build order by excluding app workspace from early foreach step

### DIFF
--- a/packages/apps/fortune/exchange-oracle/client/Dockerfile
+++ b/packages/apps/fortune/exchange-oracle/client/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/fortune-exchange-oracle-client
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/fortune-exchange-oracle-client run build
+RUN yarn workspaces foreach -Rpt --from @apps/fortune-exchange-oracle-client --exclude @apps/fortune-exchange-oracle-client run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/fortune/exchange-oracle/server/Dockerfile
+++ b/packages/apps/fortune/exchange-oracle/server/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/fortune-exchange-oracle-server
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/fortune-exchange-oracle-server run build
+RUN yarn workspaces foreach -Rpt --from @apps/fortune-exchange-oracle-server --exclude @apps/fortune-exchange-oracle-server run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/fortune/recording-oracle/Dockerfile
+++ b/packages/apps/fortune/recording-oracle/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/fortune-recording-oracle
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/fortune-recording-oracle run build
+RUN yarn workspaces foreach -Rpt --from @apps/fortune-recording-oracle --exclude @apps/fortune-recording-oracle run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/human-app/frontend/Dockerfile
+++ b/packages/apps/human-app/frontend/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/human-app-frontend
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/human-app-frontend run build
+RUN yarn workspaces foreach -Rpt --from @apps/human-app-frontend --exclude @apps/human-app-frontend run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/human-app/server/Dockerfile
+++ b/packages/apps/human-app/server/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/human-app-server
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/human-app-server run build
+RUN yarn workspaces foreach -Rpt --from @apps/human-app-server --exclude @apps/human-app-server run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/job-launcher/client/Dockerfile
+++ b/packages/apps/job-launcher/client/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/job-launcher-client
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/job-launcher-client run build
+RUN yarn workspaces foreach -Rpt --from @apps/job-launcher-client --exclude @apps/job-launcher-client run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/job-launcher/server/Dockerfile
+++ b/packages/apps/job-launcher/server/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspaces focus @apps/job-launcher-server
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
 # Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/job-launcher-server run build
+RUN yarn workspaces foreach -Rpt --from @apps/job-launcher-server --exclude @apps/job-launcher-server run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}

--- a/packages/apps/reputation-oracle/server/Dockerfile
+++ b/packages/apps/reputation-oracle/server/Dockerfile
@@ -22,8 +22,9 @@ RUN yarn workspaces focus @apps/reputation-oracle
 
 # Copy base TS config that is required to build packages
 COPY tsconfig.base.json ./
-# Build libs (scoped)
-RUN yarn workspaces foreach -Rpt --from @apps/reputation-oracle run build
+# Build only dependency workspaces; the app itself is built later
+# after its full source (including tsconfig.json) is copied.
+RUN yarn workspaces foreach -Rpt --from @apps/reputation-oracle --exclude @apps/reputation-oracle run build
 
 # Copy everything else
 COPY ${APP_PATH} ./${APP_PATH}


### PR DESCRIPTION
## Issue tracking
None

## Context behind the change
Several app Dockerfiles were building workspaces too early with:
`yarn workspaces foreach -Rpt --from <app> run build`
At that stage, the full app source was not copied yet, so the app workspace could fail (for example missing `tsconfig.json`).
This PR updates those Dockerfiles to build only dependency workspaces first `--exclude <app>`, and keeps app build in the final RUN yarn build step after full source copy.

## How has this been tested?
Ran full local path: `DOCKER_PARALLEL=1 make -C docker-setup build-services`.

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None