### PR TITLE
add MARKETING category to OperatorCategory enum

### DIFF
--- a/.changeset/grumpy-shoes-film.md
+++ b/.changeset/grumpy-shoes-film.md
@@ -1,0 +1,6 @@
+---
+"@human-protocol/sdk": patch
+"@human-protocol/python-sdk": patch
+---
+
+Add marketing category to OperatorCategory enum

--- a/packages/apps/dashboard/client/src/features/leaderboard/ui/CategoryCell.tsx
+++ b/packages/apps/dashboard/client/src/features/leaderboard/ui/CategoryCell.tsx
@@ -27,7 +27,7 @@ const getCategoryColor = (category: string) => {
     case 'market_making':
       return 'success';
     case 'marketing':
-      return 'primary';
+      return 'secondary';
     default:
       return 'default';
   }

--- a/packages/apps/dashboard/client/src/features/leaderboard/ui/CategoryCell.tsx
+++ b/packages/apps/dashboard/client/src/features/leaderboard/ui/CategoryCell.tsx
@@ -13,6 +13,8 @@ const getCategoryLabel = (category: string) => {
       return 'Machine Learning';
     case 'market_making':
       return 'Market Making';
+    case 'marketing':
+      return 'Marketing';
     default:
       return category;
   }
@@ -24,6 +26,8 @@ const getCategoryColor = (category: string) => {
       return 'primary';
     case 'market_making':
       return 'success';
+    case 'marketing':
+      return 'primary';
     default:
       return 'default';
   }

--- a/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
+++ b/packages/sdk/python/human-protocol-sdk/human_protocol_sdk/constants.py
@@ -47,6 +47,7 @@ class OperatorCategory(Enum):
 
     MACHINE_LEARNING = "machine_learning"
     MARKET_MAKING = "market_making"
+    MARKETING = "marketing"
 
 
 NETWORKS = {

--- a/packages/sdk/typescript/human-protocol-sdk/src/enums.ts
+++ b/packages/sdk/typescript/human-protocol-sdk/src/enums.ts
@@ -17,4 +17,5 @@ export enum OrderDirection {
 export enum OperatorCategory {
   MACHINE_LEARNING = 'machine_learning',
   MARKET_MAKING = 'market_making',
+  MARKETING = 'marketing',
 }


### PR DESCRIPTION
## Issue tracking
#3886 

## Context behind the change
add MARKETING category to OperatorCategory enum in both SDKs

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

## Release plan
Deploy new SDK version

## Potential risks; What to monitor; Rollback plan
None