### PR TITLE
[Job Launcher] fix: error loading fee with an invalid rpc

### DIFF
--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
   Checkbox,
+  CircularProgress,
   FormControl,
   FormControlLabel,
   Grid,
@@ -17,14 +18,10 @@ import {
 } from '@mui/material';
 import { Decimal } from 'decimal.js';
 import { ethers } from 'ethers';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Address } from 'viem';
-import {
-  useAccount,
-  useReadContract,
-  useWalletClient,
-  usePublicClient,
-} from 'wagmi';
+import { readContract } from 'viem/actions';
+import { useAccount, useWalletClient, usePublicClient } from 'wagmi';
 import { TokenSelect } from '../../../components/TokenSelect';
 import { useCreateJobPageUI } from '../../../providers/CreateJobPageUIProvider';
 import * as jobService from '../../../services/job';
@@ -51,6 +48,7 @@ export const CryptoPayForm = ({
   const [amount, setAmount] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
   const [jobLauncherAddress, setJobLauncherAddress] = useState<string>();
+  const [jobLauncherFee, setJobLauncherFee] = useState<string>();
   const [minFee, setMinFee] = useState<number>(0.01);
   const { data: signer } = useWalletClient();
   const publicClient = usePublicClient();
@@ -59,6 +57,8 @@ export const CryptoPayForm = ({
   const [fundTokenRate, setFundTokenRate] = useState<number>(0);
   const [decimals, setDecimals] = useState<number>(6);
   const [tokenDecimals, setTokenDecimals] = useState<number>(18);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   useEffect(() => {
     const fetchJobLauncherData = async () => {
@@ -106,17 +106,30 @@ export const CryptoPayForm = ({
     setDecimals(Math.min(tokenDecimals, 6));
   }, [tokenDecimals]);
 
-  const { data: jobLauncherFee } = useReadContract({
-    address: NETWORKS[jobRequest.chainId!]?.kvstoreAddress as Address,
-    abi: KVStoreABI,
-    functionName: 'get',
-    args: jobLauncherAddress
-      ? [jobLauncherAddress, KVStoreKeys.fee]
-      : undefined,
-    query: {
-      enabled: !!jobLauncherAddress,
-    },
-  });
+  useEffect(() => {
+    if (!signer || !jobLauncherAddress || !jobRequest.chainId) return;
+
+    let ignore = false;
+
+    const fetchJobLauncherFee = async () => {
+      const fee = await readContract(signer, {
+        address: NETWORKS[jobRequest.chainId!]?.kvstoreAddress as Address,
+        abi: KVStoreABI,
+        functionName: 'get',
+        args: [jobLauncherAddress, KVStoreKeys.fee],
+      });
+
+      if (!ignore) {
+        setJobLauncherFee(fee as string);
+      }
+    };
+
+    fetchJobLauncherFee().catch(onErrorRef.current);
+
+    return () => {
+      ignore = true;
+    };
+  }, [jobLauncherAddress, jobRequest.chainId, signer]);
 
   const minFeeToken = useMemo(() => {
     if (minFee && paymentTokenRate)
@@ -125,7 +138,7 @@ export const CryptoPayForm = ({
   }, [minFee, paymentTokenRate]);
 
   const feeAmount = useMemo(() => {
-    if (!amount) return 0;
+    if (!amount || jobLauncherFee == null) return 0;
     const amountDecimal = new Decimal(amount);
     const feeDecimal = new Decimal(jobLauncherFee as string).div(100);
     return Number(
@@ -254,6 +267,18 @@ export const CryptoPayForm = ({
         <Button variant="outlined" onClick={goToPrevStep}>
           Back
         </Button>
+      </Box>
+    );
+
+  if (!jobLauncherAddress || jobLauncherFee == null)
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight={400}
+      >
+        <CircularProgress />
       </Box>
     );
 
@@ -476,6 +501,7 @@ export const CryptoPayForm = ({
               !paymentTokenAddress ||
               !fundTokenSymbol ||
               !amount ||
+              jobLauncherFee == null ||
               jobRequest.chainId !== chain?.id
             }
             loading={isLoading}

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/CryptoPayForm.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mui/material';
 import { Decimal } from 'decimal.js';
 import { ethers } from 'ethers';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Address } from 'viem';
 import { readContract } from 'viem/actions';
 import { useAccount, useWalletClient, usePublicClient } from 'wagmi';
@@ -49,6 +49,10 @@ export const CryptoPayForm = ({
   const [isLoading, setIsLoading] = useState(false);
   const [jobLauncherAddress, setJobLauncherAddress] = useState<string>();
   const [jobLauncherFee, setJobLauncherFee] = useState<string>();
+  const [configurationError, setConfigurationError] = useState<string>();
+  const [configurationRetry, setConfigurationRetry] = useState(0);
+  const [feeError, setFeeError] = useState<string>();
+  const [feeRetry, setFeeRetry] = useState(0);
   const [minFee, setMinFee] = useState<number>(0.01);
   const { data: signer } = useWalletClient();
   const publicClient = usePublicClient();
@@ -57,19 +61,24 @@ export const CryptoPayForm = ({
   const [fundTokenRate, setFundTokenRate] = useState<number>(0);
   const [decimals, setDecimals] = useState<number>(6);
   const [tokenDecimals, setTokenDecimals] = useState<number>(18);
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
 
   useEffect(() => {
     const fetchJobLauncherData = async () => {
-      const address = await paymentService.getOperatorAddress();
-      const fee = await paymentService.getFee();
-      setJobLauncherAddress(address);
-      setMinFee(fee);
+      setConfigurationError(undefined);
+      try {
+        const address = await paymentService.getOperatorAddress();
+        const fee = await paymentService.getFee();
+        setJobLauncherAddress(address);
+        setMinFee(fee);
+      } catch {
+        setConfigurationError(
+          'Unable to load the payment configuration. Please try again.',
+        );
+      }
     };
 
     fetchJobLauncherData();
-  }, []);
+  }, [configurationRetry]);
 
   useEffect(() => {
     const fetchRates = async () => {
@@ -107,29 +116,45 @@ export const CryptoPayForm = ({
   }, [tokenDecimals]);
 
   useEffect(() => {
-    if (!signer || !jobLauncherAddress || !jobRequest.chainId) return;
+    if (!signer || !publicClient || !jobLauncherAddress || !jobRequest.chainId)
+      return;
 
     let ignore = false;
 
     const fetchJobLauncherFee = async () => {
-      const fee = await readContract(signer, {
-        address: NETWORKS[jobRequest.chainId!]?.kvstoreAddress as Address,
-        abi: KVStoreABI,
-        functionName: 'get',
-        args: [jobLauncherAddress, KVStoreKeys.fee],
-      });
+      setFeeError(undefined);
+      setJobLauncherFee(undefined);
+      try {
+        const parameters = {
+          address: NETWORKS[jobRequest.chainId!]?.kvstoreAddress as Address,
+          abi: KVStoreABI,
+          functionName: 'get',
+          args: [jobLauncherAddress, KVStoreKeys.fee],
+        } as const;
 
-      if (!ignore) {
-        setJobLauncherFee(fee as string);
+        let fee: string;
+        try {
+          fee = (await readContract(signer, parameters)) as string;
+        } catch {
+          fee = (await readContract(publicClient, parameters)) as string;
+        }
+
+        if (!ignore) {
+          setJobLauncherFee(fee);
+        }
+      } catch {
+        if (!ignore) {
+          setFeeError('Unable to load the job launcher fee. Please try again.');
+        }
       }
     };
 
-    fetchJobLauncherFee().catch(onErrorRef.current);
+    fetchJobLauncherFee();
 
     return () => {
       ignore = true;
     };
-  }, [jobLauncherAddress, jobRequest.chainId, signer]);
+  }, [feeRetry, jobLauncherAddress, jobRequest.chainId, publicClient, signer]);
 
   const minFeeToken = useMemo(() => {
     if (minFee && paymentTokenRate)
@@ -257,7 +282,7 @@ export const CryptoPayForm = ({
     }
   };
 
-  if (!chain || chain.id !== jobRequest.chainId)
+  if (isConnected && (!chain || chain.id !== jobRequest.chainId))
     return (
       <Box textAlign="center">
         <Typography textAlign="center">
@@ -270,7 +295,32 @@ export const CryptoPayForm = ({
       </Box>
     );
 
-  if (!jobLauncherAddress || jobLauncherFee == null)
+  if (configurationError || feeError)
+    return (
+      <Box textAlign="center" minHeight={400}>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {configurationError || feeError}
+        </Alert>
+        <Button
+          variant="contained"
+          onClick={() => {
+            if (configurationError) {
+              setConfigurationRetry((retry) => retry + 1);
+            }
+            if (feeError) {
+              setFeeRetry((retry) => retry + 1);
+            }
+          }}
+        >
+          Try again
+        </Button>
+      </Box>
+    );
+
+  if (
+    !jobLauncherAddress ||
+    (isConnected && (!signer || jobLauncherFee == null))
+  )
     return (
       <Box
         display="flex"
@@ -414,7 +464,7 @@ export const CryptoPayForm = ({
                 >
                   <Typography>Fee</Typography>
                   <Typography color="text.secondary">
-                    ({Number(jobLauncherFee)}%){' '}
+                    ({jobLauncherFee == null ? '—' : Number(jobLauncherFee)}%){' '}
                     {paymentTokenSymbol
                       ? `${Number(feeAmount.toFixed(6))} ${paymentTokenSymbol?.toUpperCase()}`
                       : ''}

--- a/packages/apps/job-launcher/client/src/components/Jobs/Create/FiatPayForm.tsx
+++ b/packages/apps/job-launcher/client/src/components/Jobs/Create/FiatPayForm.tsx
@@ -2,6 +2,7 @@ import KVStoreABI from '@human-protocol/core/abis/KVStore.json';
 import { KVStoreKeys, NETWORKS } from '@human-protocol/sdk';
 import { LoadingButton } from '@mui/lab';
 import {
+  Alert,
   Box,
   Button,
   Checkbox,
@@ -142,6 +143,8 @@ export const FiatPayForm = ({
     data: jobLauncherFee,
     error,
     isError,
+    isFetching: isFeeFetching,
+    refetch: refetchJobLauncherFee,
   } = useReadContract({
     address: NETWORKS[jobRequest.chainId!]?.kvstoreAddress as Address,
     abi: KVStoreABI,
@@ -276,7 +279,9 @@ export const FiatPayForm = ({
 
   return (
     <Box sx={{ width: '100%' }}>
-      {loadingInitialData ? (
+      {loadingInitialData ||
+      !jobLauncherAddress ||
+      (!isError && (isFeeFetching || jobLauncherFee == null)) ? (
         <Box
           display="flex"
           justifyContent="center"
@@ -284,6 +289,16 @@ export const FiatPayForm = ({
           minHeight={400}
         >
           <CircularProgress />
+        </Box>
+      ) : isError ? (
+        <Box textAlign="center" minHeight={400}>
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Unable to load the job launcher fee from MetaMask or the public
+            network provider.
+          </Alert>
+          <Button variant="contained" onClick={() => refetchJobLauncherFee()}>
+            Try again
+          </Button>
         </Box>
       ) : (
         <Box>
@@ -522,6 +537,8 @@ export const FiatPayForm = ({
                   !amount ||
                   (!payWithAccountBalance && !selectedCard) ||
                   hasError ||
+                  isFeeFetching ||
+                  jobLauncherFee == null ||
                   !tokenSymbol
                 }
               >

--- a/packages/apps/job-launcher/client/src/providers/WagmiProvider.tsx
+++ b/packages/apps/job-launcher/client/src/providers/WagmiProvider.tsx
@@ -4,10 +4,11 @@ import {
   WagmiProvider as WWagmiProvider,
   fallback,
   http,
+  injected,
   unstable_connector,
 } from 'wagmi';
 import * as wagmiChains from 'wagmi/chains';
-import { coinbaseWallet, walletConnect, metaMask } from 'wagmi/connectors';
+import { coinbaseWallet, walletConnect } from 'wagmi/connectors';
 
 import { LOCALHOST } from '../constants/chains';
 
@@ -37,41 +38,41 @@ export const wagmiConfig = createConfig({
     coinbaseWallet({
       appName: 'human-job-launcher',
     }),
-    metaMask(),
+    injected({ target: 'metaMask' }),
   ],
   transports: {
-    [wagmiChains.mainnet.id]: fallback([unstable_connector(metaMask), http()]),
-    [wagmiChains.sepolia.id]: fallback([unstable_connector(metaMask), http()]),
-    [wagmiChains.bsc.id]: fallback([unstable_connector(metaMask), http()]),
+    [wagmiChains.mainnet.id]: fallback([unstable_connector(injected), http()]),
+    [wagmiChains.sepolia.id]: fallback([unstable_connector(injected), http()]),
+    [wagmiChains.bsc.id]: fallback([unstable_connector(injected), http()]),
     [wagmiChains.bscTestnet.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(),
     ]),
-    [wagmiChains.polygon.id]: fallback([unstable_connector(metaMask), http()]),
+    [wagmiChains.polygon.id]: fallback([unstable_connector(injected), http()]),
     [wagmiChains.polygonAmoy.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(),
     ]),
-    [wagmiChains.moonbeam.id]: fallback([unstable_connector(metaMask), http()]),
+    [wagmiChains.moonbeam.id]: fallback([unstable_connector(injected), http()]),
     [wagmiChains.moonbaseAlpha.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(),
     ]),
     [wagmiChains.avalanche.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(),
     ]),
     [wagmiChains.avalancheFuji.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(),
     ]),
-    [wagmiChains.xLayer.id]: fallback([unstable_connector(metaMask), http()]),
+    [wagmiChains.xLayer.id]: fallback([unstable_connector(injected), http()]),
     [wagmiChains.xLayerTestnet.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(),
     ]),
     [LOCALHOST.id]: fallback([
-      unstable_connector(metaMask),
+      unstable_connector(injected),
       http(LOCALHOST.rpcUrls.default.http[0]),
     ]),
   },


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
The app used MetaMask’s SDK connector, which used Wagmi’s default Polygon Amoy RPC instead of the RPC configured in the MetaMask extension. That public RPC failed DNS/network requests, leaving jobLauncherFee undefined and causing the Decimal crash.
We switched to MetaMask’s injected browser provider and added loading guards before calculating the fee.

## How has this been tested?
Locally

## Release plan
NA

## Potential risks; What to monitor; Rollback plan
NA