### PR TITLE
add "types" for node and jest to multiple tsconfig files

### DIFF
--- a/packages/apps/dashboard/server/tsconfig.json
+++ b/packages/apps/dashboard/server/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "es2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
@@ -17,6 +16,7 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node", "jest"]
   }
 }

--- a/packages/apps/faucet/client/tsconfig.json
+++ b/packages/apps/faucet/client/tsconfig.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "baseUrl": "./",
     "types": ["node"]
   },
   "include": ["src"]

--- a/packages/apps/faucet/server/tsconfig.json
+++ b/packages/apps/faucet/server/tsconfig.json
@@ -17,6 +17,7 @@
     "outDir": "build",
     "useUnknownInCatchVariables": false,
     "strictNullChecks": false,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["node", "jest"]
   }
 }

--- a/packages/apps/fortune/exchange-oracle/client/tsconfig.json
+++ b/packages/apps/fortune/exchange-oracle/client/tsconfig.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "baseUrl": ".",
     "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": ["src", "tests"]

--- a/packages/apps/fortune/exchange-oracle/server/tsconfig.json
+++ b/packages/apps/fortune/exchange-oracle/server/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "es2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
@@ -18,6 +17,7 @@
     "strictBindCallApply": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node", "jest"]
   }
 }

--- a/packages/apps/fortune/recording-oracle/tsconfig.json
+++ b/packages/apps/fortune/recording-oracle/tsconfig.json
@@ -21,6 +21,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": false,
     "baseUrl": ".",
+    "types": ["node", "jest"],
     "paths": {
       "@/*": ["src/*"]
     }

--- a/packages/apps/human-app/server/tsconfig.json
+++ b/packages/apps/human-app/server/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "es2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
@@ -19,6 +18,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
   }
 }

--- a/packages/apps/job-launcher/client/tsconfig.json
+++ b/packages/apps/job-launcher/client/tsconfig.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "baseUrl": ".",
     "types": ["node", "jest"]
   },
   "include": ["src", "tests"]

--- a/packages/apps/job-launcher/server/src/common/validators/tokens.ts
+++ b/packages/apps/job-launcher/server/src/common/validators/tokens.ts
@@ -5,7 +5,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
-import { JobDto } from 'src/modules/job/job.dto';
+import { JobDto } from '../../modules/job/job.dto';
 import { TOKEN_ADDRESSES } from '../constants/tokens';
 import { ChainId } from '@human-protocol/sdk';
 

--- a/packages/apps/job-launcher/server/src/modules/job/job.repository.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.repository.ts
@@ -18,7 +18,7 @@ import {
   JobCountDto,
 } from '../statistic/statistic.dto';
 import { convertToDatabaseSortDirection } from '../../database/database.utils';
-import { PaymentSource } from 'src/common/enums/payment';
+import { PaymentSource } from '../../common/enums/payment';
 
 @Injectable()
 export class JobRepository extends BaseRepository<JobEntity> {

--- a/packages/apps/job-launcher/server/src/modules/job/job.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.service.ts
@@ -83,8 +83,7 @@ import { JobRepository } from './job.repository';
 @Injectable()
 export class JobService {
   private readonly logger = logger.child({ context: JobService.name });
-  public readonly bucket: string;
-  private cronJobRepository: CronJobRepository;
+  private cronJobRepository!: CronJobRepository;
 
   constructor(
     @Inject(Web3Service)
@@ -454,7 +453,7 @@ export class JobService {
       });
 
       return new PageDto(data.page!, data.pageSize!, itemCount, jobs);
-    } catch (error) {
+    } catch (error: any) {
       throw new ServerError(error.message, error.stack);
     }
   }

--- a/packages/apps/job-launcher/server/src/modules/manifest/manifest.service.ts
+++ b/packages/apps/job-launcher/server/src/modules/manifest/manifest.service.ts
@@ -37,8 +37,6 @@ import {
 
 @Injectable()
 export class ManifestService {
-  public readonly bucket: string;
-
   constructor(
     private readonly web3Service: Web3Service,
     private readonly cvatConfigService: CvatConfigService,

--- a/packages/apps/job-launcher/server/tsconfig.json
+++ b/packages/apps/job-launcher/server/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "es2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
@@ -18,6 +17,7 @@
     "strictBindCallApply": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node", "jest"]
   }
 }

--- a/packages/apps/reputation-oracle/server/tsconfig.json
+++ b/packages/apps/reputation-oracle/server/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "es2024",
     "rootDir": ".",
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
@@ -18,16 +17,16 @@
     "noImplicitAny": true,
     "strictBindCallApply": true,
     "isolatedModules": true,
+    "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
       "~/test/*": ["test/*"]
     },
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
   },
   "ts-node": {
     "files": true,
-    "require": [
-      "tsconfig-paths/register"
-    ]
+    "require": ["tsconfig-paths/register"]
   }
 }

--- a/packages/apps/staking/tsconfig.json
+++ b/packages/apps/staking/tsconfig.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "baseUrl": ".",
     "types": ["node", "jest"]
   },
   "include": ["src"]

--- a/packages/subgraph/hmt/tsconfig.json
+++ b/packages/subgraph/hmt/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "types": ["@graphprotocol/graph-ts", "node"]
   },
   "include": ["src", "tests"]

--- a/packages/subgraph/human-protocol/tsconfig.json
+++ b/packages/subgraph/human-protocol/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "types": ["@graphprotocol/graph-ts", "node"]
   },
   "include": ["src", "tests"]


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
- Add "types" for node and jest to multiple tsconfig files.
- Remove unnecessary "baseUrl" entries.
- Fix some absolute paths in JL.

## How has this been tested?
Deployed locally

## Release plan
None

## Potential risks; What to monitor; Rollback plan
None