### PR TITLE
[HUMAN App] fix: missing fn memo

### DIFF
--- a/packages/apps/human-app/frontend/src/api/hooks/use-access-token-refresh.ts
+++ b/packages/apps/human-app/frontend/src/api/hooks/use-access-token-refresh.ts
@@ -14,7 +14,7 @@ export function useAccessTokenRefresh() {
   const { user, signOut } = useAuth();
 
   const mutation = useMutation({
-    mutationFn: async (params?: RefreshAccessTokenParams) => {
+    mutationFn: async (params: RefreshAccessTokenParams) => {
       const throwExpirationModalOnSignOut =
         params?.throwExpirationModalOnSignOut ?? true;
 
@@ -39,16 +39,8 @@ export function useAccessTokenRefresh() {
   });
 
   return {
-    refreshAccessToken: (
-      params?: RefreshAccessTokenParams,
-      options?: Parameters<typeof mutation.mutate>[1]
-    ) => {
-      mutation.mutate(params, options);
-    },
-    refreshAccessTokenAsync: (
-      params?: RefreshAccessTokenParams,
-      options?: Parameters<typeof mutation.mutateAsync>[1]
-    ) => mutation.mutateAsync(params, options),
+    refreshAccessToken: mutation.mutate,
+    refreshAccessTokenAsync: mutation.mutateAsync,
     isRefreshingAccessToken: mutation.isPending,
   };
 }

--- a/packages/apps/human-app/frontend/src/api/hooks/use-access-token-refresh.ts
+++ b/packages/apps/human-app/frontend/src/api/hooks/use-access-token-refresh.ts
@@ -13,10 +13,10 @@ export function useAccessTokenRefresh() {
   const navigate = useNavigate();
   const { user, signOut } = useAuth();
 
-  const mutation = useMutation({
-    mutationFn: async (params: RefreshAccessTokenParams) => {
+  return useMutation({
+    mutationFn: async (params: RefreshAccessTokenParams = {}) => {
       const throwExpirationModalOnSignOut =
-        params?.throwExpirationModalOnSignOut ?? true;
+        params.throwExpirationModalOnSignOut ?? true;
 
       try {
         await authService.refreshAccessToken();
@@ -37,10 +37,4 @@ export function useAccessTokenRefresh() {
       id: 'refresh-access-token',
     },
   });
-
-  return {
-    refreshAccessToken: mutation.mutate,
-    refreshAccessTokenAsync: mutation.mutateAsync,
-    isRefreshingAccessToken: mutation.isPending,
-  };
 }

--- a/packages/apps/human-app/frontend/src/modules/worker/hcaptcha-labeling/hooks/enable-hcaptcha-labeling.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/hcaptcha-labeling/hooks/enable-hcaptcha-labeling.ts
@@ -7,7 +7,7 @@ import * as hCaptchaLabelingService from '../services/hcaptcha-labeling.service'
 
 export function useEnableHCaptchaLabelingMutation() {
   const navigate = useNavigate();
-  const { refreshAccessTokenAsync } = useAccessTokenRefresh();
+  const { mutateAsync: refreshAccessTokenAsync } = useAccessTokenRefresh();
 
   const mutation = useMutation({
     mutationFn: async () => {

--- a/packages/apps/human-app/frontend/src/modules/worker/hcaptcha-labeling/hooks/enable-hcaptcha-labeling.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/hcaptcha-labeling/hooks/enable-hcaptcha-labeling.ts
@@ -12,7 +12,7 @@ export function useEnableHCaptchaLabelingMutation() {
   const mutation = useMutation({
     mutationFn: async () => {
       const result = await hCaptchaLabelingService.enableHCaptchaLabeling();
-      await refreshAccessTokenAsync();
+      await refreshAccessTokenAsync({});
       return result;
     },
     onSuccess: () => {

--- a/packages/apps/human-app/frontend/src/modules/worker/hooks/use-register-address.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/hooks/use-register-address.ts
@@ -15,7 +15,7 @@ interface RegisterAddressCallbacks {
 
 function useRegisterAddressMutation(callbacks: RegisterAddressCallbacks) {
   const { user, updateUserData } = useAuth();
-  const { refreshAccessTokenAsync } = useAccessTokenRefresh();
+  const { mutateAsync: refreshAccessTokenAsync } = useAccessTokenRefresh();
   const { address, chainId, signMessage } = useWalletConnect();
   const { prepareSignature } = usePrepareSignature(
     PrepareSignatureType.REGISTER_ADDRESS

--- a/packages/apps/human-app/frontend/src/modules/worker/hooks/use-register-address.ts
+++ b/packages/apps/human-app/frontend/src/modules/worker/hooks/use-register-address.ts
@@ -37,7 +37,7 @@ function useRegisterAddressMutation(callbacks: RegisterAddressCallbacks) {
     // wallet address is part of the JWT payload
     // so we need to refresh the token after the address is registered
     await profileService.registerAddress({ address, chainId, signature });
-    await refreshAccessTokenAsync();
+    await refreshAccessTokenAsync({});
     updateUserData({
       wallet_address: address,
     });

--- a/packages/apps/human-app/frontend/src/modules/worker/profile/components/identity-verification-control.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/profile/components/identity-verification-control.tsx
@@ -47,8 +47,10 @@ export function IdentityVerificationControl({
   const { t } = useTranslation();
   const { isIdvAlreadyInProgress, idvStarted, idvStartIsPending, startIdv } =
     useStartIdv();
-  const { refreshAccessTokenAsync, isRefreshingAccessToken } =
-    useAccessTokenRefresh();
+  const {
+    mutateAsync: refreshAccessTokenAsync,
+    isPending: isRefreshingAccessToken,
+  } = useAccessTokenRefresh();
   const { updateUserData } = useAuth();
   const { colorPalette } = useColorMode();
 

--- a/packages/apps/human-app/frontend/src/modules/worker/profile/components/identity-verification-control.tsx
+++ b/packages/apps/human-app/frontend/src/modules/worker/profile/components/identity-verification-control.tsx
@@ -64,7 +64,7 @@ export function IdentityVerificationControl({
     }, CHECK_STATUS_COOLDOWN_TIME);
 
     try {
-      await refreshAccessTokenAsync();
+      await refreshAccessTokenAsync({});
       const accessToken = browserAuthProvider.getAccessToken();
 
       if (!accessToken) {

--- a/packages/apps/human-app/frontend/src/shared/contexts/generic-auth-context.tsx
+++ b/packages/apps/human-app/frontend/src/shared/contexts/generic-auth-context.tsx
@@ -65,6 +65,8 @@ export function createAuthProvider<T extends UserData>(config: {
 
         const validUserData = schema.parse(userData);
 
+        queryClient.setDefaultOptions({ queries: { enabled: true } });
+
         setAuthState({ user: validUserData, status: 'success' });
 
         browserAuthProvider.signOutSubscription = displayExpirationModal;

--- a/packages/apps/human-app/frontend/src/shared/contexts/jwt-expiration-check.tsx
+++ b/packages/apps/human-app/frontend/src/shared/contexts/jwt-expiration-check.tsx
@@ -12,7 +12,7 @@ export function JWTExpirationCheck({
   const checksOnProfile = useRef(0);
   const auth = useAuth();
   const location = useLocation();
-  const { refreshAccessToken } = useAccessTokenRefresh();
+  const { mutate: refreshAccessToken } = useAccessTokenRefresh();
 
   useEffect(() => {
     if (location.pathname.includes('profile') && auth.user) {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Refresh token hook returns new "mutate" function instances on every render loop, which causes unnecessary calls of jwt-expiration-check logic and incorrect auth loop. Fixing it by returning memoized version provided by `useMutation`. Also fixed disabled queries on token expiration.

## How has this been tested?
- [x] e2e locally: wait for access & refresh token expirations, make sure auth is correct after that and data loads correctly w/o page reload

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No