### PR TITLE
add cancellationRequestedAt field to Escrow data model and related functionality

### DIFF
--- a/.changeset/wide-islands-leave.md
+++ b/.changeset/wide-islands-leave.md
@@ -1,6 +1,0 @@
----
-"@human-protocol/sdk": minor
-"@human-protocol/python-sdk": minor
----
-
-Add cancellationRequestedAt field to Escrow data model

--- a/.changeset/wide-islands-leave.md
+++ b/.changeset/wide-islands-leave.md
@@ -1,0 +1,6 @@
+---
+"@human-protocol/sdk": minor
+"@human-protocol/python-sdk": minor
+---
+
+Add cancellationRequestedAt field to Escrow data model

--- a/.github/workflows/cd-subgraph-hmt.yaml
+++ b/.github/workflows/cd-subgraph-hmt.yaml
@@ -53,9 +53,9 @@ jobs:
       - name: Install dependencies
         if: steps.filter_networks.outputs.continue == 'true'
         run: yarn workspaces focus @tools/subgraph-hmt
-      - name: Build packages (scoped)
+      - name: Build core dependency
         if: steps.filter_networks.outputs.continue == 'true'
-        run: yarn workspaces foreach -Rpt --from @tools/subgraph-hmt run build
+        run: yarn workspace @human-protocol/core build
       - name: Generate and build Subgraph
         if: steps.filter_networks.outputs.continue == 'true'
         run: yarn generate && yarn build

--- a/.github/workflows/cd-subgraph-human.yaml
+++ b/.github/workflows/cd-subgraph-human.yaml
@@ -53,9 +53,9 @@ jobs:
       - name: Install dependencies
         if: steps.filter_networks.outputs.continue == 'true'
         run: yarn workspaces focus @tools/subgraph-human-protocol
-      - name: Build packages (scoped)
+      - name: Build core dependency
         if: steps.filter_networks.outputs.continue == 'true'
-        run: yarn workspaces foreach -Rpt --from @tools/subgraph-human-protocol run build
+        run: yarn workspace @human-protocol/core build
       - name: Generate and build Subgraph
         if: steps.filter_networks.outputs.continue == 'true'
         run: yarn generate && yarn build

--- a/packages/sdk/python/human-protocol-sdk/CHANGELOG.md
+++ b/packages/sdk/python/human-protocol-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @human-protocol/python-sdk
 
+## 7.2.0
+
+### Minor Changes
+
+- af6ec22: Add cancellationRequestedAt field to Escrow data model
+
 ## 7.1.0
 
 ### Minor Changes

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -57,7 +57,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/human-ethereum/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmQZ3yL1FzydDwaB56ozgTiBESciTNFsMLyTBfHXzNd1gg"
+            "https://gateway.thegraph.com/api/deployments/id/QmceuRi331MC3NMajeLejepHShGNRaK87VRiePtHRbNsVV"
         ),
         "hmt_address": "0xd1ba9BAC957322D6e8c07a160a3A8dA11A0d2867",
         "factory_address": "0xD9c75a1Aa4237BB72a41E5E26bd8384f10c1f55a",
@@ -75,7 +75,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/human-sepolia/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmQEbyGSf8VG9pdskowsK6C977wkcyJSxw9q6EDctKEkUw"
+            "https://gateway.thegraph.com/api/deployments/id/QmdsJaanpNKXd3ov2Cp6vmpu8uvA69iBfwxswFMu4ZcmNJ"
         ),
         "hmt_address": "0x792abbcC99c01dbDec49c9fa9A828a186Da45C33",
         "factory_address": "0x5987A5558d961ee674efe4A8c8eB7B1b5495D3bf",
@@ -93,7 +93,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/human-bsc/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmV3nZUM51NGt7F8RpZP9GxKPpKox3F24iJ8H1ekPb6ha4"
+            "https://gateway.thegraph.com/api/deployments/id/QmcEAT53JPUfddhdxAdFMcHjEtQYpbzNiLkP5dMHZ9Stm7"
         ),
         "hmt_address": "0x711Fd6ab6d65A98904522d4e3586F492B989c527",
         "factory_address": "0x92FD968AcBd521c232f5fB8c33b342923cC72714",
