### PR TITLE
[Reputation Oracle] Mark escrow completion as completed before webhook creation

### DIFF
--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.spec.ts
@@ -987,7 +987,10 @@ describe('EscrowCompletionService', () => {
         );
         expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledWith({
           ...paidPayoutsRecord,
-          status: 'completed',
+          failureDetail: expect.stringContaining(
+            'Failed to create outgoing webhook for oracle. Address: 0x',
+          ),
+          status: 'failed',
         });
       });
     });
@@ -1173,7 +1176,8 @@ describe('EscrowCompletionService', () => {
       expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledTimes(1);
       expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledWith({
         ...paidPayoutsRecord,
-        status: 'completed',
+        failureDetail: 'Error message: Oracle data is missing',
+        status: 'failed',
       });
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.spec.ts
@@ -958,8 +958,7 @@ describe('EscrowCompletionService', () => {
         );
         expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledWith({
           ...paidPayoutsRecord,
-          failureDetail: 'Error message: Webhook url is no set for oracle',
-          status: 'failed',
+          status: 'completed',
         });
       });
 
@@ -988,10 +987,7 @@ describe('EscrowCompletionService', () => {
         );
         expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledWith({
           ...paidPayoutsRecord,
-          failureDetail: expect.stringContaining(
-            'Failed to create outgoing webhook for oracle. Address: 0x',
-          ),
-          status: 'failed',
+          status: 'completed',
         });
       });
     });
@@ -1177,8 +1173,7 @@ describe('EscrowCompletionService', () => {
       expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledTimes(1);
       expect(mockEscrowCompletionRepository.updateOne).toHaveBeenCalledWith({
         ...paidPayoutsRecord,
-        failureDetail: 'Error message: Oracle data is missing',
-        status: 'failed',
+        status: 'completed',
       });
     });
   });

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -268,6 +268,9 @@ export class EscrowCompletionService {
           );
         }
 
+        escrowCompletionEntity.status = EscrowCompletionStatus.COMPLETED;
+        await this.escrowCompletionRepository.updateOne(escrowCompletionEntity);
+
         const oracleAddresses: string[] = [
           escrowData.launcher as string,
           escrowData.exchangeOracle as string,
@@ -282,19 +285,26 @@ export class EscrowCompletionService {
               : OutgoingWebhookEventType.ESCROW_COMPLETED,
         };
 
-        let allWebhooksCreated = true;
         for (const oracleAddress of oracleAddresses) {
           const oracleData = await OperatorUtils.getOperator(
             chainId,
             oracleAddress,
           );
           if (!oracleData) {
-            throw new Error('Oracle data is missing');
+            this.logger.error('Oracle data is missing', {
+              escrowCompletionEntityId: escrowCompletionEntity.id,
+              oracleAddress,
+            });
+            continue;
           }
 
           const { webhookUrl } = oracleData;
           if (!webhookUrl) {
-            throw new Error('Webhook url is no set for oracle');
+            this.logger.error('Webhook url is no set for oracle', {
+              escrowCompletionEntityId: escrowCompletionEntity.id,
+              oracleAddress,
+            });
+            continue;
           }
 
           try {
@@ -308,32 +318,14 @@ export class EscrowCompletionService {
                * Already created. Noop.
                */
               continue;
-            } else {
-              this.logger.error(
-                'Failed to create outgoing webhook for oracle',
-                {
-                  error,
-                  escrowCompletionEntityId: escrowCompletionEntity.id,
-                  oracleAddress,
-                },
-              );
-
-              await this.handleEscrowCompletionError(
-                escrowCompletionEntity,
-                `Failed to create outgoing webhook for oracle. Address: ${oracleAddress}.`,
-              );
-              allWebhooksCreated = false;
-              break;
             }
-          }
-        }
 
-        // Only set the status to COMPLETED if all webhooks were created successfully
-        if (allWebhooksCreated) {
-          escrowCompletionEntity.status = EscrowCompletionStatus.COMPLETED;
-          await this.escrowCompletionRepository.updateOne(
-            escrowCompletionEntity,
-          );
+            this.logger.error('Failed to create outgoing webhook for oracle', {
+              error,
+              escrowCompletionEntityId: escrowCompletionEntity.id,
+              oracleAddress,
+            });
+          }
         }
       } catch (error) {
         this.logger.error('Failed to process paid escrow completion', {

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -268,9 +268,6 @@ export class EscrowCompletionService {
           );
         }
 
-        escrowCompletionEntity.status = EscrowCompletionStatus.COMPLETED;
-        await this.escrowCompletionRepository.updateOne(escrowCompletionEntity);
-
         const oracleAddresses: string[] = [
           escrowData.launcher as string,
           escrowData.exchangeOracle as string,
@@ -285,17 +282,14 @@ export class EscrowCompletionService {
               : OutgoingWebhookEventType.ESCROW_COMPLETED,
         };
 
+        let allWebhooksCreated = true;
         for (const oracleAddress of oracleAddresses) {
           const oracleData = await OperatorUtils.getOperator(
             chainId,
             oracleAddress,
           );
           if (!oracleData) {
-            this.logger.error('Oracle data is missing', {
-              escrowCompletionEntityId: escrowCompletionEntity.id,
-              oracleAddress,
-            });
-            continue;
+            throw new Error('Oracle data is missing');
           }
 
           const { webhookUrl } = oracleData;
@@ -318,14 +312,32 @@ export class EscrowCompletionService {
                * Already created. Noop.
                */
               continue;
-            }
+            } else {
+              this.logger.error(
+                'Failed to create outgoing webhook for oracle',
+                {
+                  error,
+                  escrowCompletionEntityId: escrowCompletionEntity.id,
+                  oracleAddress,
+                },
+              );
 
-            this.logger.error('Failed to create outgoing webhook for oracle', {
-              error,
-              escrowCompletionEntityId: escrowCompletionEntity.id,
-              oracleAddress,
-            });
+              await this.handleEscrowCompletionError(
+                escrowCompletionEntity,
+                `Failed to create outgoing webhook for oracle. Address: ${oracleAddress}.`,
+              );
+              allWebhooksCreated = false;
+              break;
+            }
           }
+        }
+
+        // Only set the status to COMPLETED if all webhooks were created successfully
+        if (allWebhooksCreated) {
+          escrowCompletionEntity.status = EscrowCompletionStatus.COMPLETED;
+          await this.escrowCompletionRepository.updateOne(
+            escrowCompletionEntity,
+          );
         }
       } catch (error) {
         this.logger.error('Failed to process paid escrow completion', {

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/escrow-completion.service.ts
@@ -300,7 +300,7 @@ export class EscrowCompletionService {
 
           const { webhookUrl } = oracleData;
           if (!webhookUrl) {
-            this.logger.error('Webhook url is no set for oracle', {
+            this.logger.error('Webhook url is not set for this oracle', {
               escrowCompletionEntityId: escrowCompletionEntity.id,
               oracleAddress,
             });


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Persist escrow completion immediately after successful on-chain finalization, so webhook creation failures no longer leave the escrow stuck in an inconsistent DB state.

## How has this been tested?
Ran unit tests locally

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None