### PR TITLE
[Reputation Oracle] fix: cvat v2 manifest format

### DIFF
--- a/packages/apps/reputation-oracle/server/src/common/enums/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/manifest.ts
@@ -8,7 +8,6 @@ export enum MarketingJobType {
 }
 
 export enum CvatJobType {
-  IMAGE_LABEL_BINARY = 'image_label_binary',
   IMAGE_POINTS = 'image_points',
   IMAGE_BOXES = 'image_boxes',
   IMAGE_BOXES_FROM_POINTS = 'image_boxes_from_points',

--- a/packages/apps/reputation-oracle/server/src/common/enums/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/common/enums/manifest.ts
@@ -8,11 +8,13 @@ export enum MarketingJobType {
 }
 
 export enum CvatJobType {
-  IMAGE_BOXES = 'image_boxes',
+  IMAGE_LABEL_BINARY = 'image_label_binary',
   IMAGE_POINTS = 'image_points',
+  IMAGE_BOXES = 'image_boxes',
   IMAGE_BOXES_FROM_POINTS = 'image_boxes_from_points',
   IMAGE_SKELETONS_FROM_BOXES = 'image_skeletons_from_boxes',
   IMAGE_POLYGONS = 'image_polygons',
+  AUDIO_TRANSCRIPTION = 'audio_transcription',
 }
 
 export const JobType = [

--- a/packages/apps/reputation-oracle/server/src/common/types/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/common/types/manifest.ts
@@ -19,13 +19,11 @@ export interface MarketingManifest extends BaseManifest<MarketingJobType> {
 }
 
 export type CvatManifest = {
-  annotation: {
-    type: CvatJobType;
-  };
-  validation: {
-    min_quality: number;
-  };
-  job_bounty: string;
+  version: 2;
+  job_type: CvatJobType;
+  // not necessary for RepO
+  data: unknown;
+  annotation: unknown;
 };
 
 export type JobManifest = FortuneManifest | MarketingManifest | CvatManifest;

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/fixtures/cvat.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/fixtures/cvat.ts
@@ -5,12 +5,9 @@ import { CvatManifest } from '@/common/types';
 
 export function generateCvatManifest(): CvatManifest {
   return {
-    annotation: {
-      type: faker.helpers.arrayElement(Object.values(CvatJobType)),
-    },
-    validation: {
-      min_quality: faker.number.float({ min: 0.1, max: 0.9 }),
-    },
-    job_bounty: faker.finance.amount({ max: 42 }),
+    version: 2,
+    job_type: faker.helpers.arrayElement(Object.values(CvatJobType)),
+    data: undefined,
+    annotation: undefined,
   };
 }

--- a/packages/apps/reputation-oracle/server/src/modules/escrow-completion/payouts-calculation/cvat-payouts-calculator.spec.ts
+++ b/packages/apps/reputation-oracle/server/src/modules/escrow-completion/payouts-calculation/cvat-payouts-calculator.spec.ts
@@ -204,12 +204,10 @@ describe('CvatPayoutsCalculator', () => {
       );
       mockedGetReservedFunds.mockResolvedValueOnce(reservedFunds);
 
-      const manifest = generateCvatManifest();
-
       const payouts = await calculator.calculate({
         chainId,
         escrowAddress,
-        manifest,
+        manifest: generateCvatManifest(),
         finalResultsUrl: faker.internet.url(),
       });
 

--- a/packages/apps/reputation-oracle/server/src/utils/manifest.ts
+++ b/packages/apps/reputation-oracle/server/src/utils/manifest.ts
@@ -40,8 +40,8 @@ export function getJobRequestType(manifest: JobManifest): JobRequestType {
 
   if ('requestType' in manifest) {
     jobRequestType = manifest.requestType;
-  } else if ('annotation' in manifest) {
-    jobRequestType = manifest.annotation.type;
+  } else if ('job_type' in manifest) {
+    jobRequestType = manifest.job_type;
   }
 
   if (!jobRequestType) {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
RepO fails to get job type from manifest for new manifest format of CVAT jobs. It appeared that it tried to get job type from previous format, so use new one now.

## How has this been tested?
- [x] existing tests pass
- [x] e2e on staging for existing escrow

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No