@@ -111,7 +111,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/human-bsc-testnet/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmdQJog9vMghK2o39U9YJL8vpU9VZnkJa7jGg7wnsod7qV"
+            "https://gateway.thegraph.com/api/deployments/id/QmNNb3ZQdJiziXksfUNiKYKio7A9u8eMTJYB8jpWQza2uv"
         ),
         "hmt_address": "0xE3D74BBFa45B4bCa69FF28891fBE392f4B4d4e4d",
         "factory_address": "0x2bfA592DBDaF434DDcbb893B1916120d181DAD18",
@@ -131,7 +131,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/human-polygon/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmSu7B48kgGgMgXaD6Yb4fXjbnsJNmobKAU9qZgescZXid"
+            "https://gateway.thegraph.com/api/deployments/id/QmXPEzDjLTU8AiJ3Zemcodq8hVax3BvC3wskAqjULrgX7Z"
         ),
         "hmt_address": "0xc748B2A084F8eFc47E086ccdDD9b7e67aEb571BF",
         "factory_address": "0xBDBfD2cC708199C5640C6ECdf3B0F4A4C67AdfcB",
@@ -151,7 +151,7 @@ NETWORKS = {
             "https://api.studio.thegraph.com/query/74256/human-amoy/version/latest"
         ),
         "subgraph_url_api_key": (
-            "https://gateway.thegraph.com/api/deployments/id/QmRx5WSi7o9FtENWnE5eEz8Dr7kYUazk4TNPRt65UZkKkB"
+            "https://gateway.thegraph.com/api/deployments/id/QmW3KQfZu1sGz1CedPKC9okCuMFvi8EbrjKncoHn3UPFry"
         ),
         "hmt_address": "0x792abbcC99c01dbDec49c9fa9A828a186Da45C33",
         "factory_address": "0xAFf5a986A530ff839d49325A5dF69F96627E8D29",

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow/escrow_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/escrow/escrow_utils.py
@@ -68,6 +68,8 @@ class EscrowData:
         token (str): Address of the payment token.
         total_funded_amount (int): Total amount funded to the escrow.
         created_at (int): Creation timestamp in milliseconds.
+        cancellation_requested_at (Optional[int]): Cancellation request timestamp in
+            milliseconds.
         chain_id (ChainId): Chain where the escrow is deployed.
     """
 
@@ -86,6 +88,7 @@ class EscrowData:
         token: str,
         total_funded_amount: str,
         created_at: str,
+        cancellation_requested_at: Optional[str] = None,
         final_results_url: Optional[str] = None,
         final_results_hash: Optional[str] = None,
         intermediate_results_url: Optional[str] = None,
@@ -129,6 +132,11 @@ class EscrowData:
         self.token = token
         self.total_funded_amount = int(total_funded_amount)
         self.created_at = int(created_at) * 1000
+        self.cancellation_requested_at = (
+            int(cancellation_requested_at) * 1000
+            if cancellation_requested_at is not None
+            else None
+        )
         self.chain_id = chain_id
 
 
@@ -325,6 +333,7 @@ class EscrowUtils:
                     token=escrow.get("token"),
                     total_funded_amount=escrow.get("totalFundedAmount"),
                     created_at=escrow.get("createdAt"),
+                    cancellation_requested_at=escrow.get("cancellationRequestedAt"),
                     final_results_url=escrow.get("finalResultsUrl"),
                     final_results_hash=escrow.get("finalResultsHash"),
                     intermediate_results_url=escrow.get("intermediateResultsUrl"),
@@ -423,6 +432,7 @@ class EscrowUtils:
             token=escrow.get("token"),
             total_funded_amount=escrow.get("totalFundedAmount"),
             created_at=escrow.get("createdAt"),
+            cancellation_requested_at=escrow.get("cancellationRequestedAt"),
             final_results_url=escrow.get("finalResultsUrl"),
             final_results_hash=escrow.get("finalResultsHash"),
             intermediate_results_url=escrow.get("intermediateResultsUrl"),

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/gql/escrow.py
@@ -27,6 +27,7 @@ fragment EscrowFields on Escrow {
     token
     totalFundedAmount
     createdAt
+    cancellationRequestedAt
 }
 """
 

