### PR TITLE
[HUMAN App] chore: remove unused prop

### DIFF
--- a/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
+++ b/packages/apps/human-app/server/src/modules/cron-job/cron-job.service.ts
@@ -35,7 +35,6 @@ function assertJobsDiscoveryResponseItemsFormat(
       item.reward_amount,
       item.reward_token,
       item.created_at,
-      item.updated_at,
     ].includes(undefined)
   ) {
     throw new Error('Job discovery response items missing expected fields');
@@ -129,7 +128,6 @@ export class CronJobService {
         JobDiscoveryFieldName.RewardAmount,
         JobDiscoveryFieldName.RewardToken,
         JobDiscoveryFieldName.CreatedAt,
-        JobDiscoveryFieldName.UpdatedAt,
       ];
       command.data.status = JobStatus.ACTIVE;
       const initialResponse =


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
`updated_at` is not used and not allowed by CVAT ExcO, so simply remove it

## How has this been tested?
N/A

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Should be none