### PR TITLE
Remove fundAmount from manifest and related logic

### DIFF
--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.spec.ts
@@ -102,7 +102,6 @@ describe('AssignmentService', () => {
       requesterTitle: 'Example Title',
       requesterDescription: 'Example Description',
       submissionsRequired: 5,
-      fundAmount: 100,
     };
 
     beforeAll(async () => {
@@ -128,6 +127,7 @@ describe('AssignmentService', () => {
         .mockResolvedValue(null);
       jest.spyOn(assignmentRepository, 'countByJobId').mockResolvedValue(0);
       jest.spyOn(jobService, 'getManifest').mockResolvedValue(manifest);
+      jest.spyOn(jobService, 'getRewardAmount').mockResolvedValue(20);
       (Escrow__factory.connect as any).mockImplementation(() => ({
         duration: jest
           .fn()
@@ -150,12 +150,17 @@ describe('AssignmentService', () => {
         workerAddress: workerAddress,
         status: AssignmentStatus.ACTIVE,
         expiresAt: expect.any(Date),
-        rewardAmount: manifest.fundAmount / manifest.submissionsRequired,
+        rewardAmount: 20,
       });
       expect(jobService.getManifest).toHaveBeenCalledWith(
         chainId,
         escrowAddress,
         MOCK_MANIFEST_URL,
+      );
+      expect(jobService.getRewardAmount).toHaveBeenCalledWith(
+        chainId,
+        escrowAddress,
+        manifest.submissionsRequired,
       );
     });
 
@@ -371,7 +376,6 @@ describe('AssignmentService', () => {
         requesterTitle: 'Example Title',
         requesterDescription: 'Example Description',
         submissionsRequired: 5,
-        fundAmount: 100,
       };
 
       jest.spyOn(jobService, 'getManifest').mockResolvedValue(manifest);

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/assignment/assignment.service.ts
@@ -79,6 +79,11 @@ export class AssignmentService {
       data.escrowAddress,
       jobEntity.manifestUrl,
     );
+    const rewardAmount = await this.jobService.getRewardAmount(
+      data.chainId,
+      data.escrowAddress,
+      manifest.submissionsRequired,
+    );
 
     // Check if all required qualifications are present
     const userQualificationsSet = new Set(jwtUser.qualifications);
@@ -110,8 +115,7 @@ export class AssignmentService {
     newAssignmentEntity.job = jobEntity;
     newAssignmentEntity.workerAddress = jwtUser.address;
     newAssignmentEntity.status = AssignmentStatus.ACTIVE;
-    newAssignmentEntity.rewardAmount =
-      manifest.fundAmount / manifest.submissionsRequired;
+    newAssignmentEntity.rewardAmount = rewardAmount;
     newAssignmentEntity.expiresAt = expirationDate;
     return this.assignmentRepository.createUnique(newAssignmentEntity);
   }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.dto.ts
@@ -20,7 +20,6 @@ export class ManifestDto {
   requesterTitle: string;
   requesterDescription: string;
   submissionsRequired: number;
-  fundAmount: number;
   qualifications?: string[];
 }
 

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.spec.ts
@@ -373,7 +373,6 @@ describe('JobService', () => {
         requesterTitle: 'Example Title',
         requesterDescription: 'Example Description',
         submissionsRequired: 5,
-        fundAmount: 100,
       };
 
       jest.spyOn(jobService, 'getManifest').mockResolvedValue(manifest);
@@ -473,7 +472,6 @@ describe('JobService', () => {
         requesterTitle: 'Example Title',
         requesterDescription: 'Example Description',
         submissionsRequired: 5,
-        fundAmount: 100,
       };
 
       jest
@@ -531,7 +529,6 @@ describe('JobService', () => {
         requesterTitle: 'Example Title',
         requesterDescription: 'Example Description',
         submissionsRequired: 1,
-        fundAmount: 100,
       };
 
       assignment.status = AssignmentStatus.ACTIVE;
@@ -564,7 +561,6 @@ describe('JobService', () => {
         requesterTitle: 'Example Title',
         requesterDescription: 'Example Description',
         submissionsRequired: 5,
-        fundAmount: 100,
       };
 
       assignment.status = AssignmentStatus.ACTIVE;

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/job/job.service.ts
@@ -7,10 +7,11 @@ import {
   Encryption,
   EncryptionUtils,
   EscrowClient,
+  EscrowUtils,
 } from '@human-protocol/sdk';
 import { Inject, Injectable } from '@nestjs/common';
+import { ethers } from 'ethers';
 
-import { downloadFileFromUrl } from '../../common/utils/storage';
 import { PGPConfigService } from '../../common/config/pgp-config.service';
 import { ErrorAssignment, ErrorJob } from '../../common/constant/errors';
 import { SortDirection } from '../../common/enums/collection';
@@ -30,6 +31,7 @@ import {
 } from '../../common/errors';
 import { ISolution } from '../../common/interfaces/job';
 import { PageDto } from '../../common/pagination/pagination.dto';
+import { downloadFileFromUrl } from '../../common/utils/storage';
 import { AssignmentEntity } from '../assignment/assignment.entity';
 import { AssignmentRepository } from '../assignment/assignment.repository';
 import { StorageService } from '../storage/storage.service';
@@ -184,7 +186,11 @@ export class JobService {
             data.sortField === JobSortField.REWARD_AMOUNT
           ) {
             job.rewardAmount = (
-              manifest.fundAmount / manifest.submissionsRequired
+              await this.getRewardAmount(
+                entity.chainId,
+                entity.escrowAddress,
+                manifest.submissionsRequired,
+              )
             ).toString();
           }
           if (data.fields?.includes(JobFieldName.RewardToken)) {
@@ -382,5 +388,26 @@ export class JobService {
     }
 
     return manifest;
+  }
+
+  public async getRewardAmount(
+    chainId: number,
+    escrowAddress: string,
+    submissionsRequired: number,
+  ): Promise<number> {
+    const escrow = await EscrowUtils.getEscrow(chainId, escrowAddress);
+    if (!escrow) {
+      throw new NotFoundError(ErrorJob.NotFound);
+    }
+
+    const decimals = await HMToken__factory.connect(
+      escrow.token,
+      this.web3Service.getSigner(chainId),
+    ).decimals();
+
+    return (
+      Number(ethers.formatUnits(escrow.totalFundedAmount, decimals)) /
+      submissionsRequired
+    );
   }
 }

--- a/packages/apps/fortune/exchange-oracle/server/src/modules/web3/web3.service.ts
+++ b/packages/apps/fortune/exchange-oracle/server/src/modules/web3/web3.service.ts
@@ -19,7 +19,6 @@ export class Web3Service {
 
   private signers: { [key: number]: Wallet } = {};
   readonly signerAddress: string;
-  readonly currentWeb3Env: string;
 
   constructor(
     private readonly web3ConfigService: Web3ConfigService,

--- a/packages/apps/fortune/recording-oracle/src/common/interfaces/job.ts
+++ b/packages/apps/fortune/recording-oracle/src/common/interfaces/job.ts
@@ -4,7 +4,6 @@ export interface IManifest {
   submissionsRequired: number;
   requesterTitle: string;
   requesterDescription: string;
-  fundAmount: string;
   requestType: JobRequestType;
 }
 

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.spec.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.spec.ts
@@ -34,7 +34,6 @@ import { StorageService } from '../storage/storage.service';
 import { Web3Service } from '../web3/web3.service';
 import { WebhookDto } from '../webhook/webhook.dto';
 import { JobService } from './job.service';
-import { HMToken__factory } from '@human-protocol/core/typechain-types';
 import { downloadFileFromUrl } from '@/common/utils/storage';
 
 jest.mock('minio', () => {
@@ -60,6 +59,11 @@ jest.mock('@human-protocol/sdk', () => ({
   ...jest.requireActual('@human-protocol/sdk'),
   EscrowClient: {
     build: jest.fn().mockImplementation(() => ({})),
+  },
+  EscrowUtils: {
+    getEscrow: jest.fn().mockResolvedValue({
+      totalFundedAmount: 8n,
+    }),
   },
   KVStoreUtils: {
     get: jest.fn(),
@@ -130,13 +134,6 @@ describe('JobService', () => {
   });
 
   describe('processJobSolution', () => {
-    beforeAll(() => {
-      const decimalsMock = jest.fn().mockResolvedValue(18);
-      const tokenContractMock = { decimals: decimalsMock };
-      jest
-        .spyOn(HMToken__factory, 'connect')
-        .mockReturnValue(tokenContractMock as any);
-    });
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -241,7 +238,6 @@ describe('JobService', () => {
         submissionsRequired: 2,
         requesterTitle: MOCK_REQUESTER_TITLE,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-        fundAmount: '10',
         requestType: JobRequestType.FORTUNE,
       };
 
@@ -303,7 +299,6 @@ describe('JobService', () => {
         submissionsRequired: 2,
         requesterTitle: MOCK_REQUESTER_TITLE,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-        fundAmount: '10',
         requestType: JobRequestType.FORTUNE,
       };
 
@@ -316,7 +311,6 @@ describe('JobService', () => {
           .fn()
           .mockResolvedValue('http://example.com/results'),
         storeResults: jest.fn().mockResolvedValue(true),
-        getTokenAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       };
       (EscrowClient.build as jest.Mock).mockResolvedValue(escrowClient);
 
@@ -370,7 +364,6 @@ describe('JobService', () => {
         getManifest: jest.fn().mockResolvedValue('http://example.com/manifest'),
         getIntermediateResultsUrl: jest.fn().mockResolvedValue(''),
         storeResults: jest.fn().mockResolvedValue(true),
-        getTokenAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       };
       (EscrowClient.build as jest.Mock).mockResolvedValue(escrowClient);
 
@@ -378,7 +371,6 @@ describe('JobService', () => {
         submissionsRequired: 3,
         requesterTitle: MOCK_REQUESTER_TITLE,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-        fundAmount: '10',
         requestType: JobRequestType.FORTUNE,
       };
 
@@ -426,7 +418,6 @@ describe('JobService', () => {
           .fn()
           .mockResolvedValue('http://existing-solutions'),
         storeResults: jest.fn().mockResolvedValue(true),
-        getTokenAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
       };
       (EscrowClient.build as jest.Mock).mockResolvedValue(escrowClient);
 
@@ -438,7 +429,6 @@ describe('JobService', () => {
         submissionsRequired: 2,
         requesterTitle: MOCK_REQUESTER_TITLE,
         requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-        fundAmount: '10',
         requestType: JobRequestType.FORTUNE,
       };
 
@@ -504,7 +494,6 @@ describe('JobService', () => {
         .fn()
         .mockResolvedValue('http://existing-solutions'),
       storeResults: jest.fn().mockResolvedValue(true),
-      getTokenAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
     };
     (EscrowClient.build as jest.Mock).mockResolvedValue(escrowClient);
 
@@ -512,7 +501,6 @@ describe('JobService', () => {
       submissionsRequired: 4,
       requesterTitle: MOCK_REQUESTER_TITLE,
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-      fundAmount: '10',
       requestType: JobRequestType.FORTUNE,
     };
 
@@ -594,7 +582,6 @@ describe('JobService', () => {
         .fn()
         .mockResolvedValue('http://existing-solutions'),
       storeResults: jest.fn().mockResolvedValue(true),
-      getTokenAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
     };
     (EscrowClient.build as jest.Mock).mockResolvedValue(escrowClient);
     KVStoreUtils.get = jest
@@ -606,7 +593,6 @@ describe('JobService', () => {
       submissionsRequired: 3,
       requesterTitle: MOCK_REQUESTER_TITLE,
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-      fundAmount: '10',
       requestType: JobRequestType.FORTUNE,
     };
 
@@ -676,7 +662,6 @@ describe('JobService', () => {
         .fn()
         .mockResolvedValue('http://existing-solutions'),
       storeResults: jest.fn().mockResolvedValue(true),
-      getTokenAddress: jest.fn().mockResolvedValue(MOCK_ADDRESS),
     };
     (EscrowClient.build as jest.Mock).mockResolvedValue(escrowClient);
     KVStoreUtils.get = jest
@@ -688,7 +673,6 @@ describe('JobService', () => {
       submissionsRequired: 3,
       requesterTitle: MOCK_REQUESTER_TITLE,
       requesterDescription: MOCK_REQUESTER_DESCRIPTION,
-      fundAmount: '10',
       requestType: JobRequestType.FORTUNE,
     };
 

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
@@ -194,7 +194,8 @@ export class JobService {
       throw new ValidationError('Escrow not found');
     }
 
-    const amountToReserve = escrow.totalFundedAmount / BigInt(submissionsRequired);
+    const amountToReserve =
+      escrow.totalFundedAmount / BigInt(submissionsRequired);
 
     await escrowClient.storeResults(
       webhook.escrowAddress,

--- a/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
+++ b/packages/apps/fortune/recording-oracle/src/modules/job/job.service.ts
@@ -3,6 +3,7 @@ import {
   EscrowStatus,
   KVStoreKeys,
   KVStoreUtils,
+  EscrowUtils,
 } from '@human-protocol/sdk';
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable } from '@nestjs/common';
@@ -25,7 +26,6 @@ import {
   SolutionEventData,
   WebhookDto,
 } from '../webhook/webhook.dto';
-import { HMToken__factory } from '@human-protocol/core/typechain-types';
 
 @Injectable()
 export class JobService {
@@ -121,7 +121,7 @@ export class JobService {
     }
 
     const manifestUrl = await escrowClient.getManifest(webhook.escrowAddress);
-    const { submissionsRequired, requestType, fundAmount }: IManifest =
+    const { submissionsRequired, requestType }: IManifest =
       await this.storageService.download(manifestUrl);
 
     if (!submissionsRequired || !requestType) {
@@ -186,16 +186,15 @@ export class JobService {
         s.solution === lastExchangeSolution.solution,
     );
 
-    const tokenAddress = await escrowClient.getTokenAddress(
+    const escrow = await EscrowUtils.getEscrow(
+      webhook.chainId,
       webhook.escrowAddress,
     );
-    const tokenContract = HMToken__factory.connect(
-      tokenAddress,
-      this.web3Service.getSigner(webhook.chainId),
-    );
-    const decimals = await tokenContract.decimals();
-    const fundAmountInWei = ethers.parseUnits(fundAmount.toString(), decimals);
-    const amountToReserve = fundAmountInWei / BigInt(submissionsRequired);
+    if (!escrow) {
+      throw new ValidationError('Escrow not found');
+    }
+
+    const amountToReserve = escrow.totalFundedAmount / BigInt(submissionsRequired);
 
     await escrowClient.storeResults(
       webhook.escrowAddress,

--- a/packages/apps/fortune/recording-oracle/test/constants.ts
+++ b/packages/apps/fortune/recording-oracle/test/constants.ts
@@ -37,7 +37,6 @@ export const MOCK_MANIFEST: IManifest = {
   submissionsRequired: 2,
   requesterTitle: 'Fortune',
   requesterDescription: 'Some desc',
-  fundAmount: '8',
   requestType: JobRequestType.FORTUNE,
 };
 export const MOCK_ENCRYPTION_PRIVATE_KEY = 'private-key';

--- a/packages/apps/job-launcher/client/src/types/index.ts
+++ b/packages/apps/job-launcher/client/src/types/index.ts
@@ -43,7 +43,6 @@ export type FortuneManifest = {
   submissionsRequired: number;
   requesterTitle: string;
   requesterDescription: string;
-  fundAmount?: number;
   requestType: JobType.FORTUNE;
   qualifications?: string[];
 };

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.spec.ts
@@ -147,9 +147,7 @@ describe('JobService', () => {
         const jobManifestDto: JobManifestDto = createJobManifestDto({
           paymentCurrency: PaymentCurrency.USDC,
           escrowFundToken: EscrowFundToken.USDC,
-          manifest: createMockFortuneManifest({
-            fundAmount: undefined as unknown as number,
-          }),
+          manifest: createMockFortuneManifest(),
         });
         const fundTokenDecimals = getTokenDecimals(
           jobManifestDto.chainId!,
@@ -181,22 +179,17 @@ describe('JobService', () => {
             mul(div(1, 100), jobManifestDto.paymentAmount),
           ).toFixed(18),
         );
-        const expectedManifest = {
-          ...jobManifestDto.manifest,
-          fundAmount: jobManifestDto.paymentAmount,
-        };
-
         expect(result).toBe(jobEntityMock.id);
         expect(mockWeb3Service.validateChainId).toHaveBeenCalledWith(
           jobManifestDto.chainId,
         );
         expect(mockManifestService.validateManifest).toHaveBeenCalledWith(
           FortuneJobType.FORTUNE,
-          expectedManifest,
+          jobManifestDto.manifest,
         );
         expect(mockManifestService.uploadManifest).toHaveBeenCalledWith(
           jobManifestDto.chainId,
-          expectedManifest,
+          jobManifestDto.manifest,
           [
             jobManifestDto.exchangeOracle,
             jobManifestDto.reputationOracle,
@@ -236,9 +229,7 @@ describe('JobService', () => {
         const jobManifestDto: JobManifestDto = createJobManifestDto({
           paymentCurrency: PaymentCurrency.USD,
           escrowFundToken: EscrowFundToken.USDC,
-          manifest: createMockFortuneManifest({
-            fundAmount: undefined,
-          }),
+          manifest: createMockFortuneManifest(),
         });
 
         const fundTokenDecimals = getTokenDecimals(
@@ -277,11 +268,6 @@ describe('JobService', () => {
             usdToTokenRate,
           ).toFixed(6),
         );
-        const expectedManifest = {
-          ...jobManifestDto.manifest,
-          fundAmount: expectedFundAmount,
-        };
-
         expect(result).toBe(jobEntityMock.id);
 
         expect(mockWeb3Service.validateChainId).toHaveBeenCalledWith(
@@ -289,11 +275,11 @@ describe('JobService', () => {
         );
         expect(mockManifestService.validateManifest).toHaveBeenCalledWith(
           FortuneJobType.FORTUNE,
-          expectedManifest,
+          jobManifestDto.manifest,
         );
         expect(mockManifestService.uploadManifest).toHaveBeenCalledWith(
           jobManifestDto.chainId,
-          expectedManifest,
+          jobManifestDto.manifest,
           [
             jobManifestDto.exchangeOracle,
             jobManifestDto.reputationOracle,
@@ -336,9 +322,7 @@ describe('JobService', () => {
           exchangeOracle: null,
           recordingOracle: null,
           reputationOracle: null,
-          manifest: createMockFortuneManifest({
-            fundAmount: undefined,
-          }),
+          manifest: createMockFortuneManifest(),
         });
 
         const fundTokenDecimals = getTokenDecimals(
@@ -387,11 +371,6 @@ describe('JobService', () => {
             mul(div(1, 100), jobManifestDto.paymentAmount),
           ).toFixed(18),
         );
-        const expectedManifest = {
-          ...jobManifestDto.manifest,
-          fundAmount: jobManifestDto.paymentAmount,
-        };
-
         expect(result).toBe(jobEntityMock.id);
 
         expect(mockWeb3Service.validateChainId).toHaveBeenCalledWith(
@@ -404,11 +383,11 @@ describe('JobService', () => {
         );
         expect(mockManifestService.validateManifest).toHaveBeenCalledWith(
           FortuneJobType.FORTUNE,
-          expectedManifest,
+          jobManifestDto.manifest,
         );
         expect(mockManifestService.uploadManifest).toHaveBeenCalledWith(
           jobManifestDto.chainId,
-          expectedManifest,
+          jobManifestDto.manifest,
           [
             mockOracles.exchangeOracle,
             mockOracles.reputationOracle,
@@ -1317,9 +1296,7 @@ describe('JobService', () => {
         18,
       );
 
-      const manifestMock = createMockFortuneManifest({
-        fundAmount: jobEntity.fundAmount,
-      });
+      const manifestMock = createMockFortuneManifest();
 
       const getEscrowData = {
         token: faker.finance.ethereumAddress(),
@@ -1375,9 +1352,7 @@ describe('JobService', () => {
     it('should return job details without escrow address successfully', async () => {
       const jobEntity = createJobEntity({ escrowAddress: null });
 
-      const manifestMock = createMockFortuneManifest({
-        fundAmount: jobEntity.fundAmount,
-      });
+      const manifestMock = createMockFortuneManifest();
 
       mockJobRepository.findOneByIdAndUserId.mockResolvedValueOnce(jobEntity);
       mockManifestService.downloadManifest.mockResolvedValueOnce(manifestMock);

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -232,16 +232,11 @@ export class JobService {
 
       jobEntity.manifestUrl = dto.manifestUrl;
     } else if ('manifest' in dto) {
-      const manifest = dto.manifest;
-      if (requestType === FortuneJobType.FORTUNE) {
-        (manifest as FortuneManifestDto).fundAmount = fundTokenAmount;
-      }
-
-      await this.manifestService.validateManifest(requestType, manifest);
+      await this.manifestService.validateManifest(requestType, dto.manifest);
 
       const { url, hash } = await this.manifestService.uploadManifest(
         chainId,
-        manifest,
+        dto.manifest,
         [exchangeOracle, reputationOracle, recordingOracle],
       );
 

--- a/packages/apps/job-launcher/server/src/modules/manifest/fixtures.ts
+++ b/packages/apps/job-launcher/server/src/modules/manifest/fixtures.ts
@@ -9,7 +9,6 @@ export function createMockFortuneManifest(
     submissionsRequired: faker.number.int({ min: 1, max: 100 }),
     requesterTitle: faker.lorem.sentence(),
     requesterDescription: faker.lorem.sentence(),
-    fundAmount: faker.number.int({ min: 1, max: 100000 }),
     requestType: FortuneJobType.FORTUNE,
     ...overrides,
   };

--- a/packages/apps/job-launcher/server/src/modules/manifest/manifest.dto.ts
+++ b/packages/apps/job-launcher/server/src/modules/manifest/manifest.dto.ts
@@ -35,11 +35,6 @@ export class FortuneManifestDto {
   @IsString()
   public requesterDescription: string;
 
-  @ApiProperty({ name: 'fund_amount' })
-  @IsNumber()
-  @IsPositive()
-  public fundAmount: number;
-
   @ApiProperty({ enum: FortuneJobType, name: 'request_type' })
   @IsEnumCaseInsensitive(FortuneJobType)
   public requestType: FortuneJobType;

--- a/packages/apps/job-launcher/server/src/modules/manifest/manifest.service.spec.ts
+++ b/packages/apps/job-launcher/server/src/modules/manifest/manifest.service.spec.ts
@@ -92,7 +92,7 @@ describe('ManifestService', () => {
 
     it('should throw when a required fortune property is missing', async () => {
       const manifest = createMockFortuneManifest();
-      delete (manifest as Partial<typeof manifest>).fundAmount;
+      delete (manifest as Partial<typeof manifest>).requesterDescription;
 
       await expect(
         manifestService.validateManifest(FortuneJobType.FORTUNE, manifest),
@@ -194,7 +194,8 @@ describe('ManifestService', () => {
 
     it('should throw if downloaded manifest is invalid', async () => {
       const mockManifest = createMockFortuneManifest();
-      delete (mockManifest as Partial<typeof mockManifest>).fundAmount;
+      delete (mockManifest as Partial<typeof mockManifest>)
+        .requesterDescription;
 
       mockStorageService.downloadJsonLikeData.mockResolvedValueOnce(
         mockManifest,

--- a/packages/apps/job-launcher/server/test/constants.ts
+++ b/packages/apps/job-launcher/server/test/constants.ts
@@ -44,7 +44,6 @@ export const MOCK_MANIFEST: FortuneManifestDto = {
   submissionsRequired: 2,
   requesterTitle: 'Fortune',
   requesterDescription: 'Some desc',
-  fundAmount: 10,
   requestType: FortuneJobType.FORTUNE,
 };
 

--- a/packages/apps/reputation-oracle/server/src/common/types/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/common/types/manifest.ts
@@ -2,7 +2,6 @@ import { CvatJobType, FortuneJobType } from '@/common/enums';
 
 export type FortuneManifest = {
   submissionsRequired: number;
-  fundAmount: number;
   requestType: FortuneJobType;
 };
 

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/fixtures/fortune.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/fixtures/fortune.ts
@@ -6,7 +6,6 @@ import { FortuneFinalResult, FortuneManifest } from '@/common/types';
 export function generateFortuneManifest(): FortuneManifest {
   return {
     requestType: FortuneJobType.FORTUNE,
-    fundAmount: Number(faker.finance.amount()),
     submissionsRequired: faker.number.int({ min: 2, max: 5 }),
   };
 }


### PR DESCRIPTION
## Issue tracking
#3806 #3865 

## Context behind the change

- Removed fundAmount from the Fortune manifest.
- Updated Job Launcher, Fortune Exchange Oracle, and Fortune Recording Oracle so they no longer rely on fundAmount being present in the manifest.
- Moved reward and reservation calculations to subgraph data instead of manifest data, so Fortune jobs use the escrow as the source of truth for funded amounts.
- Updated related types, fixtures, and tests accordingly.

## How has this been tested?
Ran fortune locally.
Ran unit tests.

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None.