### PR TITLE
[SDK] feat: consistent kvstore.get in python sdk

### DIFF
--- a/.changeset/cozy-poets-go.md
+++ b/.changeset/cozy-poets-go.md
@@ -1,0 +1,6 @@
+---
+"@human-protocol/sdk": major
+"@human-protocol/python-sdk": major
+---
+
+Updated KV Store utils in sdk to return empty string in case no value in subgraph instead of throwing and error

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore/kvstore_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/kvstore/kvstore_utils.py
@@ -125,7 +125,7 @@ class KVStoreUtils:
         address: str,
         key: str,
         options: Optional[SubgraphOptions] = None,
-    ) -> Optional[str]:
+    ) -> str:
         """Get the value of a specific key for an address.
 
         Queries the subgraph for a specific key-value pair associated with an address.
@@ -181,7 +181,7 @@ class KVStoreUtils:
             or "kvstores" not in kvstore_data["data"]
             or len(kvstore_data["data"]["kvstores"]) == 0
         ):
-            return None
+            return ""
 
         return kvstore_data["data"]["kvstores"][0]["value"]
 
@@ -232,12 +232,12 @@ class KVStoreUtils:
             raise KVStoreClientError(f"Invalid address: {address}")
 
         url = KVStoreUtils.get(chain_id, address, key, options=options)
-        if url is None:
+        if url == "":
             raise KVStoreClientError("No URL found for the given address and key")
 
         hash = KVStoreUtils.get(chain_id, address, key + "_hash", options=options)
 
-        if hash is None:
+        if hash == "":
             raise KVStoreClientError("No hash found for the given address and url")
 
         content = requests.get(url).text

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/kvstore/test_kvstore_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/kvstore/test_kvstore_utils.py
@@ -149,7 +149,7 @@ class TestKVStoreUtils(unittest.TestCase):
 
         result = KVStoreUtils.get(ChainId.LOCALHOST, address, key)
 
-        self.assertIsNone(result)
+        self.assertEqual(result, "")
 
         mock_function.assert_called_once_with(
             NETWORKS[ChainId.LOCALHOST],


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Follow up to https://github.com/humanprotocol/human-protocol/pull/3819:
- added missed changeset
- applied suggestions from aforementioned PR to python sdk as well so we always return empty string instead of `None`

## How has this been tested?
- [x] unit tests

## Release plan
As part of base PR

## Potential risks; What to monitor; Rollback plan
None