### PR TITLE
[Job Launcher] fix: accept unknown manifest as is

### DIFF
--- a/packages/apps/job-launcher/server/src/common/interceptors/snake-case.ts
+++ b/packages/apps/job-launcher/server/src/common/interceptors/snake-case.ts
@@ -5,6 +5,7 @@ import {
   NestInterceptor,
   StreamableFile,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
@@ -12,16 +13,49 @@ import {
   transformKeysFromSnakeToCamel,
 } from '../utils/case-converter';
 
+export const SkipSnakeCaseTransform = Reflector.createDecorator<
+  | {
+      // Either skip specified top-level body props or skip it entirely
+      body?: string[] | boolean;
+      query?: boolean;
+      response?: boolean;
+    }
+  | undefined
+>({
+  key: 'skipSnakeCaseTransform',
+});
+
 @Injectable()
 export class SnakeCaseInterceptor implements NestInterceptor {
+  constructor(private reflector: Reflector) {}
+
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
 
-    if (request.body) {
-      request.body = transformKeysFromSnakeToCamel(request.body);
+    const skipTransformOptions = this.reflector.getAllAndOverride(
+      SkipSnakeCaseTransform,
+      [context.getHandler(), context.getClass()],
+    ) || { body: false, query: false, response: false };
+
+    const shouldSkipBody = skipTransformOptions.body === true;
+    if (request.body && !shouldSkipBody) {
+      const transformed = transformKeysFromSnakeToCamel(request.body);
+
+      const skipBodyProps = Array.isArray(skipTransformOptions.body)
+        ? skipTransformOptions.body
+        : [];
+      for (const prop of skipBodyProps) {
+        if (prop in request.body) {
+          // @ts-expect-error - 'transformed' is same type as 'request.body'
+          transformed[prop] = request.body[prop];
+        }
+      }
+
+      request.body = transformed;
     }
 
-    if (request.query) {
+    const shouldSkipQuery = skipTransformOptions.query === true;
+    if (request.query && !shouldSkipQuery) {
       const transformedQuery = transformKeysFromSnakeToCamel(request.query);
       Object.defineProperty(request, 'query', {
         value: transformedQuery,
@@ -33,9 +67,11 @@ export class SnakeCaseInterceptor implements NestInterceptor {
 
     return next.handle().pipe(
       map((data) => {
-        if (data instanceof StreamableFile) {
+        const shouldSkipResponse = skipTransformOptions.query === true;
+        if (data instanceof StreamableFile || shouldSkipResponse) {
           return data;
         }
+
         return transformKeysFromCamelToSnake(data);
       }),
     );

--- a/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
+++ b/packages/apps/job-launcher/server/src/modules/job/job.controller.ts
@@ -36,6 +36,7 @@ import {
   JobUnknownManifestDto,
 } from './job.dto';
 import { JobService } from './job.service';
+import { SkipSnakeCaseTransform } from '../../common/interceptors/snake-case';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -135,6 +136,7 @@ export class JobController {
       'Endpoint to create a job using a manifest JSON body without validating its format.',
   })
   @ApiBody({ type: JobUnknownManifestDto })
+  @SkipSnakeCaseTransform({ body: ['manifest'] })
   @ApiResponse({
     status: 201,
     description: 'ID of the created job.',


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When using `manifest-quick-launch` it's assumed that `manifest` is passed as is in request body, but at the same time our application has interceptor to transform snake case props to camel case. Described behavior affects manifest as well so it is not correct for downstream oracles. So we need to keep only `manifest` props as is (it can be not just snake case but any naming) and also preserve validation of other fields in body, introduced a decorator that allows skipping specific body props for case transformation.

## How has this been tested?
- [x] e2e locally: send `manifest` with a mix of various cases and namings, make sure it's logged as is in controller before business logic is called

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Should be none