--- a/packages/sdk/python/human-protocol-sdk/package.json
+++ b/packages/sdk/python/human-protocol-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@human-protocol/python-sdk",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "private": true,
   "description": "Stub package to integrate the Python SDK with Changesets (dev-only).",
   "license": "MIT",

--- a/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/escrow/test_escrow_utils.py
+++ b/packages/sdk/python/human-protocol-sdk/test/human_protocol_sdk/escrow/test_escrow_utils.py
@@ -49,6 +49,7 @@ class TestEscrowUtils(unittest.TestCase):
                 "token": "0x1234567890123456789012345678901234567891",
                 "totalFundedAmount": "1000000000000000000",
                 "createdAt": "1683811973",
+                "cancellationRequestedAt": "1683812000",
             }
 
             def side_effect(subgraph_url, query, params, options):
@@ -134,6 +135,10 @@ class TestEscrowUtils(unittest.TestCase):
             self.assertEqual(
                 int(filtered[0].created_at), int(mock_escrow["createdAt"]) * 1000
             )
+            self.assertEqual(
+                int(filtered[0].cancellation_requested_at),
+                int(mock_escrow["cancellationRequestedAt"]) * 1000,
+            )
 
             filter = EscrowFilter(chain_id=ChainId.POLYGON_AMOY)
 
@@ -184,6 +189,7 @@ class TestEscrowUtils(unittest.TestCase):
                 "token": "0x1234567890123456789012345678901234567891",
                 "totalFundedAmount": "1000000000000000000",
                 "createdAt": "1672531200000",
+                "cancellationRequestedAt": None,
             }
             mock_escrow_2 = {
                 "id": "0x1234567890123456789012345678901234567891",
@@ -204,6 +210,7 @@ class TestEscrowUtils(unittest.TestCase):
                 "token": "0x1234567890123456789012345678901234567891",
                 "totalFundedAmount": "1000000000000000000",
                 "createdAt": "1672531200000",
+                "cancellationRequestedAt": None,
             }
 
             def side_effect(subgraph_url, query, params, options):
@@ -239,6 +246,8 @@ class TestEscrowUtils(unittest.TestCase):
             self.assertEqual(len(filtered), 2)
             self.assertEqual(filtered[0].address, mock_escrow_1["address"])
             self.assertEqual(filtered[1].address, mock_escrow_2["address"])
+            self.assertIsNone(filtered[0].cancellation_requested_at)
+            self.assertIsNone(filtered[1].cancellation_requested_at)
 
     def test_get_escrow(self):
         with patch(
@@ -268,6 +277,7 @@ class TestEscrowUtils(unittest.TestCase):
                 "token": "0x1234567890123456789012345678901234567891",
                 "totalFundedAmount": "1000000000000000000",
                 "createdAt": "1683813973",
+                "cancellationRequestedAt": "1683814000",
             }
 
             mock_function.return_value = {
@@ -325,6 +335,10 @@ class TestEscrowUtils(unittest.TestCase):
             )
             self.assertEqual(
                 int(escrow.created_at), int(mock_escrow["createdAt"]) * 1000
+            )
+            self.assertEqual(
+                int(escrow.cancellation_requested_at),
+                int(mock_escrow["cancellationRequestedAt"]) * 1000,
             )
 
     def test_get_escrow_empty_data(self):

--- a/packages/sdk/typescript/human-protocol-sdk/CHANGELOG.md
+++ b/packages/sdk/typescript/human-protocol-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @human-protocol/sdk
 
+## 7.2.0
+
+### Minor Changes
+
+- af6ec22: Add cancellationRequestedAt field to Escrow data model
+
 ## 7.1.0
 
 ### Minor Changes

