### PR TITLE
[Subgraph] Add Escrow ABI to dataSources

### DIFF
--- a/docker-setup/docker-compose.dev.yml
+++ b/docker-setup/docker-compose.dev.yml
@@ -102,7 +102,7 @@ services:
     container_name: hp-dev-graph-node
     # In case of issues on Mac M1 rebuild the image for it locally
     # https://github.com/graphprotocol/graph-node/blob/master/docker/README.md#running-graph-node-on-an-macbook-m1
-    image: graphprotocol/graph-node
+    image: graphprotocol/graph-node:v0.41.1
     restart: *default-restart
     logging:
       <<: *default-logging

--- a/packages/subgraph/human-protocol/template.yaml
+++ b/packages/subgraph/human-protocol/template.yaml
@@ -28,6 +28,8 @@ dataSources:
       abis:
         - name: EscrowFactory
           file: '{{{ EscrowFactory.abi }}}'
+        - name: Escrow
+          file: '{{{ Escrow.abi }}}'
       eventHandlers:
         - event: Launched(address,address)
           handler: handleLaunched


### PR DESCRIPTION
## Issue tracking
Fix #3837 

## Context behind the change
- add Escrow ABI to dataSources in template.yaml 
- update graph-node image to v0.41.1 in docker-compose.dev.yml


## How has this been tested?
Deployed and tested locally

## Release plan
Deploy new subgraph version 

## Potential risks; What to monitor; Rollback plan
None