### PR TITLE
fix: remove npm update in ci

### DIFF
--- a/.github/workflows/cd-packages.yaml
+++ b/.github/workflows/cd-packages.yaml
@@ -45,9 +45,6 @@ jobs:
           cache: yarn
           # Necessary to set up registry for auth
           registry-url: "https://registry.npmjs.org"
-      # Ensure npm 11.5.1 or later is installed to support OIDC
-      - name: Update npm
-        run: npm install -g npm@latest
       - name: Install dependencies
         run: yarn install --immutable
       # If there is no new version for dependency package (e.g. core)

--- a/packages/apps/human-app/frontend/.env.example
+++ b/packages/apps/human-app/frontend/.env.example
@@ -19,11 +19,10 @@ VITE_H_CAPTCHA_EXCHANGE_URL=replace_me
 VITE_H_CAPTCHA_LABELING_BASE_URL=replace_me
 
 # Other
-VITE_HUMAN_PROTOCOL_HELP_URL=https://docs.humanprotocol.org/
 VITE_HUMAN_PROTOCOL_URL=https://humanprotocol.org/
 VITE_STAKING_DASHBOARD_URL=https://staking.humanprotocol.org/
 VITE_HUMAN_SUPPORT_EMAIL=support@local.app
-VITE_NAVBAR__LINK__HOW_IT_WORK_URL=https://humanprotocol.org/
+VITE_NAVBAR__LINK__HOW_IT_WORK_URL=https://docs.humanprotocol.org/
 VITE_NAVBAR__LINK__PROTOCOL_URL=https://humanprotocol.org/
 VITE_PRIVACY_POLICY_URL=http://local.app/privacy-policy/
 VITE_TERMS_OF_SERVICE_URL=http://local.app/terms-and-conditions/

--- a/packages/apps/human-app/frontend/src/modules/worker/send-reset-link/send-reset-link-success.page.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/send-reset-link/send-reset-link-success.page.tsx
@@ -137,7 +137,7 @@ export function SendResetLinkSuccessPage() {
                 <Trans
                   components={{
                     1: <Typography component="span" sx={{ fontWeight: 600 }} />,
-                    2: <MailTo mail={env.VITE_HUMAN_PROTOCOL_HELP_URL} />,
+                    2: <MailTo mail={env.VITE_HUMAN_SUPPORT_EMAIL} />,
                   }}
                   i18nKey="worker.sendResetLinkSuccess.paragraph4"
                 />

--- a/packages/apps/human-app/frontend/src/shared/env.ts
+++ b/packages/apps/human-app/frontend/src/shared/env.ts
@@ -9,7 +9,6 @@ const envSchema = z.object({
   VITE_NAVBAR__LINK__PROTOCOL_URL: z.string(),
   VITE_NAVBAR__LINK__HOW_IT_WORK_URL: z.string(),
   VITE_HUMAN_SUPPORT_EMAIL: z.string(),
-  VITE_HUMAN_PROTOCOL_HELP_URL: z.string(),
   VITE_H_CAPTCHA_SITE_KEY: z.string(),
   VITE_HMT_DAILY_SPENT_LIMIT: z
     .string()


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
"Publish packages" action fails because of `npm update` step in it ([ref](https://github.com/humanprotocol/human-protocol/actions/runs/31384553048/job/93441955342)). Some time ago when we were using Node@22 - default npm version was below 11.5.1 required for OIDC. Now we use 24.13 and it already includes npm@11.6.2, so we can just remove unnecessary step.

Also removed unnecessary env var for HUMAN App

## How has this been tested?
- [x] Manually triggered action from this branch ([ref](https://github.com/humanprotocol/human-protocol/actions/runs/31385424514/job/93444654725))

## Release plan
Merge to `main`

## Potential risks; What to monitor; Rollback plan
No