--- a/packages/sdk/typescript/human-protocol-sdk/package.json
+++ b/packages/sdk/typescript/human-protocol-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@human-protocol/sdk",
   "description": "Human Protocol SDK",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "files": [
     "src",
     "dist"

--- a/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/constants.ts
@@ -36,7 +36,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/human-ethereum/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmQZ3yL1FzydDwaB56ozgTiBESciTNFsMLyTBfHXzNd1gg',
+      'https://gateway.thegraph.com/api/deployments/id/QmceuRi331MC3NMajeLejepHShGNRaK87VRiePtHRbNsVV',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
     hmtSubgraphUrl:
@@ -55,7 +55,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/human-sepolia/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmQEbyGSf8VG9pdskowsK6C977wkcyJSxw9q6EDctKEkUw',
+      'https://gateway.thegraph.com/api/deployments/id/QmdsJaanpNKXd3ov2Cp6vmpu8uvA69iBfwxswFMu4ZcmNJ',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
     hmtSubgraphUrl:
@@ -74,7 +74,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/human-bsc/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmV3nZUM51NGt7F8RpZP9GxKPpKox3F24iJ8H1ekPb6ha4',
+      'https://gateway.thegraph.com/api/deployments/id/QmcEAT53JPUfddhdxAdFMcHjEtQYpbzNiLkP5dMHZ9Stm7',
     oldSubgraphUrl: 'https://api.thegraph.com/subgraphs/name/humanprotocol/bsc',
     oldFactoryAddress: '0xc88bC422cAAb2ac8812de03176402dbcA09533f4',
     hmtSubgraphUrl:
@@ -93,7 +93,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/human-bsc-testnet/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmdQJog9vMghK2o39U9YJL8vpU9VZnkJa7jGg7wnsod7qV',
+      'https://gateway.thegraph.com/api/deployments/id/QmNNb3ZQdJiziXksfUNiKYKio7A9u8eMTJYB8jpWQza2uv',
     oldSubgraphUrl:
       'https://api.thegraph.com/subgraphs/name/humanprotocol/bsctest',
     oldFactoryAddress: '0xaae6a2646c1f88763e62e0cd08ad050ea66ac46f',
@@ -113,7 +113,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/human-polygon/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmSu7B48kgGgMgXaD6Yb4fXjbnsJNmobKAU9qZgescZXid',
+      'https://gateway.thegraph.com/api/deployments/id/QmXPEzDjLTU8AiJ3Zemcodq8hVax3BvC3wskAqjULrgX7Z',
     oldSubgraphUrl:
       'https://api.thegraph.com/subgraphs/name/humanprotocol/polygon',
     oldFactoryAddress: '0x45eBc3eAE6DA485097054ae10BA1A0f8e8c7f794',
@@ -133,7 +133,7 @@ export const NETWORKS: {
     subgraphUrl:
       'https://api.studio.thegraph.com/query/74256/human-amoy/version/latest',
     subgraphUrlApiKey:
-      'https://gateway.thegraph.com/api/deployments/id/QmRx5WSi7o9FtENWnE5eEz8Dr7kYUazk4TNPRt65UZkKkB',
+      'https://gateway.thegraph.com/api/deployments/id/QmW3KQfZu1sGz1CedPKC9okCuMFvi8EbrjKncoHn3UPFry',
     oldSubgraphUrl: '',
     oldFactoryAddress: '',
     hmtSubgraphUrl:

--- a/packages/sdk/typescript/human-protocol-sdk/src/escrow/escrow_utils.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/escrow/escrow_utils.ts
@@ -513,6 +513,9 @@ function mapEscrow(e: EscrowData, chainId: ChainId | number): IEscrow {
     token: e.token,
     totalFundedAmount: BigInt(e.totalFundedAmount),
     createdAt: Number(e.createdAt) * 1000,
+    cancellationRequestedAt: e.cancellationRequestedAt
+      ? Number(e.cancellationRequestedAt) * 1000
+      : null,
     chainId: Number(chainId),
   };
 }

--- a/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/escrow.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/graphql/queries/escrow.ts
@@ -27,6 +27,7 @@ const ESCROW_FRAGMENT = gql`
     token
     totalFundedAmount
     createdAt
+    cancellationRequestedAt
   }
 `;
 

--- a/packages/sdk/typescript/human-protocol-sdk/src/graphql/types.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/graphql/types.ts
@@ -25,6 +25,7 @@ export type EscrowData = {
   token: string;
   totalFundedAmount: string;
   createdAt: string;
+  cancellationRequestedAt: string | null;
 };
 
 export type WorkerData = {

--- a/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/interfaces.ts
@@ -68,6 +68,7 @@ export interface IEscrow {
   token: string;
   totalFundedAmount: bigint;
   createdAt: number;
+  cancellationRequestedAt: number | null;
   chainId: number;
 }
 

--- a/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/test/escrow.test.ts
@@ -3472,6 +3472,7 @@ describe('EscrowUtils', () => {
           token: '0x0',
           totalFundedAmount: '3',
           createdAt: '1',
+          cancellationRequestedAt: '2',
           finalResultsHash: null,
           finalResultsUrl: null,
           intermediateResultsHash: null,
@@ -3498,6 +3499,7 @@ describe('EscrowUtils', () => {
           token: '0x0',
           totalFundedAmount: '3',
           createdAt: '1',
+          cancellationRequestedAt: null,
           finalResultsHash: null,
           finalResultsUrl: null,
           intermediateResultsHash: null,
@@ -3529,6 +3531,9 @@ describe('EscrowUtils', () => {
         count: Number(e.count),
         totalFundedAmount: BigInt(e.totalFundedAmount),
         createdAt: Number(e.createdAt) * 1000,
+        cancellationRequestedAt: e.cancellationRequestedAt
+          ? Number(e.cancellationRequestedAt) * 1000
+          : null,
         recordingOracleFee: e.recordingOracleFee
           ? Number(e.recordingOracleFee)
           : null,
@@ -3570,6 +3575,7 @@ describe('EscrowUtils', () => {
           balance: '0',
           count: '1',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Pending',
@@ -3596,6 +3602,7 @@ describe('EscrowUtils', () => {
           balance: '0',
           count: '1',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Complete',
@@ -3632,6 +3639,9 @@ describe('EscrowUtils', () => {
         count: Number(e.count),
         totalFundedAmount: BigInt(e.totalFundedAmount),
         createdAt: Number(e.createdAt) * 1000,
+        cancellationRequestedAt: e.cancellationRequestedAt
+          ? Number(e.cancellationRequestedAt) * 1000
+          : null,
         recordingOracleFee: e.recordingOracleFee
           ? Number(e.recordingOracleFee)
           : null,
@@ -3656,6 +3666,7 @@ describe('EscrowUtils', () => {
           balance: '0',
           count: '1',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Completed',
@@ -3692,6 +3703,9 @@ describe('EscrowUtils', () => {
         count: Number(e.count),
         totalFundedAmount: BigInt(e.totalFundedAmount),
         createdAt: Number(e.createdAt) * 1000,
+        cancellationRequestedAt: e.cancellationRequestedAt
+          ? Number(e.cancellationRequestedAt) * 1000
+          : null,
         recordingOracleFee: e.recordingOracleFee
           ? Number(e.recordingOracleFee)
           : null,
@@ -3717,6 +3731,7 @@ describe('EscrowUtils', () => {
           count: '1',
           jobRequesterId: '1',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Completed',
@@ -3752,6 +3767,9 @@ describe('EscrowUtils', () => {
         count: Number(e.count),
         totalFundedAmount: BigInt(e.totalFundedAmount),
         createdAt: Number(e.createdAt) * 1000,
+        cancellationRequestedAt: e.cancellationRequestedAt
+          ? Number(e.cancellationRequestedAt) * 1000
+          : null,
         recordingOracleFee: e.recordingOracleFee
           ? Number(e.recordingOracleFee)
           : null,
@@ -3776,6 +3794,7 @@ describe('EscrowUtils', () => {
           balance: '0',
           count: '1',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Completed',
@@ -3802,6 +3821,7 @@ describe('EscrowUtils', () => {
           balance: '3',
           count: '2',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Pending',
@@ -3840,6 +3860,9 @@ describe('EscrowUtils', () => {
         count: Number(e.count),
         totalFundedAmount: BigInt(e.totalFundedAmount),
         createdAt: Number(e.createdAt) * 1000,
+        cancellationRequestedAt: e.cancellationRequestedAt
+          ? Number(e.cancellationRequestedAt) * 1000
+          : null,
         recordingOracleFee: e.recordingOracleFee
           ? Number(e.recordingOracleFee)
           : null,
@@ -3881,6 +3904,7 @@ describe('EscrowUtils', () => {
           balance: '0',
           count: '1',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Completed',
@@ -3907,6 +3931,7 @@ describe('EscrowUtils', () => {
           balance: '3',
           count: '2',
           createdAt: '1',
+          cancellationRequestedAt: null,
           factoryAddress: '0x0',
           launcher: '0x0',
           status: 'Pending',
@@ -3946,6 +3971,9 @@ describe('EscrowUtils', () => {
         count: Number(e.count),
         totalFundedAmount: BigInt(e.totalFundedAmount),
         createdAt: Number(e.createdAt) * 1000,
+        cancellationRequestedAt: e.cancellationRequestedAt
+          ? Number(e.cancellationRequestedAt) * 1000
+          : null,
         recordingOracleFee: e.recordingOracleFee
           ? Number(e.recordingOracleFee)
           : undefined,
@@ -4025,6 +4053,7 @@ describe('EscrowUtils', () => {
         manifest: null,
         manifestHash: null,
         createdAt: '0',
+        cancellationRequestedAt: '12',
       };
       const gqlFetchSpy = vi
         .spyOn(gqlFetch, 'default')
@@ -4042,6 +4071,7 @@ describe('EscrowUtils', () => {
         reputationOracleFee: 1,
         exchangeOracleFee: 1,
         createdAt: 0,
+        cancellationRequestedAt: 12000,
         chainId,
         jobRequesterId: null,
         manifest: null,

--- a/packages/subgraph/human-protocol/schema.graphql
+++ b/packages/subgraph/human-protocol/schema.graphql
@@ -67,6 +67,7 @@ type Escrow @entity(immutable: false) {
   intermediateResultsHash: String # string
   finalResultsUrl: String # string
   finalResultsHash: String # string
+  cancellationRequestedAt: BigInt
   jobRequesterId: String # string
   createdAt: BigInt!
 }

--- a/packages/subgraph/human-protocol/src/mapping/EscrowTemplate.ts
+++ b/packages/subgraph/human-protocol/src/mapping/EscrowTemplate.ts
@@ -799,6 +799,7 @@ export function handleCancellationRequested(
       null,
       Address.fromBytes(escrowEntity.address)
     );
+    escrowEntity.cancellationRequestedAt = event.block.timestamp;
     escrowEntity.status = 'ToCancel';
     escrowEntity.save();
     statusEventEntity.launcher = escrowEntity.launcher;

--- a/packages/subgraph/human-protocol/tests/escrow/escrow.test.ts
+++ b/packages/subgraph/human-protocol/tests/escrow/escrow.test.ts
@@ -1316,6 +1316,12 @@ describe('Escrow', () => {
     assert.fieldEquals('EscrowStatusEvent', id, 'status', 'ToCancel');
 
     // Escrow
+    assert.fieldEquals(
+      'Escrow',
+      escrowAddress.toHex(),
+      'cancellationRequestedAt',
+      cancellationRequested.block.timestamp.toString()
+    );
     assert.fieldEquals('Escrow', escrowAddress.toHex(), 'status', 'ToCancel');
     assert.fieldEquals(
       'Transaction',


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
- Added `cancellationRequestedAt` to subgraph `Escrow` entity.
- Set the field when handling `CancellationRequested`.
- Exposed the field in TypeScript and Python SDKs.
- Kept subgraph timestamps in seconds and converted them to milliseconds in SDKs.

## How has this been tested?
Ran unit tests

## Release plan
Deploy new subgraph and SDK version

## Potential risks; What to monitor; Rollback plan
None